### PR TITLE
add CORS middleware

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+/node_modules

--- a/index.js
+++ b/index.js
@@ -5,17 +5,15 @@
 
 const superagent = require('superagent');
 const url = require('url')
+const cors = require("cors");
+const corsMiddleware = cors();
 
-exports.martha_v1 = (req, res) => {
+const handler = (req, res) => {
     var orig_url = req.body.url;
     var pattern = req.body.pattern;
     if(!orig_url) {
       orig_url = JSON.parse(req.body.toString()).url;
       pattern = JSON.parse(req.body.toString()).pattern;
-    }
-    if(req.headers && req.headers.hasOwnProperty('origin')) {
-      res.setHeader('Access-Control-Allow-Origin', '*');
-      res.setHeader('Access-Control-Allow-Methods', ["POST", "GET"]);
     }
     var parsed_url = url.parse(orig_url);
     var orig_path = parsed_url.pathname;
@@ -67,4 +65,8 @@ exports.martha_v1 = (req, res) => {
             }
             ;
         });
+};
+
+exports.martha_v1 = (req, res) => {
+  corsMiddleware(req, res, () => handler(req, res));
 };

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1294,6 +1294,15 @@
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
     },
+    "cors": {
+      "version": "2.8.4",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.4.tgz",
+      "integrity": "sha1-K9OB8usgECAQXNUOpZ2mMJBpRoY=",
+      "requires": {
+        "object-assign": "4.1.1",
+        "vary": "1.1.2"
+      }
+    },
     "create-error-class": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/create-error-class/-/create-error-class-3.0.2.tgz",
@@ -1735,11 +1744,6 @@
         "combined-stream": "1.0.6",
         "mime-types": "2.1.18"
       }
-    },
-    "formidable": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/formidable/-/formidable-1.1.1.tgz",
-      "integrity": "sha1-lriIb3w8NQi5Mta9cMTTqI818ak="
     },
     "forwarded": {
       "version": "0.1.2",
@@ -5989,20 +5993,20 @@
       "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo="
     },
     "superagent": {
-      "version": "3.8.2",
-      "resolved": "https://registry.npmjs.org/superagent/-/superagent-3.8.2.tgz",
-      "integrity": "sha512-gVH4QfYHcY3P0f/BZzavLreHW3T1v7hG9B+hpMQotGQqurOvhv87GcMCd6LWySmBuf+BDR44TQd0aISjVHLeNQ==",
+      "version": "3.8.3",
+      "resolved": "https://registry.npmjs.org/superagent/-/superagent-3.8.3.tgz",
+      "integrity": "sha512-GLQtLMCoEIK4eDv6OGtkOoSMt3D+oq0y3dsxMuYuDvaNUvuT8eFBuLmfR0iYYzHC1e8hpzC6ZsxbuP6DIalMFA==",
       "requires": {
         "component-emitter": "1.2.1",
         "cookiejar": "2.1.1",
         "debug": "3.1.0",
         "extend": "3.0.1",
         "form-data": "2.3.2",
-        "formidable": "1.1.1",
+        "formidable": "1.2.1",
         "methods": "1.1.2",
         "mime": "1.4.1",
         "qs": "6.5.1",
-        "readable-stream": "2.3.4"
+        "readable-stream": "2.3.6"
       },
       "dependencies": {
         "debug": {
@@ -6011,6 +6015,33 @@
           "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
           "requires": {
             "ms": "2.0.0"
+          }
+        },
+        "formidable": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/formidable/-/formidable-1.2.1.tgz",
+          "integrity": "sha512-Fs9VRguL0gqGHkXS5GQiMCr1VhZBxz0JnJs4JmMp/2jL18Fmbzvv7vOFRU+U8TBkHEE/CX1qDXzJplVULgsLeg=="
+        },
+        "readable-stream": {
+          "version": "2.3.6",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+          "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+          "requires": {
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "2.0.0",
+            "safe-buffer": "5.1.1",
+            "string_decoder": "1.1.1",
+            "util-deprecate": "1.0.2"
+          }
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+          "requires": {
+            "safe-buffer": "5.1.1"
           }
         }
       }
@@ -6039,7 +6070,7 @@
       "integrity": "sha1-jUu2j9GDDuBwM7HFpamkAhyWUpY=",
       "requires": {
         "methods": "1.1.2",
-        "superagent": "3.8.2"
+        "superagent": "3.8.3"
       }
     },
     "supports-color": {

--- a/package.json
+++ b/package.json
@@ -5,12 +5,13 @@
   "private": true,
   "scripts": {
     "test": "ava -m !smoketest*",
-    "smoketest" : "ava -m smoketest*"
+    "smoketest": "ava -m smoketest*"
   },
   "dependencies": {
     "ava": "^0.25.0",
     "axios": "~0.18.0",
     "firebase-functions": "^0.8.1",
+    "cors": "^2.8.4",
     "nock": "^9.2.3",
     "npm-shrinkwrap": "^6.1.0",
     "sinon": "^4.4.2",


### PR DESCRIPTION
This adds full CORS handling to the endpoint, so it can be called from a strict browser environment (e.g. `fetch`).

Also cleans up the tests a bit and adds a .gitignore file.