### PR TITLE
Default DRS Resolution Host

### DIFF
--- a/config.json.ctmpl
+++ b/config.json.ctmpl
@@ -3,7 +3,7 @@
 {{with $dnsDomain := env "DNS_DOMAIN"}}
 
 {
-    "dosResolutionHost": {{if eq $environment "prod"}}"dataguids.org"{{else if eq $environment "staging"}}"dataguids.org"{{else}}"broad-dsp-dos.storage.googleapis.com"{{end}},
+    "dosResolutionHost": {{if eq $environment "prod"}}"dataguids.org"{{else if eq $environment "staging"}}"dataguids.org"{{else}}"wb-mock-drs-dev.storage.googleapis.com"{{end}},
     "bondBaseUrl": {{if eq $runContext "fiab"}}"bond-fiab.{{$dnsDomain}}"{{else}}"broad-bond-{{$environment}}.appspot.com"{{end}},
     "samBaseUrl": {{if eq $runContext "fiab"}}"https://sam-fiab.{{$dnsDomain}}"{{else}}"https://sam.dsde-{{$environment}}.broadinstitute.org"{{end}}
 }


### PR DESCRIPTION
Martha should default to using the mock DRS resolution host, which is a google bucket