### PR TITLE
Forgot to update the dos resolution url in the config.json.ctmpl

### DIFF
--- a/config.json.ctmpl
+++ b/config.json.ctmpl
@@ -1,5 +1,5 @@
 {
-    "dosResolutionHost": {{if eq (env "ENVIRONMENT") "prod"}}"dcp.bionimbus.org"{{else}}"dcp.bionimbus.org"{{end}},
+    "dosResolutionHost": "dataguids.org",
     "bondBaseUrl": {{if eq (env "ENVIRONMENT") "prod"}}"broad-bond-prod.appspot.com"{{else if eq (env "ENVIRONMENT") "staging"}}"broad-bond-staging.appspot.com"{{else if eq (env "ENVIRONMENT") "alpha"}}"broad-bond-staging.appspot.com"{{else}}"broad-bond-dev.appspot.com"{{end}},
     "samBaseUrl": {{if eq (env "ENVIRONMENT") "prod"}}"https://sam.dsde-prod.broadinstitute.org"{{else if eq (env "ENVIRONMENT") "staging"}}"https://sam.dsde-staging.broadinstitute.org"{{else if eq (env "ENVIRONMENT") "alpha"}}"https://sam.dsde-alpha.broadinstitute.org"{{else}}"https://sam.dsde-dev.broadinstitute.org"{{end}}
 }


### PR DESCRIPTION
I had previously only updated `config.json` and forgot to update `config.json.ctmpl`.  Part of me is questioning whether `config.json` should be committed at all or if it should be git ignored.  For now, it's there and it's not hurting anything, but we should consider removing it.