### PR TITLE
Mock resolver for FiaBs and dev

### DIFF
--- a/config.json.ctmpl
+++ b/config.json.ctmpl
@@ -3,7 +3,7 @@
 {{with $dnsDomain := env "DNS_DOMAIN"}}
 
 {
-    "dosResolutionHost": {{if eq $environment "prod"}}"dataguids.org"{{else if eq $environment "staging"}}"dataguids.org"{{else}}"wb-mock-drs-dev.storage.googleapis.com"{{end}},
+    "dosResolutionHost": {{if or (eq $runContext "fiab") (eq $environment "dev")}}"wb-mock-drs-dev.storage.googleapis.com"{{else}}"dataguids.org"{{end}},
     "bondBaseUrl": {{if eq $runContext "fiab"}}"bond-fiab.{{$dnsDomain}}"{{else}}"broad-bond-{{$environment}}.appspot.com"{{end}},
     "samBaseUrl": {{if eq $runContext "fiab"}}"https://sam-fiab.{{$dnsDomain}}"{{else}}"https://sam.dsde-{{$environment}}.broadinstitute.org"{{end}}
 }


### PR DESCRIPTION
In Bond, we want to use the mock-provider on FiaBs and the dev tier only.  In order for Martha to work properly in getting SA keys to access protected files, we need Martha's config to match Bond, because the mock-provider in Bond is the only way to grant access to resources protected by the mock-drs