### PR TITLE
use common path for cloud function deploy account, not martha-specific path [risk: low]

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -25,7 +25,7 @@ PROJECT_NAME="broad-dsde-${ENVIRONMENT}"
 SERVICE_ACCT_KEY_FILE="deploy_account.json"
 # Get the tier specific credentials for the service account out of Vault
 # Put key into SERVICE_ACCT_KEY_FILE
-docker run --rm -e VAULT_TOKEN=${VAULT_TOKEN} broadinstitute/dsde-toolbox vault read --format=json "secret/dsde/martha/${ENVIRONMENT}/deploy-account.json" | jq .data > ${SERVICE_ACCT_KEY_FILE}
+docker run --rm -e VAULT_TOKEN=${VAULT_TOKEN} broadinstitute/dsde-toolbox vault read --format=json "secret/dsde/firecloud/${ENVIRONMENT}/common/cloud-function-deploy-account.json" | jq .data > ${SERVICE_ACCT_KEY_FILE}
 
 MARTHA_PATH=/martha
 # Process all Consul .ctmpl files


### PR DESCRIPTION
As of broadinstitute/workbench-tos#9, I copied the secrets at 
```
secret/dsde/martha/${ENVIRONMENT}/deploy-account.json
```
to
```
secret/dsde/firecloud/${ENVIRONMENT}/common/cloud-function-deploy-account.json
```
so they can be shared by any script needing to deploy a Cloud Function.

FYI, I also populated a secret into the `perf` path in Vault, so perf deploys should work now too (they work for workbench-tos; I assume they'd work for Martha).

This PR updates Martha's deploy script to read from the common path. Once this gets merged to all of Martha's branches, we could/should delete the martha-specific Vault paths, unless you know of anything else using them.