### PR TITLE
Revert "use common path for cloud function deploy account, not martha-specific path [risk: low]"

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -25,7 +25,7 @@ PROJECT_NAME="broad-dsde-${ENVIRONMENT}"
 SERVICE_ACCT_KEY_FILE="deploy_account.json"
 # Get the tier specific credentials for the service account out of Vault
 # Put key into SERVICE_ACCT_KEY_FILE
-docker run --rm -e VAULT_TOKEN=${VAULT_TOKEN} broadinstitute/dsde-toolbox vault read --format=json "secret/dsde/firecloud/${ENVIRONMENT}/common/cloud-function-deploy-account.json" | jq .data > ${SERVICE_ACCT_KEY_FILE}
+docker run --rm -e VAULT_TOKEN=${VAULT_TOKEN} broadinstitute/dsde-toolbox vault read --format=json "secret/dsde/martha/${ENVIRONMENT}/deploy-account.json" | jq .data > ${SERVICE_ACCT_KEY_FILE}
 
 MARTHA_PATH=/martha
 # Process all Consul .ctmpl files


### PR DESCRIPTION
Reverts broadinstitute/martha#106.

In discussion with devops, we would prefer to 1) deploy each Cloud Function to a dedicated Google project, and 2) use dedicated SAs to deploy to each individual Google project. Thus, I'm reverting this PR, and once this PR merges I will remove the SA credentials from the common location in Vault.
