### PR TITLE
martha_v2 refactoring and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-﻿Martha v1
+﻿Martha
 =========
 
 ![alt text](https://raw.githubusercontent.com/broadinstitute/martha/dev/images/doctor_martha_jones_and_the_tardis.jpg)

--- a/README.md
+++ b/README.md
@@ -47,6 +47,9 @@ Production: https://us-central1-broad-dsde-prod.cloudfunctions.net/martha_v2
 * Start the GCF emulator: `functions start`
 * Deploy Martha to your local GCF emulator: `functions deploy martha_v<versionNumber> --trigger-http`
 * Test the function: `functions call martha_v<versionNumber> --data '{"url": "dos.url.here", "pattern" : "gs://"}'`
+* Testing functions that require you to include `header` information in the request (such as an `authorization` header)
+will require you to use a tool like `curl` to test the function.  To get the URL for the function running on your local
+emulator, run the command: `functions describe martha_v2`
 
 ## Google Cloud Functions (GCF) Emulator
 * See the [Setup](#Setup) section for installation and deployment instructions

--- a/api_adapter.js
+++ b/api_adapter.js
@@ -1,13 +1,13 @@
 const request = require('superagent');
 
-function get_text_from(url, authorization = null) {
-    const get_req = request.get(url);
+function getTextFrom(url, authorization = null) {
+    const getReq = request.get(url);
     if (authorization != null) {
-        get_req.set('authorization', authorization)
+        getReq.set('authorization', authorization);
     }
-    return get_req.then(function (response) {
+    return getReq.then(function (response) {
             return response.text;
         });
 }
 
-exports.get_text_from = get_text_from;
+exports.getTextFrom = getTextFrom;

--- a/api_adapter.js
+++ b/api_adapter.js
@@ -1,9 +1,9 @@
-const request = require('superagent');
+const request = require("superagent");
 
 function getTextFrom(url, authorization = null) {
     const getReq = request.get(url);
     if (authorization != null) {
-        getReq.set('authorization', authorization);
+        getReq.set("authorization", authorization);
     }
     return getReq.then(function (response) {
             return response.text;

--- a/api_adapter.js
+++ b/api_adapter.js
@@ -1,4 +1,3 @@
-const helpers = require('./helpers');
 const request = require('superagent');
 
 function get_text_from(url, authorization = null) {
@@ -11,30 +10,4 @@ function get_text_from(url, authorization = null) {
         });
 }
 
-function resolve_dos(dos_url) {
-    return request.get(dos_url)
-        .then(function (response) {
-            try {
-                return JSON.parse(response.text);
-            } catch (e) {
-                throw new Error('DOS response is not valid JSON\n' + e);
-            }
-        });
-}
-
-function talk_to_bond(authorization) {
-    // return superagent.get(`${helpers.bondBaseUrl()}/api/link/v1/fence/serviceaccount/key`)
-    return request.get(`${helpers.bondBaseUrl()}/api/status/v1/`)
-        .set('authorization', authorization)
-        .then(function (bondResponse) {
-            try {
-                return JSON.parse(bondResponse.text);
-            } catch (e) {
-                throw new Error('Bond response is not valid JSON\n' + e);
-            }
-        });
-}
-
-exports.resolve_dos = resolve_dos;
-exports.talk_to_bond = talk_to_bond;
 exports.get_text_from = get_text_from;

--- a/api_adapter.js
+++ b/api_adapter.js
@@ -1,0 +1,40 @@
+const helpers = require('./helpers');
+const request = require('superagent');
+
+function get_text_from(url, authorization = null) {
+    const get_req = request.get(url);
+    if (authorization != null) {
+        get_req.set('authorization', authorization)
+    }
+    return get_req.then(function (response) {
+            return response.text;
+        });
+}
+
+function resolve_dos(dos_url) {
+    return request.get(dos_url)
+        .then(function (response) {
+            try {
+                return JSON.parse(response.text);
+            } catch (e) {
+                throw new Error('DOS response is not valid JSON\n' + e);
+            }
+        });
+}
+
+function talk_to_bond(authorization) {
+    // return superagent.get(`${helpers.bondBaseUrl()}/api/link/v1/fence/serviceaccount/key`)
+    return request.get(`${helpers.bondBaseUrl()}/api/status/v1/`)
+        .set('authorization', authorization)
+        .then(function (bondResponse) {
+            try {
+                return JSON.parse(bondResponse.text);
+            } catch (e) {
+                throw new Error('Bond response is not valid JSON\n' + e);
+            }
+        });
+}
+
+exports.resolve_dos = resolve_dos;
+exports.talk_to_bond = talk_to_bond;
+exports.get_text_from = get_text_from;

--- a/helpers.js
+++ b/helpers.js
@@ -1,0 +1,24 @@
+const url = require('url');
+const config = require("./config.json");
+
+function dosToHttps(dosUri) {
+    var parsed_url = url.parse(dosUri);
+    var orig_path = parsed_url.pathname;
+    var new_path = '/ga4gh/dos/v1/dataobjects' + orig_path;
+
+    // special case for hostless dos uris which will be better supported in martha v2
+    if (parsed_url.host.startsWith("dg.")) {
+        new_path = '/ga4gh/dos/v1/dataobjects/' + parsed_url.hostname + orig_path;
+        parsed_url.host = config.dosResolutionHost;
+    }
+
+    console.log(new_path);
+    parsed_url.protocol = 'https';
+    parsed_url.path = new_path;
+    parsed_url.pathname = new_path;
+    console.log(parsed_url);
+    console.log(parsed_url.toString);
+    return url.format(parsed_url);
+}
+
+exports.dosToHttps = dosToHttps;

--- a/helpers.js
+++ b/helpers.js
@@ -1,4 +1,4 @@
-const url = require('url');
+const url = require("url");
 const config = require("./config.json");
 
 function dosToHttps(dosUri) {

--- a/helpers.js
+++ b/helpers.js
@@ -2,23 +2,23 @@ const url = require("url");
 const config = require("./config.json");
 
 function dosToHttps(dosUri) {
-    var parsed_url = url.parse(dosUri);
-    var orig_path = parsed_url.pathname;
-    var new_path = '/ga4gh/dos/v1/dataobjects' + orig_path;
+    const parsedUrl = url.parse(dosUri);
+    const origPath = parsedUrl.pathname;
+    let newPath = "/ga4gh/dos/v1/dataobjects" + origPath;
 
     // special case for hostless dos uris which will be better supported in martha v2
-    if (parsed_url.host.startsWith("dg.")) {
-        new_path = '/ga4gh/dos/v1/dataobjects/' + parsed_url.hostname + orig_path;
-        parsed_url.host = config.dosResolutionHost;
+    if (parsedUrl.host.startsWith("dg.")) {
+        newPath = "/ga4gh/dos/v1/dataobjects/" + parsedUrl.hostname + origPath;
+        parsedUrl.host = config.dosResolutionHost;
     }
 
-    console.log(new_path);
-    parsed_url.protocol = 'https';
-    parsed_url.path = new_path;
-    parsed_url.pathname = new_path;
-    console.log(parsed_url);
-    console.log(parsed_url.toString);
-    return url.format(parsed_url);
+    console.log(newPath);
+    parsedUrl.protocol = "https";
+    parsedUrl.path = newPath;
+    parsedUrl.pathname = newPath;
+    console.log(parsedUrl);
+    console.log(parsedUrl.toString);
+    return url.format(parsedUrl);
 }
 
 function bondBaseUrl() {

--- a/helpers.js
+++ b/helpers.js
@@ -21,4 +21,9 @@ function dosToHttps(dosUri) {
     return url.format(parsed_url);
 }
 
+function bondBaseUrl() {
+    return config.bondBaseUrl;
+}
+
 exports.dosToHttps = dosToHttps;
+exports.bondBaseUrl = bondBaseUrl;

--- a/index.js
+++ b/index.js
@@ -3,9 +3,7 @@
  * written by Ursa S 02/18
  */
 
-const cors = require("cors");
-const corsMiddleware = cors();
-
+const corsMiddleware = require("cors")();
 const martha_v1 = require("./martha_v1");
 const martha_v2 = require("./martha_v2");
 
@@ -16,6 +14,3 @@ exports.martha_v1 = (req, res) => {
 exports.martha_v2 = (req, res) => {
     corsMiddleware(req, res, () => martha_v2.martha_v2_handler(req, res));
 };
-
-const helpers = require("./helpers");
-exports.dosToHttps = helpers.dosToHttps;

--- a/index.js
+++ b/index.js
@@ -3,130 +3,19 @@
  * written by Ursa S 02/18
  */
 
-const superagent = require('superagent');
-const url = require('url')
 const cors = require("cors");
 const corsMiddleware = cors();
-const config = require("./config.json")
 
-function dosToHttps(dosUri) {
-    var parsed_url = url.parse(dosUri);
-    var orig_path = parsed_url.pathname;
-    var new_path = '/ga4gh/dos/v1/dataobjects' + orig_path;
-
-    // special case for hostless dos uris which will be better supported in martha v2
-    if (parsed_url.host.startsWith("dg.")) {
-        new_path = '/ga4gh/dos/v1/dataobjects/' + parsed_url.hostname + orig_path;
-        parsed_url.host = config.dosResolutionHost;
-    }
-
-    console.log(new_path);
-    parsed_url.protocol = 'https';
-    parsed_url.path = new_path;
-    parsed_url.pathname = new_path;
-    console.log(parsed_url);
-    console.log(parsed_url.toString);
-    return url.format(parsed_url);
-}
-
-const martha_v1_handler = (req, res) => {
-    var orig_url = req.body.url;
-    var pattern = req.body.pattern;
-    if(!orig_url) {
-      orig_url = JSON.parse(req.body.toString()).url;
-      pattern = JSON.parse(req.body.toString()).pattern;
-    }
-
-    var http_url = dosToHttps(orig_url)
-
-    console.log(http_url);
-    superagent.get(http_url)
-        .end(function(err, response) {
-            if(err){
-                console.error(err);
-                res.status(502).send(err);
-                return;
-            };
-            try {
-                var parsedData = JSON.parse(response.text);
-            } catch(e) {
-                // console.error(e);
-                res.status(400).send(`Data returned not in correct format`);
-                return;
-            };
-            var allData = parsedData["data_object"];
-            if (!allData) {
-                res.status(400).send(`No data received from ${req.body.url}`);
-            } else {
-                var urls = allData["urls"];
-                if (!pattern) {
-                    res.status(400).send(`No pattern param specified`);
-                    return;
-                }
-                for (var url in urls) {
-                    var currentUrl = urls[url]["url"];
-                    if (currentUrl.startsWith(pattern)) {
-                        var correctUrl = currentUrl;
-                        res.status(200).send(correctUrl);
-                    }
-                }
-                //gone through all urls, no match found
-                if (!correctUrl) {
-                    res.status(404).send(`No ${pattern} link found`);
-                }
-                ;
-            }
-            ;
-        });
-};
-
-const martha_v2_handler = (req, res) => {
-    var orig_url = req.body.url;
-    if(!orig_url) {
-        orig_url = JSON.parse(req.body.toString()).url;
-    }
-
-    var http_url = dosToHttps(orig_url);
-
-    console.log(http_url);
-    superagent.get(http_url)
-        .end(function(err, response) {
-            if(err) {
-                console.error(err);
-                res.status(502).send(err);
-                return;
-            }
-            try {
-                var parsedData = JSON.parse(response.text);
-            } catch(e) {
-                res.status(400).send(`Data returned not in correct format`);
-                return;
-            }
-            superagent
-                .get(`${config.bondBaseUrl}/api/link/v1/fence/serviceaccount/key`)
-                .set('authorization', req.get("authorization"))
-                .end(function(bondErr, bondResponse) {
-                    if(bondErr) {
-                        console.error(bondErr);
-                        res.status(502).send(bondErr);
-                        return;
-                    }
-                    try {
-                        var parsedServiceAccountKey = JSON.parse(bondResponse.text);
-                    } catch(e) {
-                        res.status(500).send(`Service account key not in correct format`);
-                        return;
-                    }
-                    res.status(200).send({'dos': parsedData, 'googleServiceAccount': parsedServiceAccountKey["data"]});
-                });
-        });
-};
+const martha_v1 = require("./martha_v1");
+const martha_v2 = require("./martha_v2");
 
 exports.martha_v1 = (req, res) => {
-  corsMiddleware(req, res, () => martha_v1_handler(req, res));
-};
-exports.martha_v2 = (req, res) => {
-    corsMiddleware(req, res, () => martha_v2_handler(req, res));
+    corsMiddleware(req, res, () => martha_v1.martha_v1_handler(req, res));
 };
 
-exports.dosToHttps = dosToHttps;
+exports.martha_v2 = (req, res) => {
+    corsMiddleware(req, res, () => martha_v2.martha_v2_handler(req, res));
+};
+
+const helpers = require("./helpers");
+exports.dosToHttps = helpers.dosToHttps;

--- a/martha_v1.js
+++ b/martha_v1.js
@@ -1,0 +1,53 @@
+const superagent = require('superagent');
+const helpers = require('./helpers');
+
+const martha_v1_handler = (req, res) => {
+    var orig_url = req.body.url;
+    var pattern = req.body.pattern;
+    if (!orig_url) {
+        orig_url = JSON.parse(req.body.toString()).url;
+        pattern = JSON.parse(req.body.toString()).pattern;
+    }
+
+    var http_url = helpers.dosToHttps(orig_url);
+
+    console.log(http_url);
+    superagent.get(http_url)
+        .end(function (err, response) {
+            if (err) {
+                console.error(err);
+                res.status(502).send(err);
+                return;
+            }
+            try {
+                var parsedData = JSON.parse(response.text);
+            } catch (e) {
+                // console.error(e);
+                res.status(400).send(`Data returned not in correct format`);
+                return;
+            }
+            var allData = parsedData["data_object"];
+            if (!allData) {
+                res.status(400).send(`No data received from ${req.body.url}`);
+            } else {
+                var urls = allData["urls"];
+                if (!pattern) {
+                    res.status(400).send(`No pattern param specified`);
+                    return;
+                }
+                for (var url in urls) {
+                    var currentUrl = urls[url]["url"];
+                    if (currentUrl.startsWith(pattern)) {
+                        var correctUrl = currentUrl;
+                        res.status(200).send(correctUrl);
+                    }
+                }
+                //gone through all urls, no match found
+                if (!correctUrl) {
+                    res.status(404).send(`No ${pattern} link found`);
+                }
+            }
+        });
+};
+
+exports.martha_v1_handler = martha_v1_handler;

--- a/martha_v1.js
+++ b/martha_v1.js
@@ -13,16 +13,11 @@ const martha_v1_handler = (req, res) => {
 
     console.log(http_url);
     superagent.get(http_url)
-        .end(function (err, response) {
-            if (err) {
-                console.error(err);
-                res.status(502).send(err);
-                return;
-            }
+        .then(function (response) {
             try {
                 var parsedData = JSON.parse(response.text);
             } catch (e) {
-                // console.error(e);
+                console.error(e);
                 res.status(400).send(`Data returned not in correct format`);
                 return;
             }
@@ -47,6 +42,11 @@ const martha_v1_handler = (req, res) => {
                     res.status(404).send(`No ${pattern} link found`);
                 }
             }
+        })
+        .catch(function(err) {
+            // TODO: this error condition has never been tested, write a test for it
+            console.error(err);
+            res.status(502).send(err);
         });
 };
 

--- a/martha_v2.js
+++ b/martha_v2.js
@@ -2,6 +2,7 @@ const superagent = require('superagent');
 const helpers = require('./helpers');
 
 const martha_v2_handler = (req, res) => {
+    // res.status(200).send("headers are: " + JSON.stringify(req.headers.authorization));
     var orig_url = req.body.url;
     if (!orig_url) {
         orig_url = JSON.parse(req.body.toString()).url;
@@ -11,12 +12,7 @@ const martha_v2_handler = (req, res) => {
 
     console.log(http_url);
     superagent.get(http_url)
-        .end(function (err, response) {
-            if (err) {
-                console.error(err);
-                res.status(502).send(err);
-                return;
-            }
+        .then(function (response) {
             try {
                 var parsedData = JSON.parse(response.text);
             } catch (e) {
@@ -24,22 +20,32 @@ const martha_v2_handler = (req, res) => {
                 return;
             }
             superagent
-                .get(`${config.bondBaseUrl}/api/link/v1/fence/serviceaccount/key`)
-                .set('authorization', req.get("authorization"))
-                .end(function (bondErr, bondResponse) {
-                    if (bondErr) {
-                        console.error(bondErr);
-                        res.status(502).send(bondErr);
-                        return;
-                    }
+                .get(`${helpers.bondBaseUrl()}/api/link/v1/fence/serviceaccount/key`)
+                .set('authorization', req.headers.authorization)
+                .then(function (bondResponse) {
+                    // if (bondErr) {
+                    //     console.error(new Error(bondErr));
+                    //     res.status(502).send(bondErr);
+                    //     return;
+                    // }
                     try {
                         var parsedServiceAccountKey = JSON.parse(bondResponse.text);
                     } catch (e) {
+                        console.log(bondResponse);
+                        console.error(new Error(e));
                         res.status(500).send(`Service account key not in correct format`);
                         return;
                     }
                     res.status(200).send({'dos': parsedData, 'googleServiceAccount': parsedServiceAccountKey["data"]});
+                })
+                .catch(function (bondErr) {
+                    console.error(new Error(bondErr));
+                    res.status(502).send(bondErr);
                 });
+        })
+        .catch(function (err) {
+            console.error(new Error(err));
+            res.status(502).send(err);
         });
 };
 

--- a/martha_v2.js
+++ b/martha_v2.js
@@ -1,7 +1,7 @@
 const helpers = require("./helpers");
 const apiAdapter = require("./api_adapter");
 
-function parse_request(req) {
+function parseRequest(req) {
     let origUrl = req.body.url;
     if (!origUrl) {
         try {
@@ -14,7 +14,7 @@ function parse_request(req) {
 }
 
 function martha_v2_handler(req, res) {
-    let origUrl = parse_request(req);
+    let origUrl = parseRequest(req);
     if (!origUrl) {
         res.status(400).send("You must specify the URL of a DOS object");
         return;

--- a/martha_v2.js
+++ b/martha_v2.js
@@ -1,43 +1,43 @@
-const helpers = require('./helpers');
-const api_adapter = require('./api_adapter');
+const helpers = require("./helpers");
+const api_adapter = require("./api_adapter");
 
 function parse_request(req) {
-    let orig_url = req.body.url;
-    if (!orig_url) {
+    let origUrl = req.body.url;
+    if (!origUrl) {
         try {
-            orig_url = JSON.parse(req.body.toString()).url;
+            origUrl = JSON.parse(req.body.toString()).url;
         } catch (e) {
             console.error(new Error(`Request did not specify a valid url:\n${JSON.stringify(req)}\n${e}`));
         }
     }
-    return orig_url;
+    return origUrl;
 }
 
 function martha_v2_handler(req, res) {
-    let orig_url = parse_request(req);
-    if (!orig_url) {
-        res.status(400).send('You must specify the URL of a DOS object');
+    let origUrl = parse_request(req);
+    if (!origUrl) {
+        res.status(400).send("You must specify the URL of a DOS object");
         return;
     }
 
-    let dos_url;
+    let dosUrl;
     try {
-        dos_url = helpers.dosToHttps(orig_url);
+        dosUrl = helpers.dosToHttps(origUrl);
     } catch (e) {
         console.error(e);
-        res.status(400).send('The specified URL is invalid');
+        res.status(400).send("The specified URL is invalid");
         return;
     }
 
-    console.log(dos_url);
+    console.log(dosUrl);
 
-    let dos_promise = api_adapter.getTextFrom(dos_url);
-    let bond_promise = api_adapter.getTextFrom(`${helpers.bondBaseUrl()}/api/link/v1/fence/serviceaccount/key`, req.headers.authorization);
+    let dosPromise = api_adapter.getTextFrom(dosUrl);
+    let bondPromise = api_adapter.getTextFrom(`${helpers.bondBaseUrl()}/api/link/v1/fence/serviceaccount/key`, req.headers.authorization);
 
-    return Promise.all([dos_promise, bond_promise])
+    return Promise.all([dosPromise, bondPromise])
         .then((raw_results) => {
             const parsed_results = raw_results.map((str) => JSON.parse(str));
-            res.status(200).send({'dos': parsed_results[0], 'googleServiceAccount': parsed_results[1]});
+            res.status(200).send({dos: parsed_results[0], googleServiceAccount: parsed_results[1]});
         })
         .catch((err) => {
            console.error(err);

--- a/martha_v2.js
+++ b/martha_v2.js
@@ -31,8 +31,8 @@ function martha_v2_handler(req, res) {
 
     console.log(dos_url);
 
-    let dos_promise = api_adapter.get_text_from(dos_url);
-    let bond_promise = api_adapter.get_text_from(`${helpers.bondBaseUrl()}/api/link/v1/fence/serviceaccount/key`, req.headers.authorization);
+    let dos_promise = api_adapter.getTextFrom(dos_url);
+    let bond_promise = api_adapter.getTextFrom(`${helpers.bondBaseUrl()}/api/link/v1/fence/serviceaccount/key`, req.headers.authorization);
 
     return Promise.all([dos_promise, bond_promise])
         .then((raw_results) => {

--- a/martha_v2.js
+++ b/martha_v2.js
@@ -1,0 +1,46 @@
+const superagent = require('superagent');
+const helpers = require('./helpers');
+
+const martha_v2_handler = (req, res) => {
+    var orig_url = req.body.url;
+    if (!orig_url) {
+        orig_url = JSON.parse(req.body.toString()).url;
+    }
+
+    var http_url = helpers.dosToHttps(orig_url);
+
+    console.log(http_url);
+    superagent.get(http_url)
+        .end(function (err, response) {
+            if (err) {
+                console.error(err);
+                res.status(502).send(err);
+                return;
+            }
+            try {
+                var parsedData = JSON.parse(response.text);
+            } catch (e) {
+                res.status(400).send(`Data returned not in correct format`);
+                return;
+            }
+            superagent
+                .get(`${config.bondBaseUrl}/api/link/v1/fence/serviceaccount/key`)
+                .set('authorization', req.get("authorization"))
+                .end(function (bondErr, bondResponse) {
+                    if (bondErr) {
+                        console.error(bondErr);
+                        res.status(502).send(bondErr);
+                        return;
+                    }
+                    try {
+                        var parsedServiceAccountKey = JSON.parse(bondResponse.text);
+                    } catch (e) {
+                        res.status(500).send(`Service account key not in correct format`);
+                        return;
+                    }
+                    res.status(200).send({'dos': parsedData, 'googleServiceAccount': parsedServiceAccountKey["data"]});
+                });
+        });
+};
+
+exports.martha_v2_handler = martha_v2_handler;

--- a/martha_v2.js
+++ b/martha_v2.js
@@ -1,5 +1,5 @@
 const helpers = require("./helpers");
-const api_adapter = require("./api_adapter");
+const apiAdapter = require("./api_adapter");
 
 function parse_request(req) {
     let origUrl = req.body.url;
@@ -31,13 +31,13 @@ function martha_v2_handler(req, res) {
 
     console.log(dosUrl);
 
-    let dosPromise = api_adapter.getTextFrom(dosUrl);
-    let bondPromise = api_adapter.getTextFrom(`${helpers.bondBaseUrl()}/api/link/v1/fence/serviceaccount/key`, req.headers.authorization);
+    let dosPromise = apiAdapter.getTextFrom(dosUrl);
+    let bondPromise = apiAdapter.getTextFrom(`${helpers.bondBaseUrl()}/api/link/v1/fence/serviceaccount/key`, req.headers.authorization);
 
     return Promise.all([dosPromise, bondPromise])
-        .then((raw_results) => {
-            const parsed_results = raw_results.map((str) => JSON.parse(str));
-            res.status(200).send({dos: parsed_results[0], googleServiceAccount: parsed_results[1]});
+        .then((rawResults) => {
+            const parsedResults = rawResults.map((str) => JSON.parse(str));
+            res.status(200).send({dos: parsedResults[0], googleServiceAccount: parsedResults[1]});
         })
         .catch((err) => {
            console.error(err);

--- a/martha_v2.js
+++ b/martha_v2.js
@@ -24,12 +24,13 @@ function martha_v2_handler(req, res) {
 
     console.log(dos_url);
 
-    let dos_promise = api_adapter.resolve_dos(dos_url);
-    let bond_promise = api_adapter.talk_to_bond(req.headers.authorization);
+    let dos_promise = api_adapter.get_text_from(dos_url);
+    let bond_promise = api_adapter.get_text_from(`${helpers.bondBaseUrl()}/api/link/v1/fence/serviceaccount/key`, req.headers.authorization);
 
     return Promise.all([dos_promise, bond_promise])
-        .then((result) => {
-            res.status(200).send({'dos': result[0], 'googleServiceAccount': result[1]});
+        .then((raw_results) => {
+            const parsed_results = raw_results.map((str) => JSON.parse(str));
+            res.status(200).send({'dos': parsed_results[0], 'googleServiceAccount': parsed_results[1]});
         })
         .catch((err) => {
            console.error(err);

--- a/martha_v2.js
+++ b/martha_v2.js
@@ -20,7 +20,14 @@ function martha_v2_handler(req, res) {
         return;
     }
 
-    let dos_url = helpers.dosToHttps(orig_url);
+    let dos_url;
+    try {
+        dos_url = helpers.dosToHttps(orig_url);
+    } catch (e) {
+        console.error(e);
+        res.status(400).send('The specified URL is invalid');
+        return;
+    }
 
     console.log(dos_url);
 

--- a/package.json
+++ b/package.json
@@ -5,7 +5,9 @@
   "private": true,
   "scripts": {
     "test": "ava -m !smoketest*",
-    "smoketest": "ava -m smoketest*"
+    "smoketest": "ava -m smoketest*",
+    "smoketest_v1": "ava -m smoketest_v1*",
+    "smoketest_v2": "ava -m smoketest_v2*"
   },
   "dependencies": {
     "ava": "^0.25.0",

--- a/test/api_adapter.test.js
+++ b/test/api_adapter.test.js
@@ -22,28 +22,28 @@ test.after(t => {
     getRequest.restore();
 });
 
-test('api_adapter.get_text_from should get the value of the text field from the response', async t => {
+test('api_adapter.getTextFrom should get the value of the text field from the response', async t => {
     let some_text = "Some special text";
     getRequest.returns(mockResponseToGet(some_text));
-    const result = await api_adapter.get_text_from("Irrelevant URL");
+    const result = await api_adapter.getTextFrom("Irrelevant URL");
     t.is(result, some_text);
 });
 
-test('api_adapter.get_text_from should append an authorization header when passed an authorization string', async t => {
+test('api_adapter.getTextFrom should append an authorization header when passed an authorization string', async t => {
     let some_text = "Some special text";
     let authz_str = "abc123";
     let mockGet = mockResponseToGet(some_text);
     getRequest.returns(mockGet);
-    const result = await api_adapter.get_text_from("Irrelevant URL", authz_str);
+    const result = await api_adapter.getTextFrom("Irrelevant URL", authz_str);
     t.is(result, some_text);
     t.deepEqual(mockGet.set.firstCall.args, ["authorization", authz_str]);
 });
 
-test('api_adapter.get_text_from should NOT append an authorization header when not passed an authorization string', async t => {
+test('api_adapter.getTextFrom should NOT append an authorization header when not passed an authorization string', async t => {
     let some_text = "Some special text";
     let mockGet = mockResponseToGet(some_text);
     getRequest.returns(mockGet);
-    const result = await api_adapter.get_text_from("Irrelevant URL");
+    const result = await api_adapter.getTextFrom("Irrelevant URL");
     t.is(result, some_text);
     t.false(mockGet.set.called);
 });

--- a/test/api_adapter.test.js
+++ b/test/api_adapter.test.js
@@ -1,0 +1,49 @@
+const test = require(`ava`);
+const sinon = require(`sinon`);
+const api_adapter = require('../api_adapter');
+const superagent = require('superagent');
+
+function mockResponseToGet(text_value) {
+    return {
+        then: (cb) => {
+            return cb({text : text_value});
+        },
+        set: sinon.stub()
+    }
+}
+
+let getRequest;
+
+test.before(t => {
+    getRequest = sinon.stub(superagent, 'get');
+});
+
+test.after(t => {
+    getRequest.restore();
+});
+
+test('api_adapter.get_text_from should get the value of the text field from the response', async t => {
+    let some_text = "Some special text";
+    getRequest.returns(mockResponseToGet(some_text));
+    const result = await api_adapter.get_text_from("Irrelevant URL");
+    t.is(result, some_text);
+});
+
+test('api_adapter.get_text_from should append an authorization header when passed an authorization string', async t => {
+    let some_text = "Some special text";
+    let authz_str = "abc123";
+    let mockGet = mockResponseToGet(some_text);
+    getRequest.returns(mockGet);
+    const result = await api_adapter.get_text_from("Irrelevant URL", authz_str);
+    t.is(result, some_text);
+    t.deepEqual(mockGet.set.firstCall.args, ["authorization", authz_str]);
+});
+
+test('api_adapter.get_text_from should NOT append an authorization header when not passed an authorization string', async t => {
+    let some_text = "Some special text";
+    let mockGet = mockResponseToGet(some_text);
+    getRequest.returns(mockGet);
+    const result = await api_adapter.get_text_from("Irrelevant URL");
+    t.is(result, some_text);
+    t.false(mockGet.set.called);
+});

--- a/test/api_adapter.test.js
+++ b/test/api_adapter.test.js
@@ -9,7 +9,7 @@ function mockResponseToGet(textValue) {
             return cb({text : textValue});
         },
         set: sinon.stub()
-    }
+    };
 }
 
 let getRequest;
@@ -31,12 +31,12 @@ test("api_adapter.getTextFrom should get the value of the text field from the re
 
 test("api_adapter.getTextFrom should append an authorization header when passed an authorization string", async (t) => {
     let someText = "Some special text";
-    let authz_str = "abc123";
+    let authzStr = "abc123";
     let mockGet = mockResponseToGet(someText);
     getRequest.returns(mockGet);
-    const result = await apiAdapter.getTextFrom("Irrelevant URL", authz_str);
+    const result = await apiAdapter.getTextFrom("Irrelevant URL", authzStr);
     t.is(result, someText);
-    t.deepEqual(mockGet.set.firstCall.args, ["authorization", authz_str]);
+    t.deepEqual(mockGet.set.firstCall.args, ["authorization", authzStr]);
 });
 
 test("api_adapter.getTextFrom should NOT append an authorization header when not passed an authorization string", async (t) => {

--- a/test/api_adapter.test.js
+++ b/test/api_adapter.test.js
@@ -1,12 +1,12 @@
 const test = require("ava");
 const sinon = require("sinon");
-const api_adapter = require("../api_adapter");
+const apiAdapter = require("../api_adapter");
 const superagent = require("superagent");
 
-function mockResponseToGet(text_value) {
+function mockResponseToGet(textValue) {
     return {
         then: (cb) => {
-            return cb({text : text_value});
+            return cb({text : textValue});
         },
         set: sinon.stub()
     }
@@ -23,27 +23,27 @@ test.after(t => {
 });
 
 test("api_adapter.getTextFrom should get the value of the text field from the response", async t => {
-    let some_text = "Some special text";
-    getRequest.returns(mockResponseToGet(some_text));
-    const result = await api_adapter.getTextFrom("Irrelevant URL");
-    t.is(result, some_text);
+    let someText = "Some special text";
+    getRequest.returns(mockResponseToGet(someText));
+    const result = await apiAdapter.getTextFrom("Irrelevant URL");
+    t.is(result, someText);
 });
 
 test("api_adapter.getTextFrom should append an authorization header when passed an authorization string", async t => {
-    let some_text = "Some special text";
+    let someText = "Some special text";
     let authz_str = "abc123";
-    let mockGet = mockResponseToGet(some_text);
+    let mockGet = mockResponseToGet(someText);
     getRequest.returns(mockGet);
-    const result = await api_adapter.getTextFrom("Irrelevant URL", authz_str);
-    t.is(result, some_text);
+    const result = await apiAdapter.getTextFrom("Irrelevant URL", authz_str);
+    t.is(result, someText);
     t.deepEqual(mockGet.set.firstCall.args, ["authorization", authz_str]);
 });
 
 test("api_adapter.getTextFrom should NOT append an authorization header when not passed an authorization string", async t => {
-    let some_text = "Some special text";
-    let mockGet = mockResponseToGet(some_text);
+    let someText = "Some special text";
+    let mockGet = mockResponseToGet(someText);
     getRequest.returns(mockGet);
-    const result = await api_adapter.getTextFrom("Irrelevant URL");
-    t.is(result, some_text);
+    const result = await apiAdapter.getTextFrom("Irrelevant URL");
+    t.is(result, someText);
     t.false(mockGet.set.called);
 });

--- a/test/api_adapter.test.js
+++ b/test/api_adapter.test.js
@@ -14,22 +14,22 @@ function mockResponseToGet(textValue) {
 
 let getRequest;
 
-test.before(t => {
+test.before((t) => {
     getRequest = sinon.stub(superagent, "get");
 });
 
-test.after(t => {
+test.after((t) => {
     getRequest.restore();
 });
 
-test("api_adapter.getTextFrom should get the value of the text field from the response", async t => {
+test("api_adapter.getTextFrom should get the value of the text field from the response", async (t) => {
     let someText = "Some special text";
     getRequest.returns(mockResponseToGet(someText));
     const result = await apiAdapter.getTextFrom("Irrelevant URL");
     t.is(result, someText);
 });
 
-test("api_adapter.getTextFrom should append an authorization header when passed an authorization string", async t => {
+test("api_adapter.getTextFrom should append an authorization header when passed an authorization string", async (t) => {
     let someText = "Some special text";
     let authz_str = "abc123";
     let mockGet = mockResponseToGet(someText);
@@ -39,7 +39,7 @@ test("api_adapter.getTextFrom should append an authorization header when passed 
     t.deepEqual(mockGet.set.firstCall.args, ["authorization", authz_str]);
 });
 
-test("api_adapter.getTextFrom should NOT append an authorization header when not passed an authorization string", async t => {
+test("api_adapter.getTextFrom should NOT append an authorization header when not passed an authorization string", async (t) => {
     let someText = "Some special text";
     let mockGet = mockResponseToGet(someText);
     getRequest.returns(mockGet);

--- a/test/api_adapter.test.js
+++ b/test/api_adapter.test.js
@@ -1,7 +1,7 @@
-const test = require(`ava`);
-const sinon = require(`sinon`);
-const api_adapter = require('../api_adapter');
-const superagent = require('superagent');
+const test = require("ava");
+const sinon = require("sinon");
+const api_adapter = require("../api_adapter");
+const superagent = require("superagent");
 
 function mockResponseToGet(text_value) {
     return {
@@ -15,21 +15,21 @@ function mockResponseToGet(text_value) {
 let getRequest;
 
 test.before(t => {
-    getRequest = sinon.stub(superagent, 'get');
+    getRequest = sinon.stub(superagent, "get");
 });
 
 test.after(t => {
     getRequest.restore();
 });
 
-test('api_adapter.getTextFrom should get the value of the text field from the response', async t => {
+test("api_adapter.getTextFrom should get the value of the text field from the response", async t => {
     let some_text = "Some special text";
     getRequest.returns(mockResponseToGet(some_text));
     const result = await api_adapter.getTextFrom("Irrelevant URL");
     t.is(result, some_text);
 });
 
-test('api_adapter.getTextFrom should append an authorization header when passed an authorization string', async t => {
+test("api_adapter.getTextFrom should append an authorization header when passed an authorization string", async t => {
     let some_text = "Some special text";
     let authz_str = "abc123";
     let mockGet = mockResponseToGet(some_text);
@@ -39,7 +39,7 @@ test('api_adapter.getTextFrom should append an authorization header when passed 
     t.deepEqual(mockGet.set.firstCall.args, ["authorization", authz_str]);
 });
 
-test('api_adapter.getTextFrom should NOT append an authorization header when not passed an authorization string', async t => {
+test("api_adapter.getTextFrom should NOT append an authorization header when not passed an authorization string", async t => {
     let some_text = "Some special text";
     let mockGet = mockResponseToGet(some_text);
     getRequest.returns(mockGet);

--- a/test/helpers.test.js
+++ b/test/helpers.test.js
@@ -1,15 +1,15 @@
 const test = require("ava");
 const dosToHttps = require("../helpers").dosToHttps;
 
-test("should parse dos uri", t => {
+test("should parse dos uri", (t) => {
     t.is(dosToHttps("dos://foo/bar"), "https://foo/ga4gh/dos/v1/dataobjects/bar");
 });
 
-test("should parse dg dos uri", t => {
+test("should parse dg dos uri", (t) => {
     t.is(dosToHttps("dos://dg.2345/bar"), "https://dcp.bionimbus.org/ga4gh/dos/v1/dataobjects/dg.2345/bar");
 });
 
-test("should throw a TypeError when passed an invalid uri", t => {
+test("should throw a TypeError when passed an invalid uri", (t) => {
     t.throws(() => {
        dosToHttps("A string that is not a valid URI");
     }, TypeError);

--- a/test/helpers.test.js
+++ b/test/helpers.test.js
@@ -1,15 +1,15 @@
-const test = require(`ava`);
-const dosToHttps = require('../helpers').dosToHttps;
+const test = require("ava");
+const dosToHttps = require("../helpers").dosToHttps;
 
-test(`should parse dos uri`, t => {
+test("should parse dos uri", t => {
     t.is(dosToHttps("dos://foo/bar"), "https://foo/ga4gh/dos/v1/dataobjects/bar");
 });
 
-test(`should parse dg dos uri`, t => {
+test("should parse dg dos uri", t => {
     t.is(dosToHttps("dos://dg.2345/bar"), "https://dcp.bionimbus.org/ga4gh/dos/v1/dataobjects/dg.2345/bar");
 });
 
-test(`should throw a TypeError when passed an invalid uri`, t => {
+test("should throw a TypeError when passed an invalid uri", t => {
     t.throws(() => {
        dosToHttps("A string that is not a valid URI");
     }, TypeError);

--- a/test/helpers.test.js
+++ b/test/helpers.test.js
@@ -1,0 +1,10 @@
+const test = require(`ava`);
+const dosToHttps = require('../helpers').dosToHttps;
+
+test(`should parse dos uri`, t => {
+    t.is(dosToHttps("dos://foo/bar"), "https://foo/ga4gh/dos/v1/dataobjects/bar");
+});
+
+test(`should parse dg dos uri`, t => {
+    t.is(dosToHttps("dos://dg.2345/bar"), "https://dcp.bionimbus.org/ga4gh/dos/v1/dataobjects/dg.2345/bar");
+});

--- a/test/helpers.test.js
+++ b/test/helpers.test.js
@@ -8,3 +8,9 @@ test(`should parse dos uri`, t => {
 test(`should parse dg dos uri`, t => {
     t.is(dosToHttps("dos://dg.2345/bar"), "https://dcp.bionimbus.org/ga4gh/dos/v1/dataobjects/dg.2345/bar");
 });
+
+test(`should throw a TypeError when passed an invalid uri`, t => {
+    t.throws(() => {
+       dosToHttps("A string that is not a valid URI");
+    }, TypeError);
+});

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,7 +1,7 @@
 const test = require(`ava`);
 const sinon = require(`sinon`);
 const martha = require('..').martha_v1;
-const dosToHttps = require('..').dosToHttps
+const dosToHttps = require('..').dosToHttps;
 const superagent = require('superagent');
 const Supertest = require(`supertest`);
 const supertest = Supertest(process.env.BASE_URL);
@@ -38,7 +38,7 @@ test.before(t => {
 
 test.after(t => {
     getRequest.restore();
-})
+});
 
 test(`should return link that matches pattern param`, t => {
     getRequest.returns({end: (cb) => {cb(null, {text : withGS});}});

--- a/test/martha_v1.test.js
+++ b/test/martha_v1.test.js
@@ -1,10 +1,8 @@
 const test = require(`ava`);
 const sinon = require(`sinon`);
-const martha = require('..').martha_v1;
-const dosToHttps = require('..').dosToHttps;
+const martha_v1 = require('../martha_v1').martha_v1_handler;
 const superagent = require('superagent');
-const Supertest = require(`supertest`);
-const supertest = Supertest(process.env.BASE_URL);
+
 var getRequest;
 
 var withGS = '{"data_object": {"checksums": [{"checksum": "64573c6a0c75993c16e313f819fa71b8571b86de75b7523ae8677a92172ea2ba", "type": "sha256"}, {"checksum": "594f5f1a316e9ccfb38d02a345c86597-293", "type": "etag"}, {"checksum": "9976538e92c4f12aebfea277ecaef9fc5b54c732", "type": "sha1"}, {"checksum": "41a4b033", "type": "crc32c"}], "version": "2018-01-31T142539.590521Z", "id": "ed703a5d-4705-49a8-9429-5169d9225bbd", "urls": [{"url": "https://commons-dss.ucsc-cgp-dev.org/v1/files/ed703a5d-4705-49a8-9429-5169d9225bbd?replica=aws"}, {"url": "https://commons-dss.ucsc-cgp-dev.org/v1/files/ed703a5d-4705-49a8-9429-5169d9225bbd?replica=azure"}, {"url": "https://commons-dss.ucsc-cgp-dev.org/v1/files/ed703a5d-4705-49a8-9429-5169d9225bbd?replica=gcp"}, {"url": "s3://commons-dss-commons/blobs/64573c6a0c75993c16e313f819fa71b8571b86de75b7523ae8677a92172ea2ba.9976538e92c4f12aebfea277ecaef9fc5b54c732.594f5f1a316e9ccfb38d02a345c86597-293.41a4b033"}, {"url": "gs://commons-dss-commons/blobs/64573c6a0c75993c16e313f819fa71b8571b86de75b7523ae8677a92172ea2ba.9976538e92c4f12aebfea277ecaef9fc5b54c732.594f5f1a316e9ccfb38d02a345c86597-293.41a4b033"}]}}';
@@ -40,76 +38,53 @@ test.after(t => {
     getRequest.restore();
 });
 
+function mockResponseToGet(text_value) {
+    return {
+        then: (cb) => {
+            cb({text : text_value});
+            return {
+                catch: sinon.stub()
+            }
+        }
+    }
+}
+
 test(`should return link that matches pattern param`, t => {
-    getRequest.returns({end: (cb) => {cb(null, {text : withGS});}});
+    getRequest.returns(mockResponseToGet(withGS));
     const res = mockResponse();
-    martha(mockRequest({body: {"url" : "https://example.com/validGS", "pattern" : "gs://"}}), res);
+    martha_v1(mockRequest({body: {"url" : "https://example.com/validGS", "pattern" : "gs://"}}), res);
     t.deepEqual(res.send.lastCall.args[0], "gs://commons-dss-commons/blobs/64573c6a0c75993c16e313f819fa71b8571b86de75b7523ae8677a92172ea2ba.9976538e92c4f12aebfea277ecaef9fc5b54c732.594f5f1a316e9ccfb38d02a345c86597-293.41a4b033");
     t.is(res.statusCode, 200);
 });
 
 test(`should return descriptive error when no link matching pattern is present`, t => {
-    getRequest.returns({end: (cb) => {cb(null, {text : withNoGS});}});
+    getRequest.returns(mockResponseToGet(withNoGS));
     const res = mockResponse();
-    martha(mockRequest({body: {"url" : "https://example.com/noGSlink", "pattern" : "gs://"}}), res);
+    martha_v1(mockRequest({body: {"url" : "https://example.com/noGSlink", "pattern" : "gs://"}}), res);
     t.is(res.send.lastCall.args[0], "No gs:// link found");
     t.is(res.statusCode, 404);
 });
 
 test(`should return no data found if returned data object is empty`, t => {
-    getRequest.returns({end: (cb) => {cb(null, {text : noData });}});
+    getRequest.returns(mockResponseToGet(noData));
     const res = mockResponse();
-    martha(mockRequest({body: {"url" : "https://example.com/noData", "pattern" : "gs://"}}), res);
+    martha_v1(mockRequest({body: {"url" : "https://example.com/noData", "pattern" : "gs://"}}), res);
     t.is(res.send.lastCall.args[0], "No data received from https://example.com/noData");
     t.is(res.statusCode, 400);
 });
 
 test(`should return error if data object is bad`, t => {
-    getRequest.returns({end: (cb) => {cb(null, {text : badData});}});
+    getRequest.returns(mockResponseToGet(badData));
     const res = mockResponse();
-    martha(mockRequest({body: {"url" : "https://example.com/badData", "pattern" : "gs://"}}), res);
+    martha_v1(mockRequest({body: {"url" : "https://example.com/badData", "pattern" : "gs://"}}), res);
     t.is(res.send.lastCall.args[0], "Data returned not in correct format");
     t.is(res.statusCode, 400);
 });
 
 test(`should return error if no pattern param given`, t => {
-    getRequest.returns({end: (cb) => {cb(null, {text : withGS});}});
+    getRequest.returns(mockResponseToGet(withGS));
     var res = mockResponse();
-    martha(mockRequest({body: {"url" : "https://example.com/noData"}}), res);
+    martha_v1(mockRequest({body: {"url" : "https://example.com/noData"}}), res);
     t.is(res.send.lastCall.args[0], "No pattern param specified");
     t.is(res.statusCode, 400);
-});
-
-test(`should parse dos uri`, t => {
-    t.is(dosToHttps("dos://foo/bar"), "https://foo/ga4gh/dos/v1/dataobjects/bar");
-});
-
-test(`should parse dg dos uri`, t => {
-    t.is(dosToHttps("dos://dg.2345/bar"), "https://dcp.bionimbus.org/ga4gh/dos/v1/dataobjects/dg.2345/bar");
-});
-
-//smoketests
-test.cb(`smoketest return gs link`, t => {
-    console.log(`base url: ${process.env.BASE_URL}`);
-    supertest
-        .post(`/martha_v1`)
-        .set('Content-Type', 'application/json')
-        .send({"url" : "dos://broad-dsp-dos.storage.googleapis.com/dos.json", "pattern" : "gs://"})
-        .expect((response) => {
-            t.is(response.statusCode, 200);
-            t.deepEqual(response.text, "gs://broad-public-datasets/NA12878_downsampled_for_testing/unmapped/H06JUADXX130110.1.ATCACGAT.20k_reads.bam");
-        })
-        .end(t.end);
-});
-
-test.cb(`smoketest return error if url passed is not good`, t => {
-    supertest
-        .post(`/martha_v1`)
-        .set('Content-Type', 'application/json')
-        .send({"url" : "somethingNotValidURL"})
-        .expect(response => {
-            t.is(response.statusCode, 500);
-        })
-        .end(t.end);
-
 });

--- a/test/martha_v1.test.js
+++ b/test/martha_v1.test.js
@@ -30,11 +30,11 @@ const mockResponse = () => {
   };
 };
 
-test.before(t => {
+test.before((t) => {
     getRequest = sinon.stub(superagent, 'get');
 });
 
-test.after(t => {
+test.after((t) => {
     getRequest.restore();
 });
 
@@ -49,7 +49,7 @@ function mockResponseToGet(text_value) {
     }
 }
 
-test(`should return link that matches pattern param`, t => {
+test(`should return link that matches pattern param`, (t) => {
     getRequest.returns(mockResponseToGet(withGS));
     const res = mockResponse();
     martha_v1(mockRequest({body: {"url" : "https://example.com/validGS", "pattern" : "gs://"}}), res);
@@ -57,7 +57,7 @@ test(`should return link that matches pattern param`, t => {
     t.is(res.statusCode, 200);
 });
 
-test(`should return descriptive error when no link matching pattern is present`, t => {
+test(`should return descriptive error when no link matching pattern is present`, (t) => {
     getRequest.returns(mockResponseToGet(withNoGS));
     const res = mockResponse();
     martha_v1(mockRequest({body: {"url" : "https://example.com/noGSlink", "pattern" : "gs://"}}), res);
@@ -65,7 +65,7 @@ test(`should return descriptive error when no link matching pattern is present`,
     t.is(res.statusCode, 404);
 });
 
-test(`should return no data found if returned data object is empty`, t => {
+test(`should return no data found if returned data object is empty`, (t) => {
     getRequest.returns(mockResponseToGet(noData));
     const res = mockResponse();
     martha_v1(mockRequest({body: {"url" : "https://example.com/noData", "pattern" : "gs://"}}), res);
@@ -73,7 +73,7 @@ test(`should return no data found if returned data object is empty`, t => {
     t.is(res.statusCode, 400);
 });
 
-test(`should return error if data object is bad`, t => {
+test(`should return error if data object is bad`, (t) => {
     getRequest.returns(mockResponseToGet(badData));
     const res = mockResponse();
     martha_v1(mockRequest({body: {"url" : "https://example.com/badData", "pattern" : "gs://"}}), res);
@@ -81,7 +81,7 @@ test(`should return error if data object is bad`, t => {
     t.is(res.statusCode, 400);
 });
 
-test(`should return error if no pattern param given`, t => {
+test(`should return error if no pattern param given`, (t) => {
     getRequest.returns(mockResponseToGet(withGS));
     var res = mockResponse();
     martha_v1(mockRequest({body: {"url" : "https://example.com/noData"}}), res);

--- a/test/martha_v2.test.js
+++ b/test/martha_v2.test.js
@@ -33,7 +33,7 @@ const dosObject = {fake: "A fake dos object"};
 const googleSAKeyObject = {key: "A Google Service Account private key json object"};
 
 let getTextFromApiStub;
-let getTextFromApiMethodName = 'getTextFrom';
+let getTextFromApiMethodName = "getTextFrom";
 let sandbox = sinon.createSandbox();
 
 test.serial.beforeEach(t => {

--- a/test/martha_v2.test.js
+++ b/test/martha_v2.test.js
@@ -36,18 +36,18 @@ let getTextFromApiStub;
 let getTextFromApiMethodName = "getTextFrom";
 let sandbox = sinon.createSandbox();
 
-test.serial.beforeEach(t => {
+test.serial.beforeEach((t) => {
     sandbox.restore(); // If one test fails, the .afterEach() block will not execute, so always clean the slate here
     getTextFromApiStub = sandbox.stub(apiAdapter, getTextFromApiMethodName);
     getTextFromApiStub.onFirstCall().resolves(JSON.stringify(dosObject));
     getTextFromApiStub.onSecondCall().resolves(JSON.stringify(googleSAKeyObject));
 });
 
-test.serial.afterEach(t => {
+test.serial.afterEach((t) => {
     sandbox.restore();
 });
 
-test.serial("martha_v2 resolves a valid url into a dos object and google service account key", async t => {
+test.serial("martha_v2 resolves a valid url into a dos object and google service account key", async (t) => {
     const response = mockResponse();
     await martha_v2(mockRequest({body: {"url" : "https://example.com/validGS"}}), response);
     const result = response.send.lastCall.args[0];
@@ -56,7 +56,7 @@ test.serial("martha_v2 resolves a valid url into a dos object and google service
     t.is(response.statusCode, 200);
 });
 
-test.serial("martha_v2 resolves successfully and ignores extra data submitted besides a 'url'", async t => {
+test.serial("martha_v2 resolves successfully and ignores extra data submitted besides a 'url'", async (t) => {
     const response = mockResponse();
     await martha_v2(mockRequest({body: {url : "https://example.com/validGS", pattern: "gs://", foo: "bar"}}), response);
     const result = response.send.lastCall.args[0];
@@ -65,19 +65,19 @@ test.serial("martha_v2 resolves successfully and ignores extra data submitted be
     t.is(response.statusCode, 200);
 });
 
-test.serial("martha_v2 should return 400 if not given a url", async t => {
+test.serial("martha_v2 should return 400 if not given a url", async (t) => {
     const response = mockResponse();
     await martha_v2(mockRequest({body: {"uri" : "https://example.com/validGS"}}), response);
     t.is(response.statusCode, 400);
 });
 
-test.serial("martha_v2 should return 400 if given a 'url' with an invalid value", async t => {
+test.serial("martha_v2 should return 400 if given a 'url' with an invalid value", async (t) => {
     const response = mockResponse();
     await martha_v2(mockRequest({body: {url : "Not a valid URI"}}), response);
     t.is(response.statusCode, 400);
 });
 
-test.serial("martha_v2 should return 502 if dos resolution fails", async t => {
+test.serial("martha_v2 should return 502 if dos resolution fails", async (t) => {
     getTextFromApiStub.restore();
     sandbox.stub(apiAdapter, getTextFromApiMethodName).rejects(new Error("DOS Resolution forced to fail by testing stub"));
     const response = mockResponse();
@@ -87,7 +87,7 @@ test.serial("martha_v2 should return 502 if dos resolution fails", async t => {
     t.is(response.statusCode, 502);
 });
 
-test.serial("martha_v2 should return 502 if key retrieval from bond fails", async t => {
+test.serial("martha_v2 should return 502 if key retrieval from bond fails", async (t) => {
     getTextFromApiStub.restore();
     sandbox.stub(apiAdapter, getTextFromApiMethodName).rejects(new Error("Bond key lookup forced to fail by testing stub"));
     const response = mockResponse();

--- a/test/martha_v2.test.js
+++ b/test/martha_v2.test.js
@@ -37,6 +37,7 @@ let get_text_from_api_method_name = 'get_text_from';
 let sandbox = sinon.createSandbox();
 
 test.serial.beforeEach(t => {
+    sandbox.restore(); // If one test fails, the .afterEach() block will not execute, so always clean the slate here
     get_text_from_api_stub = sandbox.stub(api_adapters, get_text_from_api_method_name);
     get_text_from_api_stub.onFirstCall().resolves(JSON.stringify(dos_object));
     get_text_from_api_stub.onSecondCall().resolves(JSON.stringify(google_sa_key_object));
@@ -67,6 +68,12 @@ test.serial('martha_v2 resolves successfully and ignores extra data submitted be
 test.serial('martha_v2 should return 400 if not given a url', async t => {
     const response = mockResponse();
     await martha_v2(mockRequest({body: {"uri" : "https://example.com/validGS"}}), response);
+    t.is(response.statusCode, 400);
+});
+
+test.serial('martha_v2 should return 400 if given a "url" with an invalid value', async t => {
+    const response = mockResponse();
+    await martha_v2(mockRequest({body: {url : "Not a valid URI"}}), response);
     t.is(response.statusCode, 400);
 });
 

--- a/test/martha_v2.test.js
+++ b/test/martha_v2.test.js
@@ -1,0 +1,99 @@
+const test = require(`ava`);
+const sinon = require(`sinon`);
+const martha_v2 = require('../martha_v2').martha_v2_handler;
+const superagent = require('superagent');
+
+var getRequest;
+
+var withGS = '{"data_object": {"checksums": [{"checksum": "64573c6a0c75993c16e313f819fa71b8571b86de75b7523ae8677a92172ea2ba", "type": "sha256"}, {"checksum": "594f5f1a316e9ccfb38d02a345c86597-293", "type": "etag"}, {"checksum": "9976538e92c4f12aebfea277ecaef9fc5b54c732", "type": "sha1"}, {"checksum": "41a4b033", "type": "crc32c"}], "version": "2018-01-31T142539.590521Z", "id": "ed703a5d-4705-49a8-9429-5169d9225bbd", "urls": [{"url": "https://commons-dss.ucsc-cgp-dev.org/v1/files/ed703a5d-4705-49a8-9429-5169d9225bbd?replica=aws"}, {"url": "https://commons-dss.ucsc-cgp-dev.org/v1/files/ed703a5d-4705-49a8-9429-5169d9225bbd?replica=azure"}, {"url": "https://commons-dss.ucsc-cgp-dev.org/v1/files/ed703a5d-4705-49a8-9429-5169d9225bbd?replica=gcp"}, {"url": "s3://commons-dss-commons/blobs/64573c6a0c75993c16e313f819fa71b8571b86de75b7523ae8677a92172ea2ba.9976538e92c4f12aebfea277ecaef9fc5b54c732.594f5f1a316e9ccfb38d02a345c86597-293.41a4b033"}, {"url": "gs://commons-dss-commons/blobs/64573c6a0c75993c16e313f819fa71b8571b86de75b7523ae8677a92172ea2ba.9976538e92c4f12aebfea277ecaef9fc5b54c732.594f5f1a316e9ccfb38d02a345c86597-293.41a4b033"}]}}';
+
+var withNoGS = '{"data_object": {"updated": "2018-02-27T17:32:34.534544", "name": null, "created": "2018-02-27T17:32:34.534532", "version": "fe63407f", "urls": [{"url": "some/test/location", "system_metadata": {"updated_date": "2018-02-27T17:32:34.534544", "baseid": "68e8d0a7-0c5d-48cc-8f8b-690b941d55e9", "form": "object", "did": "c9b4f486-40b4-40a9-8736-d0e3891c440f", "file_name": null, "rev": "fe63407f", "version": null, "urls": ["some/test/location", "some/test/location/2", "some/test/location/3", "some/test/location/4", "some/test/location/5", "some/test/location/6"], "created_date": "2018-02-27T17:32:34.534532", "hashes": {"md5": "49aec1877b65b6c15c26eff0c3900009"}, "size": 1, "metadata": {"acls": "None,test"}}, "user_metadata": {"acls": "None,test"}}, {"url": "some/test/location/2", "system_metadata": {"updated_date": "2018-02-27T17:32:34.534544", "baseid": "68e8d0a7-0c5d-48cc-8f8b-690b941d55e9", "form": "object", "did": "c9b4f486-40b4-40a9-8736-d0e3891c440f", "file_name": null, "rev": "fe63407f", "version": null, "urls": ["some/test/location", "some/test/location/2", "some/test/location/3", "some/test/location/4", "some/test/location/5", "some/test/location/6"], "created_date": "2018-02-27T17:32:34.534532", "hashes": {"md5": "49aec1877b65b6c15c26eff0c3900009"}, "size": 1, "metadata": {"acls": "None,test"}}, "user_metadata": {"acls": "None,test"}}, {"url": "some/test/location/3", "system_metadata": {"updated_date": "2018-02-27T17:32:34.534544", "baseid": "68e8d0a7-0c5d-48cc-8f8b-690b941d55e9", "form": "object", "did": "c9b4f486-40b4-40a9-8736-d0e3891c440f", "file_name": null, "rev": "fe63407f", "version": null, "urls": ["some/test/location", "some/test/location/2", "some/test/location/3", "some/test/location/4", "some/test/location/5", "some/test/location/6"], "created_date": "2018-02-27T17:32:34.534532", "hashes": {"md5": "49aec1877b65b6c15c26eff0c3900009"}, "size": 1, "metadata": {"acls": "None,test"}}, "user_metadata": {"acls": "None,test"}}, {"url": "some/test/location/4", "system_metadata": {"updated_date": "2018-02-27T17:32:34.534544", "baseid": "68e8d0a7-0c5d-48cc-8f8b-690b941d55e9", "form": "object", "did": "c9b4f486-40b4-40a9-8736-d0e3891c440f", "file_name": null, "rev": "fe63407f", "version": null, "urls": ["some/test/location", "some/test/location/2", "some/test/location/3", "some/test/location/4", "some/test/location/5", "some/test/location/6"], "created_date": "2018-02-27T17:32:34.534532", "hashes": {"md5": "49aec1877b65b6c15c26eff0c3900009"}, "size": 1, "metadata": {"acls": "None,test"}}, "user_metadata": {"acls": "None,test"}}, {"url": "some/test/location/5", "system_metadata": {"updated_date": "2018-02-27T17:32:34.534544", "baseid": "68e8d0a7-0c5d-48cc-8f8b-690b941d55e9", "form": "object", "did": "c9b4f486-40b4-40a9-8736-d0e3891c440f", "file_name": null, "rev": "fe63407f", "version": null, "urls": ["some/test/location", "some/test/location/2", "some/test/location/3", "some/test/location/4", "some/test/location/5", "some/test/location/6"], "created_date": "2018-02-27T17:32:34.534532", "hashes": {"md5": "49aec1877b65b6c15c26eff0c3900009"}, "size": 1, "metadata": {"acls": "None,test"}}, "user_metadata": {"acls": "None,test"}}, {"url": "some/test/location/6", "system_metadata": {"updated_date": "2018-02-27T17:32:34.534544", "baseid": "68e8d0a7-0c5d-48cc-8f8b-690b941d55e9", "form": "object", "did": "c9b4f486-40b4-40a9-8736-d0e3891c440f", "file_name": null, "rev": "fe63407f", "version": null, "urls": ["some/test/location", "some/test/location/2", "some/test/location/3", "some/test/location/4", "some/test/location/5", "some/test/location/6"], "created_date": "2018-02-27T17:32:34.534532", "hashes": {"md5": "49aec1877b65b6c15c26eff0c3900009"}, "size": 1, "metadata": {"acls": "None,test"}}, "user_metadata": {"acls": "None,test"}}], "checksums": [{"checksum": "49aec1877b65b6c15c26eff0c3900009", "type": "md5"}], "id": "c9b4f486-40b4-40a9-8736-d0e3891c440f", "size": 1}}';
+
+var noData = '{}';
+
+var badData = '{"somethingelse": {"oops": not good json"}';
+
+const mockRequest = (req) => {
+    req.method = "POST";
+    req.headers = {authorization: "bearer abc123"};
+    return req;
+};
+
+const mockResponse = () => {
+    return {
+        status(s) {
+            this.statusCode = s;
+            return this;
+        },
+        send: sinon.stub(),
+        setHeader: sinon.stub()
+    };
+};
+
+test.before(t => {
+    getRequest = sinon.stub(superagent, 'get');
+});
+
+test.after(t => {
+    getRequest.restore();
+});
+
+function mockThen(text_value) {
+    return (cb) => {
+        cb({text : text_value});
+        return {
+            catch: sinon.stub()
+        }
+    }
+}
+
+function mockResponseToGet(text_value) {
+    return {
+        then: mockThen(text_value),
+        set: () => {
+            return {
+                then: mockThen('{"foo": "bar"}')
+            }
+        }
+    }
+}
+
+test(`should return link that matches pattern param`, t => {
+    getRequest.returns(mockResponseToGet(withGS));
+    const res = mockResponse();
+    martha_v2(mockRequest({body: {"url" : "https://example.com/validGS", "pattern" : "gs://"}}), res);
+    t.is(res.statusCode, 200);
+    // t.deepEqual(res.send.lastCall.args[0], "gs://commons-dss-commons/blobs/64573c6a0c75993c16e313f819fa71b8571b86de75b7523ae8677a92172ea2ba.9976538e92c4f12aebfea277ecaef9fc5b54c732.594f5f1a316e9ccfb38d02a345c86597-293.41a4b033");
+});
+
+// test(`should return descriptive error when no link matching pattern is present`, t => {
+//     getRequest.returns(mockResponseToGet(withNoGS));
+//     const res = mockResponse();
+//     martha_v2(mockRequest({body: {"url" : "https://example.com/noGSlink", "pattern" : "gs://"}}), res);
+//     t.is(res.send.lastCall.args[0], "No gs:// link found");
+//     t.is(res.statusCode, 404);
+// });
+//
+// test(`should return no data found if returned data object is empty`, t => {
+//     getRequest.returns(mockResponseToGet(noData));
+//     const res = mockResponse();
+//     martha_v2(mockRequest({body: {"url" : "https://example.com/noData", "pattern" : "gs://"}}), res);
+//     t.is(res.send.lastCall.args[0], "No data received from https://example.com/noData");
+//     t.is(res.statusCode, 400);
+// });
+//
+// test(`should return error if data object is bad`, t => {
+//     getRequest.returns(mockResponseToGet(badData));
+//     const res = mockResponse();
+//     martha_v2(mockRequest({body: {"url" : "https://example.com/badData", "pattern" : "gs://"}}), res);
+//     t.is(res.send.lastCall.args[0], "Data returned not in correct format");
+//     t.is(res.statusCode, 400);
+// });
+//
+// test(`should return error if no pattern param given`, t => {
+//     getRequest.returns(mockResponseToGet(withGS));
+//     var res = mockResponse();
+//     martha_v2(mockRequest({body: {"url" : "https://example.com/noData"}}), res);
+//     t.is(res.send.lastCall.args[0], "No pattern param specified");
+//     t.is(res.statusCode, 400);
+// });

--- a/test/martha_v2.test.js
+++ b/test/martha_v2.test.js
@@ -7,10 +7,10 @@
  * https://github.com/avajs/ava/issues/1066
  */
 
-const test = require(`ava`);
-const sinon = require(`sinon`);
-const martha_v2 = require('../martha_v2').martha_v2_handler;
-const api_adapters = require('../api_adapter');
+const test = require("ava");
+const sinon = require("sinon");
+const martha_v2 = require("../martha_v2").martha_v2_handler;
+const apiAdapter = require("../api_adapter");
 
 const mockRequest = (req) => {
     req.method = "POST";
@@ -29,57 +29,57 @@ const mockResponse = () => {
     };
 };
 
-const dos_object = {fake: "A fake dos object"};
-const google_sa_key_object = {key: "A Google Service Account private key json object"};
+const dosObject = {fake: "A fake dos object"};
+const googleSAKeyObject = {key: "A Google Service Account private key json object"};
 
-let get_text_from_api_stub;
-let get_text_from_api_method_name = 'get_text_from';
+let getTextFromApiStub;
+let getTextFromApiMethodName = 'getTextFrom';
 let sandbox = sinon.createSandbox();
 
 test.serial.beforeEach(t => {
     sandbox.restore(); // If one test fails, the .afterEach() block will not execute, so always clean the slate here
-    get_text_from_api_stub = sandbox.stub(api_adapters, get_text_from_api_method_name);
-    get_text_from_api_stub.onFirstCall().resolves(JSON.stringify(dos_object));
-    get_text_from_api_stub.onSecondCall().resolves(JSON.stringify(google_sa_key_object));
+    getTextFromApiStub = sandbox.stub(apiAdapter, getTextFromApiMethodName);
+    getTextFromApiStub.onFirstCall().resolves(JSON.stringify(dosObject));
+    getTextFromApiStub.onSecondCall().resolves(JSON.stringify(googleSAKeyObject));
 });
 
 test.serial.afterEach(t => {
     sandbox.restore();
 });
 
-test.serial('martha_v2 resolves a valid url into a dos object and google service account key', async t => {
+test.serial("martha_v2 resolves a valid url into a dos object and google service account key", async t => {
     const response = mockResponse();
     await martha_v2(mockRequest({body: {"url" : "https://example.com/validGS"}}), response);
     const result = response.send.lastCall.args[0];
-    t.deepEqual(result.dos, dos_object);
-    t.deepEqual(result.googleServiceAccount, google_sa_key_object);
+    t.deepEqual(result.dos, dosObject);
+    t.deepEqual(result.googleServiceAccount, googleSAKeyObject);
     t.is(response.statusCode, 200);
 });
 
-test.serial('martha_v2 resolves successfully and ignores extra data submitted besides a "url"', async t => {
+test.serial("martha_v2 resolves successfully and ignores extra data submitted besides a 'url'", async t => {
     const response = mockResponse();
     await martha_v2(mockRequest({body: {url : "https://example.com/validGS", pattern: "gs://", foo: "bar"}}), response);
     const result = response.send.lastCall.args[0];
-    t.deepEqual(result.dos, dos_object);
-    t.deepEqual(result.googleServiceAccount, google_sa_key_object);
+    t.deepEqual(result.dos, dosObject);
+    t.deepEqual(result.googleServiceAccount, googleSAKeyObject);
     t.is(response.statusCode, 200);
 });
 
-test.serial('martha_v2 should return 400 if not given a url', async t => {
+test.serial("martha_v2 should return 400 if not given a url", async t => {
     const response = mockResponse();
     await martha_v2(mockRequest({body: {"uri" : "https://example.com/validGS"}}), response);
     t.is(response.statusCode, 400);
 });
 
-test.serial('martha_v2 should return 400 if given a "url" with an invalid value', async t => {
+test.serial("martha_v2 should return 400 if given a 'url' with an invalid value", async t => {
     const response = mockResponse();
     await martha_v2(mockRequest({body: {url : "Not a valid URI"}}), response);
     t.is(response.statusCode, 400);
 });
 
-test.serial('martha_v2 should return 502 if dos resolution fails', async t => {
-    get_text_from_api_stub.restore();
-    sandbox.stub(api_adapters, get_text_from_api_method_name).rejects(new Error("DOS Resolution forced to fail by testing stub"));
+test.serial("martha_v2 should return 502 if dos resolution fails", async t => {
+    getTextFromApiStub.restore();
+    sandbox.stub(apiAdapter, getTextFromApiMethodName).rejects(new Error("DOS Resolution forced to fail by testing stub"));
     const response = mockResponse();
     await martha_v2(mockRequest({body: {"url" : "https://example.com/validGS"}}), response);
     const result = response.send.lastCall.args[0];
@@ -87,9 +87,9 @@ test.serial('martha_v2 should return 502 if dos resolution fails', async t => {
     t.is(response.statusCode, 502);
 });
 
-test.serial('martha_v2 should return 502 if key retrieval from bond fails', async t => {
-    get_text_from_api_stub.restore();
-    sandbox.stub(api_adapters, get_text_from_api_method_name).rejects(new Error("Bond key lookup forced to fail by testing stub"));
+test.serial("martha_v2 should return 502 if key retrieval from bond fails", async t => {
+    getTextFromApiStub.restore();
+    sandbox.stub(apiAdapter, getTextFromApiMethodName).rejects(new Error("Bond key lookup forced to fail by testing stub"));
     const response = mockResponse();
     await martha_v2(mockRequest({body: {"url" : "https://example.com/validGS"}}), response);
     const result = response.send.lastCall.args[0];

--- a/test/martha_v2.test.js
+++ b/test/martha_v2.test.js
@@ -1,17 +1,14 @@
+/**
+ * When writing/testing GCF functions, see:
+ * - https://cloud.google.com/functions/docs/monitoring/error-reporting
+ * - https://cloud.google.com/functions/docs/bestpractices/testing
+ *
+ */
+
 const test = require(`ava`);
 const sinon = require(`sinon`);
 const martha_v2 = require('../martha_v2').martha_v2_handler;
-const superagent = require('superagent');
-
-var getRequest;
-
-var withGS = '{"data_object": {"checksums": [{"checksum": "64573c6a0c75993c16e313f819fa71b8571b86de75b7523ae8677a92172ea2ba", "type": "sha256"}, {"checksum": "594f5f1a316e9ccfb38d02a345c86597-293", "type": "etag"}, {"checksum": "9976538e92c4f12aebfea277ecaef9fc5b54c732", "type": "sha1"}, {"checksum": "41a4b033", "type": "crc32c"}], "version": "2018-01-31T142539.590521Z", "id": "ed703a5d-4705-49a8-9429-5169d9225bbd", "urls": [{"url": "https://commons-dss.ucsc-cgp-dev.org/v1/files/ed703a5d-4705-49a8-9429-5169d9225bbd?replica=aws"}, {"url": "https://commons-dss.ucsc-cgp-dev.org/v1/files/ed703a5d-4705-49a8-9429-5169d9225bbd?replica=azure"}, {"url": "https://commons-dss.ucsc-cgp-dev.org/v1/files/ed703a5d-4705-49a8-9429-5169d9225bbd?replica=gcp"}, {"url": "s3://commons-dss-commons/blobs/64573c6a0c75993c16e313f819fa71b8571b86de75b7523ae8677a92172ea2ba.9976538e92c4f12aebfea277ecaef9fc5b54c732.594f5f1a316e9ccfb38d02a345c86597-293.41a4b033"}, {"url": "gs://commons-dss-commons/blobs/64573c6a0c75993c16e313f819fa71b8571b86de75b7523ae8677a92172ea2ba.9976538e92c4f12aebfea277ecaef9fc5b54c732.594f5f1a316e9ccfb38d02a345c86597-293.41a4b033"}]}}';
-
-var withNoGS = '{"data_object": {"updated": "2018-02-27T17:32:34.534544", "name": null, "created": "2018-02-27T17:32:34.534532", "version": "fe63407f", "urls": [{"url": "some/test/location", "system_metadata": {"updated_date": "2018-02-27T17:32:34.534544", "baseid": "68e8d0a7-0c5d-48cc-8f8b-690b941d55e9", "form": "object", "did": "c9b4f486-40b4-40a9-8736-d0e3891c440f", "file_name": null, "rev": "fe63407f", "version": null, "urls": ["some/test/location", "some/test/location/2", "some/test/location/3", "some/test/location/4", "some/test/location/5", "some/test/location/6"], "created_date": "2018-02-27T17:32:34.534532", "hashes": {"md5": "49aec1877b65b6c15c26eff0c3900009"}, "size": 1, "metadata": {"acls": "None,test"}}, "user_metadata": {"acls": "None,test"}}, {"url": "some/test/location/2", "system_metadata": {"updated_date": "2018-02-27T17:32:34.534544", "baseid": "68e8d0a7-0c5d-48cc-8f8b-690b941d55e9", "form": "object", "did": "c9b4f486-40b4-40a9-8736-d0e3891c440f", "file_name": null, "rev": "fe63407f", "version": null, "urls": ["some/test/location", "some/test/location/2", "some/test/location/3", "some/test/location/4", "some/test/location/5", "some/test/location/6"], "created_date": "2018-02-27T17:32:34.534532", "hashes": {"md5": "49aec1877b65b6c15c26eff0c3900009"}, "size": 1, "metadata": {"acls": "None,test"}}, "user_metadata": {"acls": "None,test"}}, {"url": "some/test/location/3", "system_metadata": {"updated_date": "2018-02-27T17:32:34.534544", "baseid": "68e8d0a7-0c5d-48cc-8f8b-690b941d55e9", "form": "object", "did": "c9b4f486-40b4-40a9-8736-d0e3891c440f", "file_name": null, "rev": "fe63407f", "version": null, "urls": ["some/test/location", "some/test/location/2", "some/test/location/3", "some/test/location/4", "some/test/location/5", "some/test/location/6"], "created_date": "2018-02-27T17:32:34.534532", "hashes": {"md5": "49aec1877b65b6c15c26eff0c3900009"}, "size": 1, "metadata": {"acls": "None,test"}}, "user_metadata": {"acls": "None,test"}}, {"url": "some/test/location/4", "system_metadata": {"updated_date": "2018-02-27T17:32:34.534544", "baseid": "68e8d0a7-0c5d-48cc-8f8b-690b941d55e9", "form": "object", "did": "c9b4f486-40b4-40a9-8736-d0e3891c440f", "file_name": null, "rev": "fe63407f", "version": null, "urls": ["some/test/location", "some/test/location/2", "some/test/location/3", "some/test/location/4", "some/test/location/5", "some/test/location/6"], "created_date": "2018-02-27T17:32:34.534532", "hashes": {"md5": "49aec1877b65b6c15c26eff0c3900009"}, "size": 1, "metadata": {"acls": "None,test"}}, "user_metadata": {"acls": "None,test"}}, {"url": "some/test/location/5", "system_metadata": {"updated_date": "2018-02-27T17:32:34.534544", "baseid": "68e8d0a7-0c5d-48cc-8f8b-690b941d55e9", "form": "object", "did": "c9b4f486-40b4-40a9-8736-d0e3891c440f", "file_name": null, "rev": "fe63407f", "version": null, "urls": ["some/test/location", "some/test/location/2", "some/test/location/3", "some/test/location/4", "some/test/location/5", "some/test/location/6"], "created_date": "2018-02-27T17:32:34.534532", "hashes": {"md5": "49aec1877b65b6c15c26eff0c3900009"}, "size": 1, "metadata": {"acls": "None,test"}}, "user_metadata": {"acls": "None,test"}}, {"url": "some/test/location/6", "system_metadata": {"updated_date": "2018-02-27T17:32:34.534544", "baseid": "68e8d0a7-0c5d-48cc-8f8b-690b941d55e9", "form": "object", "did": "c9b4f486-40b4-40a9-8736-d0e3891c440f", "file_name": null, "rev": "fe63407f", "version": null, "urls": ["some/test/location", "some/test/location/2", "some/test/location/3", "some/test/location/4", "some/test/location/5", "some/test/location/6"], "created_date": "2018-02-27T17:32:34.534532", "hashes": {"md5": "49aec1877b65b6c15c26eff0c3900009"}, "size": 1, "metadata": {"acls": "None,test"}}, "user_metadata": {"acls": "None,test"}}], "checksums": [{"checksum": "49aec1877b65b6c15c26eff0c3900009", "type": "md5"}], "id": "c9b4f486-40b4-40a9-8736-d0e3891c440f", "size": 1}}';
-
-var noData = '{}';
-
-var badData = '{"somethingelse": {"oops": not good json"}';
+const api_adapters = require('../api_adapter');
 
 const mockRequest = (req) => {
     req.method = "POST";
@@ -30,70 +27,64 @@ const mockResponse = () => {
     };
 };
 
-test.before(t => {
-    getRequest = sinon.stub(superagent, 'get');
+const dos_object = {fake: "A fake dos object"};
+const google_sa_key_object = {key: "A Google Service Account private key json object"};
+
+const dos_method_name = 'resolve_dos';
+const bond_method_name = 'talk_to_bond';
+let dos_stub;
+let bond_stub;
+let sandbox = sinon.createSandbox();
+
+test.serial.beforeEach(t => {
+    dos_stub = sandbox.stub(api_adapters, dos_method_name).resolves(dos_object);
+    bond_stub = sandbox.stub(api_adapters, bond_method_name).resolves(google_sa_key_object);
 });
 
-test.after(t => {
-    getRequest.restore();
+test.serial.afterEach(t => {
+    sandbox.restore();
 });
 
-function mockThen(text_value) {
-    return (cb) => {
-        cb({text : text_value});
-        return {
-            catch: sinon.stub()
-        }
-    }
-}
-
-function mockResponseToGet(text_value) {
-    return {
-        then: mockThen(text_value),
-        set: () => {
-            return {
-                then: mockThen('{"foo": "bar"}')
-            }
-        }
-    }
-}
-
-test(`should return link that matches pattern param`, t => {
-    getRequest.returns(mockResponseToGet(withGS));
-    const res = mockResponse();
-    martha_v2(mockRequest({body: {"url" : "https://example.com/validGS", "pattern" : "gs://"}}), res);
-    t.is(res.statusCode, 200);
-    // t.deepEqual(res.send.lastCall.args[0], "gs://commons-dss-commons/blobs/64573c6a0c75993c16e313f819fa71b8571b86de75b7523ae8677a92172ea2ba.9976538e92c4f12aebfea277ecaef9fc5b54c732.594f5f1a316e9ccfb38d02a345c86597-293.41a4b033");
+test.serial('martha_v2 resolves a valid url into a dos object and google service account key', async t => {
+    const response = mockResponse();
+    await martha_v2(mockRequest({body: {"url" : "https://example.com/validGS"}}), response);
+    const result = response.send.lastCall.args[0];
+    t.is(result.dos, dos_object);
+    t.is(result.googleServiceAccount, google_sa_key_object);
+    t.is(response.statusCode, 200);
 });
 
-// test(`should return descriptive error when no link matching pattern is present`, t => {
-//     getRequest.returns(mockResponseToGet(withNoGS));
-//     const res = mockResponse();
-//     martha_v2(mockRequest({body: {"url" : "https://example.com/noGSlink", "pattern" : "gs://"}}), res);
-//     t.is(res.send.lastCall.args[0], "No gs:// link found");
-//     t.is(res.statusCode, 404);
-// });
-//
-// test(`should return no data found if returned data object is empty`, t => {
-//     getRequest.returns(mockResponseToGet(noData));
-//     const res = mockResponse();
-//     martha_v2(mockRequest({body: {"url" : "https://example.com/noData", "pattern" : "gs://"}}), res);
-//     t.is(res.send.lastCall.args[0], "No data received from https://example.com/noData");
-//     t.is(res.statusCode, 400);
-// });
-//
-// test(`should return error if data object is bad`, t => {
-//     getRequest.returns(mockResponseToGet(badData));
-//     const res = mockResponse();
-//     martha_v2(mockRequest({body: {"url" : "https://example.com/badData", "pattern" : "gs://"}}), res);
-//     t.is(res.send.lastCall.args[0], "Data returned not in correct format");
-//     t.is(res.statusCode, 400);
-// });
-//
-// test(`should return error if no pattern param given`, t => {
-//     getRequest.returns(mockResponseToGet(withGS));
-//     var res = mockResponse();
-//     martha_v2(mockRequest({body: {"url" : "https://example.com/noData"}}), res);
-//     t.is(res.send.lastCall.args[0], "No pattern param specified");
-//     t.is(res.statusCode, 400);
-// });
+test.serial('martha_v2 resolves successfully and ignores extra data submitted besides a "url"', async t => {
+    const response = mockResponse();
+    await martha_v2(mockRequest({body: {url : "https://example.com/validGS", pattern: "gs://", foo: "bar"}}), response);
+    const result = response.send.lastCall.args[0];
+    t.is(result.dos, dos_object);
+    t.is(result.googleServiceAccount, google_sa_key_object);
+    t.is(response.statusCode, 200);
+});
+
+test.serial('martha_v2 should return 400 if not given a url', async t => {
+    const response = mockResponse();
+    await martha_v2(mockRequest({body: {"uri" : "https://example.com/validGS"}}), response);
+    t.is(response.statusCode, 400);
+});
+
+test.serial('martha_v2 should return 502 if dos resolution fails', async t => {
+    dos_stub.restore();
+    sandbox.stub(api_adapters, dos_method_name).rejects(new Error("DOS Resolution forced to fail by testing stub"));
+    const response = mockResponse();
+    await martha_v2(mockRequest({body: {"url" : "https://example.com/validGS"}}), response);
+    const result = response.send.lastCall.args[0];
+    t.true(result instanceof Error);
+    t.is(response.statusCode, 502);
+});
+
+test.serial('martha_v2 should return 502 if key retrieval from bond fails', async t => {
+    bond_stub.restore();
+    sandbox.stub(api_adapters, bond_method_name).rejects(new Error("Bond key lookup forced to fail by testing stub"));
+    const response = mockResponse();
+    await martha_v2(mockRequest({body: {"url" : "https://example.com/validGS"}}), response);
+    const result = response.send.lastCall.args[0];
+    t.true(result instanceof Error);
+    t.is(response.statusCode, 502);
+});

--- a/test/smoketest_v1.test.js
+++ b/test/smoketest_v1.test.js
@@ -1,18 +1,19 @@
-// Run smoketests from the command line.  For example:
-//
-//    BASE_URL="https://us-central1-broad-dsde-dev.cloudfunctions.net" npm run-script smoketest_v1
-//
-// Run smoketests after a deployment to confirm that the functions deployed successfully
+/** Run smoketests from the command line.  For example:
+*
+*    BASE_URL="https://us-central1-broad-dsde-dev.cloudfunctions.net" npm run-script smoketest_v1
+*
+* Run smoketests after a deployment to confirm that the functions deployed successfully
+*/
 
-const test = require(`ava`);
-const Supertest = require(`supertest`);
+const test = require("ava");
+const Supertest = require("supertest");
 const supertest = Supertest(process.env.BASE_URL);
 
-test.cb(`smoketest_v1 return gs link`, t => {
+test.cb("smoketest_v1 return gs link", t => {
     console.log(`base url: ${process.env.BASE_URL}`);
     supertest
-        .post(`/martha_v1`)
-        .set('Content-Type', 'application/json')
+        .post("/martha_v1")
+        .set("Content-Type", "application/json")
         .send({"url" : "dos://broad-dsp-dos.storage.googleapis.com/dos.json", "pattern" : "gs://"})
         .expect((response) => {
             t.is(response.statusCode, 200);
@@ -21,10 +22,10 @@ test.cb(`smoketest_v1 return gs link`, t => {
         .end(t.end);
 });
 
-test.cb(`smoketest_v1 return error if url passed is not good`, t => {
+test.cb("smoketest_v1 return error if url passed is not good", t => {
     supertest
-        .post(`/martha_v1`)
-        .set('Content-Type', 'application/json')
+        .post("/martha_v1")
+        .set("Content-Type", "application/json")
         .send({"url" : "somethingNotValidURL"})
         .expect(response => {
             t.is(response.statusCode, 500);

--- a/test/smoketest_v1.test.js
+++ b/test/smoketest_v1.test.js
@@ -26,7 +26,7 @@ test.cb("smoketest_v1 return error if url passed is not good", (t) => {
         .post("/martha_v1")
         .set("Content-Type", "application/json")
         .send({"url" : "somethingNotValidURL"})
-        .expect(response => {
+        .expect((response) => {
             t.is(response.statusCode, 500);
         })
         .end(t.end);

--- a/test/smoketest_v1.test.js
+++ b/test/smoketest_v1.test.js
@@ -8,7 +8,7 @@
 const test = require("ava");
 const supertest = require("supertest")(process.env.BASE_URL);
 
-test.cb("smoketest_v1 return gs link", t => {
+test.cb("smoketest_v1 return gs link", (t) => {
     console.log(`base url: ${process.env.BASE_URL}`);
     supertest
         .post("/martha_v1")
@@ -21,7 +21,7 @@ test.cb("smoketest_v1 return gs link", t => {
         .end(t.end);
 });
 
-test.cb("smoketest_v1 return error if url passed is not good", t => {
+test.cb("smoketest_v1 return error if url passed is not good", (t) => {
     supertest
         .post("/martha_v1")
         .set("Content-Type", "application/json")

--- a/test/smoketest_v1.test.js
+++ b/test/smoketest_v1.test.js
@@ -1,0 +1,34 @@
+// Run smoketests from the command line.  For example:
+//
+//    BASE_URL="https://us-central1-broad-dsde-dev.cloudfunctions.net" npm run-script smoketest_v1
+//
+// Run smoketests after a deployment to confirm that the functions deployed successfully
+
+const test = require(`ava`);
+const Supertest = require(`supertest`);
+const supertest = Supertest(process.env.BASE_URL);
+
+test.cb(`smoketest_v1 return gs link`, t => {
+    console.log(`base url: ${process.env.BASE_URL}`);
+    supertest
+        .post(`/martha_v1`)
+        .set('Content-Type', 'application/json')
+        .send({"url" : "dos://broad-dsp-dos.storage.googleapis.com/dos.json", "pattern" : "gs://"})
+        .expect((response) => {
+            t.is(response.statusCode, 200);
+            t.deepEqual(response.text, "gs://broad-public-datasets/NA12878_downsampled_for_testing/unmapped/H06JUADXX130110.1.ATCACGAT.20k_reads.bam");
+        })
+        .end(t.end);
+});
+
+test.cb(`smoketest_v1 return error if url passed is not good`, t => {
+    supertest
+        .post(`/martha_v1`)
+        .set('Content-Type', 'application/json')
+        .send({"url" : "somethingNotValidURL"})
+        .expect(response => {
+            t.is(response.statusCode, 500);
+        })
+        .end(t.end);
+
+});

--- a/test/smoketest_v1.test.js
+++ b/test/smoketest_v1.test.js
@@ -6,8 +6,7 @@
 */
 
 const test = require("ava");
-const Supertest = require("supertest");
-const supertest = Supertest(process.env.BASE_URL);
+const supertest = require("supertest")(process.env.BASE_URL);
 
 test.cb("smoketest_v1 return gs link", t => {
     console.log(`base url: ${process.env.BASE_URL}`);

--- a/test/smoketest_v2.test.js
+++ b/test/smoketest_v2.test.js
@@ -1,0 +1,70 @@
+/** Run smoketests from the command line.  For example:
+*
+*    BASE_URL="https://us-central1-broad-dsde-dev.cloudfunctions.net" npm run-script smoketest_v2
+*
+* Run smoketests after a deployment to confirm that the functions deployed successfully
+*/
+
+const test = require("ava");
+const supertest = require("supertest")(process.env.BASE_URL);
+const execSync = require("child_process").execSync;
+
+// console.log(output);
+
+// function execute(command, callback){
+//     exec(command, function(error, stdout, stderr){ callback(stdout); });
+// }
+//
+// let output;
+// execute("uptime", ()
+
+// test.cb("smoketest_v2 return gs link", (t) => {
+//     console.log(`base url: ${process.env.BASE_URL}`);
+//     supertest
+//         .post("/martha_v2")
+//         .set("Content-Type", "application/json")
+//         .send({"url" : "dos://broad-dsp-dos.storage.googleapis.com/dos.json", "pattern" : "gs://"})
+//         .expect((response) => {
+//             t.is(response.statusCode, 200);
+//             t.deepEqual(response.text, "gs://broad-public-datasets/NA12878_downsampled_for_testing/unmapped/H06JUADXX130110.1.ATCACGAT.20k_reads.bam");
+//         })
+//         .end(t.end);
+// });
+
+test.cb("smoketest_v2 return error if url passed is malformed", (t) => {
+    supertest
+        .post("/martha_v2")
+        .set("Content-Type", "application/json")
+        .send({"url" : "somethingNotValidURL"})
+        .expect(400)
+        .end(t.end);
+});
+
+test.cb("smoketest_v2 return error if url passed is not good", (t) => {
+    supertest
+        .post("/martha_v2")
+        .set("Content-Type", "application/json")
+        .send({"url" : "dos://broad-dsp-dos-TYPO.storage.googleapis.com/dos.json"})
+        .expect(502)
+        .end(t.end);
+});
+
+// TODO: This test cannot pass until Fence to enables Google Endpoints on their end so that when we call Bond, we can get an actual key
+test.cb.failing("smoketest_v2 do thing", (t) => {
+    // TODO: Authorize Bond to access Fence data on behalf of the user running this script
+    // These smoketests can be run by anyone, but are intended to be part of the deployment process.  Therefore, the
+    // user/SA that is running that script needs to have authorized Bond with Fence in order for this test to pass.
+    let bearerToken = String(execSync("gcloud auth print-access-token")).trim();
+    supertest
+        .post("/martha_v2")
+        .set("Content-Type", "application/json")
+        .set("authorization", `bearer ${bearerToken}`)
+        .send({"url": "dos://broad-dsp-dos.storage.googleapis.com/dos.json"})
+        .expect(200)
+        .expect((response) => {
+            const results = JSON.parse(response.text);
+            t.truthy(results.dos);
+            t.truthy(results.googleServiceAccount);
+        })
+        .end(t.end);
+});


### PR DESCRIPTION
I split up the martha_v1 and martha_v2 methods into their own modules.  I did some minor refactoring to martha_v1 and significant refactoring to martha_v2 to make it testable.  Having everything wrapped up in one method along with nested superagent calls was a nightmare to mock/stub and test to the point where I couldn't even figure out how to write the tests.