### PR TITLE
Fixing broken deploy.sh script

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -37,12 +37,16 @@ docker run --rm -v $PWD:${MARTHA_PATH} \
   -e VAULT_TOKEN=${VAULT_TOKEN} \
   broadinstitute/dsde-toolbox render-templates.sh
 
+# TODO: Do not use the martha docker image for deployments, use https://hub.docker.com/r/google/cloud-sdk/ instead
 # Build the Docker image that we can use to deploy Martha
 docker build -f docker/Dockerfile -t broadinstitute/martha:deploy .
 
-docker run --rm -v $PWD:${MARTHA_PATH} \
+# Overriding ENTRYPOINT has some subtleties: https://medium.com/@oprearocks/how-to-properly-override-the-entrypoint-using-docker-run-2e081e5feb9d
+docker run --rm \
+    --entrypoint="/bin/bash" \
+    -v $PWD:${MARTHA_PATH} \
     -e BASE_URL="https://us-central1-broad-dsde-${ENVIRONMENT}.cloudfunctions.net" \
-    broadinstitute/martha:deploy /bin/bash -c \
+    broadinstitute/martha:deploy -c \
     "gcloud config set project ${PROJECT_NAME} &&
      gcloud auth activate-service-account --key-file ${MARTHA_PATH}/${SERVICE_ACCT_KEY_FILE} &&
      cd ${MARTHA_PATH} &&

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -48,4 +48,5 @@ RUN functions start \
     && functions deploy fileSummaryV1 --trigger-http \
     && functions stop
 
-ENTRYPOINT ["functions", "start", "--tail=true"]
+ENTRYPOINT ["functions"]
+CMD ["start", "--tail=true"]


### PR DESCRIPTION
Martha deployments were broken from `deploy.sh` due to the `ENTRYPOINT` used by the martha Dockerfile.  What really should change is the container we use in `deploy.sh` to perform the `gcloud beta functions deploy` steps, which should be done from a `google/cloud-sdk` image