### PR TITLE
Use "npm ci" instead of "npm install" and update to Node 8.15

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - checkout
       - run:
-          command: npm install
+          command: npm ci
       - run:
           command: npm test
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ version: 2
 jobs:
   test:
     docker:
-      - image: circleci/node:8.11
+      - image: circleci/node:8.15
 
     working_directory: ~/repo
 
@@ -36,7 +36,7 @@ jobs:
 
   build-image:
     docker:
-      - image: circleci/node:8.11
+      - image: circleci/node:8.15
 
     environment:
       IMAGE_NAME: quay.io/broadinstitute/martha

--- a/deploy.sh
+++ b/deploy.sh
@@ -69,5 +69,5 @@ docker run --rm \
      gcloud beta functions deploy martha_v1 --source=. --trigger-http --runtime nodejs8 &&
      gcloud beta functions deploy martha_v2 --source=. --trigger-http --runtime nodejs8 &&
      gcloud beta functions deploy fileSummaryV1 --source=. --runtime nodejs8 --trigger-http &&
-     npm install &&
+     npm ci &&
      npm run-script smoketest"

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -24,8 +24,9 @@ WORKDIR /martha
 # Install GCF Emulator and project dependencies
 # Do this prior to copying over source files to take advantage of Docker layer caching of npm dependencies
 COPY package.json package.json
+COPY package-lock.json package-lock.json
 RUN npm install -g @google-cloud/functions-emulator \
-    && npm install
+    && npm ci
 
 # Copy Martha source code into image AFTER installing dependencies
 COPY . .

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:8.11
+FROM node:8.15
 
 ## Prepare the image
 ENV DEBIAN_FRONTEND noninteractive


### PR DESCRIPTION
Due to the way `npm` works, if you run `npm install` it will just read your `package.json` and install the latest valid packages that satisfy your version requirements.  This is not what we want.  Instead, we should almost always be installing packages based on `package-lock.json` whenever we run CI or deploy.  This will ensure that the exact same versions of all packages are deployed every time we run `npm ci`.  

In order to do this, I also needed to bump the node version for the base Docker image we use on CircleCI and for building our docker image for Martha.  This was a good thing because Google Cloud Functions currently run Node 8.15 anyway:  https://cloud.google.com/functions/docs/concepts/nodejs-8-runtime