### PR TITLE
AP-144  DRS URIs can have "drs://" or "dos://" scheme/protocol

### DIFF
--- a/common/helpers.js
+++ b/common/helpers.js
@@ -38,4 +38,4 @@ function determineBondProvider(urlString) {
 const bondBaseUrl = () => config.bondBaseUrl;
 const samBaseUrl = () => config.samBaseUrl;
 
-module.exports = {dataObjectUrlToHttps: dataObjectUrlToHttps, bondBaseUrl, samBaseUrl, BondProviders, determineBondProvider};
+module.exports = {dataObjectUrlToHttps, bondBaseUrl, samBaseUrl, BondProviders, determineBondProvider};

--- a/common/helpers.js
+++ b/common/helpers.js
@@ -2,20 +2,19 @@ const url = require('url');
 const config = require('../config.json');
 const URL = require('url');
 
-function drsToHttps(drsUri) {
-    const parsedUrl = url.parse(drsUri);
+function dataObjectUrlToHttps(dataObjectUrl) {
+    const parsedUrl = url.parse(dataObjectUrl);
 
     if (!parsedUrl.protocol || !parsedUrl.host || !parsedUrl.pathname) {
-        throw new Error(`Invalid URL: "${drsUri}"`);
+        throw new Error(`Invalid URL: "${dataObjectUrl}"`);
     }
 
     parsedUrl.protocol = 'https';
-    parsedUrl.host = config.drsResolutionHost;
-    // NOTE: dataguids.org currently still uses "dos" in their path as shown below.  Don't be surprised if this changes to "drs" at some point
+    parsedUrl.host = config.dataObjectResolutionHost;
     parsedUrl.pathname = `/ga4gh/dos/v1/dataobjects${parsedUrl.pathname}`;
 
     const output = url.format(parsedUrl);
-    console.log(`${drsUri} -> ${output}`);
+    console.log(`${dataObjectUrl} -> ${output}`);
     return output;
 }
 
@@ -39,4 +38,4 @@ function determineBondProvider(urlString) {
 const bondBaseUrl = () => config.bondBaseUrl;
 const samBaseUrl = () => config.samBaseUrl;
 
-module.exports = {drsToHttps, bondBaseUrl, samBaseUrl, BondProviders, determineBondProvider};
+module.exports = {dataObjectUrlToHttps: dataObjectUrlToHttps, bondBaseUrl, samBaseUrl, BondProviders, determineBondProvider};

--- a/common/helpers.js
+++ b/common/helpers.js
@@ -2,19 +2,20 @@ const url = require('url');
 const config = require('../config.json');
 const URL = require('url');
 
-function dosToHttps(dosUri) {
-    const parsedUrl = url.parse(dosUri);
+function drsToHttps(drsUri) {
+    const parsedUrl = url.parse(drsUri);
 
     if (!parsedUrl.protocol || !parsedUrl.host || !parsedUrl.pathname) {
-        throw new Error(`Invalid URL: "${dosUri}"`);
+        throw new Error(`Invalid URL: "${drsUri}"`);
     }
 
     parsedUrl.protocol = 'https';
-    parsedUrl.host = config.dosResolutionHost;
+    parsedUrl.host = config.drsResolutionHost;
+    // NOTE: dataguids.org currently still uses "dos" in their path as shown below.  Don't be surprised if this changes to "drs" at some point
     parsedUrl.pathname = `/ga4gh/dos/v1/dataobjects${parsedUrl.pathname}`;
 
     const output = url.format(parsedUrl);
-    console.log(`${dosUri} -> ${output}`);
+    console.log(`${drsUri} -> ${output}`);
     return output;
 }
 
@@ -38,4 +39,4 @@ function determineBondProvider(urlString) {
 const bondBaseUrl = () => config.bondBaseUrl;
 const samBaseUrl = () => config.samBaseUrl;
 
-module.exports = {dosToHttps, bondBaseUrl, samBaseUrl, BondProviders, determineBondProvider};
+module.exports = {drsToHttps, bondBaseUrl, samBaseUrl, BondProviders, determineBondProvider};

--- a/config.json
+++ b/config.json
@@ -3,7 +3,7 @@
 
 
 {
-    "drsResolutionHost": "dataguids.org",
+    "dataObjectResolutionHost": "dataguids.org",
     "bondBaseUrl": "broad-bond-dev.appspot.com",
     "samBaseUrl": "https://sam.dsde-dev.broadinstitute.org"
 }

--- a/config.json
+++ b/config.json
@@ -3,7 +3,7 @@
 
 
 {
-    "dosResolutionHost": "dataguids.org",
+    "drsResolutionHost": "dataguids.org",
     "bondBaseUrl": "broad-bond-dev.appspot.com",
     "samBaseUrl": "https://sam.dsde-dev.broadinstitute.org"
 }

--- a/config.json.ctmpl
+++ b/config.json.ctmpl
@@ -3,7 +3,7 @@
 {{with $dnsDomain := env "DNS_DOMAIN"}}
 
 {
-    "drsResolutionHost": {{if or (eq $runContext "fiab") (eq $environment "dev")}}"wb-mock-drs-dev.storage.googleapis.com"{{else}}"dataguids.org"{{end}},
+    "dataObjectResolutionHost": {{if or (eq $runContext "fiab") (eq $environment "dev")}}"wb-mock-drs-dev.storage.googleapis.com"{{else}}"dataguids.org"{{end}},
     "bondBaseUrl": {{if eq $runContext "fiab"}}"bond-fiab.{{$dnsDomain}}"{{else}}"broad-bond-{{$environment}}.appspot.com"{{end}},
     "samBaseUrl": {{if eq $runContext "fiab"}}"https://sam-fiab.{{$dnsDomain}}"{{else}}"https://sam.dsde-{{$environment}}.broadinstitute.org"{{end}}
 }

--- a/config.json.ctmpl
+++ b/config.json.ctmpl
@@ -3,7 +3,7 @@
 {{with $dnsDomain := env "DNS_DOMAIN"}}
 
 {
-    "dosResolutionHost": {{if or (eq $runContext "fiab") (eq $environment "dev")}}"wb-mock-drs-dev.storage.googleapis.com"{{else}}"dataguids.org"{{end}},
+    "drsResolutionHost": {{if or (eq $runContext "fiab") (eq $environment "dev")}}"wb-mock-drs-dev.storage.googleapis.com"{{else}}"dataguids.org"{{end}},
     "bondBaseUrl": {{if eq $runContext "fiab"}}"bond-fiab.{{$dnsDomain}}"{{else}}"broad-bond-{{$environment}}.appspot.com"{{end}},
     "samBaseUrl": {{if eq $runContext "fiab"}}"https://sam-fiab.{{$dnsDomain}}"{{else}}"https://sam.dsde-{{$environment}}.broadinstitute.org"{{end}}
 }

--- a/fileSummaryV1/fileSummaryV1.js
+++ b/fileSummaryV1/fileSummaryV1.js
@@ -6,17 +6,21 @@ const url = require('url');
 // This function counts on the request posing data as "application/json" content-type.
 // See: https://cloud.google.com/functions/docs/writing/http#parsing_http_requests for more details
 
+const drsProtocols = ['dos:', 'drs:'];
+const gsProtocols = ['gs:'];
+
 function isValidProtocol(urlString) {
+    const validProtocols = drsProtocols.concat(gsProtocols);
     try {
-        return ['gs:', 'dos:'].indexOf(url.parse(urlString).protocol) >= 0;
+        return validProtocols.includes(url.parse(urlString).protocol);
     } catch (e) {
-        console.error(new Error(`URI must use 'gs:' or 'dos:' protocols: ${urlString}`));
+        console.error(new Error(`URI protocols must be one of [${validProtocols.join(', ')}]: ${urlString}`));
         return false;
     }
 }
 
 /**
- * Takes a uri for a DOS object or a GS object along with an authorization header.  This method will gather and return
+ * Takes a uri for a DRS object or a GS object along with an authorization header.  This method will gather and return
  * metadata for the object and will attempt to use the bearer token to generate a signed url
  * (https://cloud.google.com/storage/docs/access-control/signed-urls) that will grant access to the object.
  * @param req
@@ -28,7 +32,7 @@ async function fileSummaryV1Handler(req, res) {
 
     if (!origUrl || !isValidProtocol(origUrl)) {
         console.error(new Error('Uri is missing or invalid'));
-        res.status(400).send('Request must specify the URI of a DOS or GS object');
+        res.status(400).send('Request must specify the URI of a DRS or GS object');
         return;
     } else if (!auth) {
         console.error(new Error('Request did not not specify an authorization header'));
@@ -38,12 +42,12 @@ async function fileSummaryV1Handler(req, res) {
 
     console.log('Input: ', origUrl);
 
-    const isDos = origUrl.startsWith('dos://');
+    const isDrs = drsProtocols.includes(url.parse(origUrl).protocol);
     try {
 
         const [serviceAccountKey, metadata] = await Promise.all([
-            saKeys.getServiceAccountKey(origUrl, auth, isDos),
-            metadataApi.getMetadata(origUrl, auth, isDos)
+            saKeys.getServiceAccountKey(origUrl, auth, isDrs),
+            metadataApi.getMetadata(origUrl, auth, isDrs)
         ]);
 
         if (serviceAccountKey) {

--- a/fileSummaryV1/metadata_api.js
+++ b/fileSummaryV1/metadata_api.js
@@ -56,18 +56,18 @@ function getGsObjectMetadata(gsUri, auth) {
         });
 }
 
-function getGsUriFromDos(dosMetadata) {
-    return dosMetadata.urls.find((e) => e.url.startsWith('gs://')).url;
+function getGsUriFromDrs(drsMetadata) {
+    return drsMetadata.urls.find((e) => e.url.startsWith('gs://')).url;
 }
 
-function getDosObjectMetadata(dosUri) {
-    const newUri = helpers.dosToHttps(dosUri);
+function getDrsObjectMetadata(drsUri) {
+    const newUri = helpers.drsToHttps(drsUri);
 
     return apiAdapter.getJsonFrom(newUri)
         .then((response) => response.data_object)
         .then((metadata) => {
             const { mime_type, size, created, updated, checksums } = metadata;
-            const gsUri = getGsUriFromDos(metadata);
+            const gsUri = getGsUriFromDrs(metadata);
             const [bucket, name] = parseGsUri(gsUri);
 
             return {
@@ -82,14 +82,14 @@ function getDosObjectMetadata(dosUri) {
             };
         })
         .catch((e) => {
-            console.error(new Error(`Failed to get metadata for: ${dosUri} -> ${newUri}`));
+            console.error(new Error(`Failed to get metadata for: ${drsUri} -> ${newUri}`));
             throw e;
         });
 }
 
-async function getMetadata(url, auth, isDos) {
+async function getMetadata(url, auth, isDrs) {
     try {
-        return isDos ? getDosObjectMetadata(url) : getGsObjectMetadata(url, auth);
+        return isDrs ? getDrsObjectMetadata(url) : getGsObjectMetadata(url, auth);
     } catch (e) {
         console.error(new Error('Metadata problems:'), e);
     }

--- a/fileSummaryV1/metadata_api.js
+++ b/fileSummaryV1/metadata_api.js
@@ -56,18 +56,18 @@ function getGsObjectMetadata(gsUri, auth) {
         });
 }
 
-function getGsUriFromDrs(drsMetadata) {
-    return drsMetadata.urls.find((e) => e.url.startsWith('gs://')).url;
+function getGsUriFromDataObject(dataObjectMetadata) {
+    return dataObjectMetadata.urls.find((e) => e.url.startsWith('gs://')).url;
 }
 
-function getDrsObjectMetadata(drsUri) {
-    const newUri = helpers.drsToHttps(drsUri);
+function getDataObjectMetadata(dataObjectUri) {
+    const newUri = helpers.dataObjectUrlToHttps(dataObjectUri);
 
     return apiAdapter.getJsonFrom(newUri)
         .then((response) => response.data_object)
         .then((metadata) => {
             const { mime_type, size, created, updated, checksums } = metadata;
-            const gsUri = getGsUriFromDrs(metadata);
+            const gsUri = getGsUriFromDataObject(metadata);
             const [bucket, name] = parseGsUri(gsUri);
 
             return {
@@ -82,14 +82,14 @@ function getDrsObjectMetadata(drsUri) {
             };
         })
         .catch((e) => {
-            console.error(new Error(`Failed to get metadata for: ${drsUri} -> ${newUri}`));
+            console.error(new Error(`Failed to get metadata for: ${dataObjectUri} -> ${newUri}`));
             throw e;
         });
 }
 
-async function getMetadata(url, auth, isDrs) {
+async function getMetadata(url, auth, isDataObjectUrl) {
     try {
-        return isDrs ? getDrsObjectMetadata(url) : getGsObjectMetadata(url, auth);
+        return isDataObjectUrl ? getDataObjectMetadata(url) : getGsObjectMetadata(url, auth);
     } catch (e) {
         console.error(new Error('Metadata problems:'), e);
     }

--- a/fileSummaryV1/service_account_keys.js
+++ b/fileSummaryV1/service_account_keys.js
@@ -24,8 +24,8 @@ function maybeTalkToSam(auth) {
     });
 }
 
-function getServiceAccountKey(url, auth, isDos) {
-    if (isDos) {
+function getServiceAccountKey(url, auth, isDrs) {
+    if (isDrs) {
         return maybeTalkToBond(auth, url);
     } else {
         return maybeTalkToSam(auth);

--- a/fileSummaryV1/service_account_keys.js
+++ b/fileSummaryV1/service_account_keys.js
@@ -24,8 +24,8 @@ function maybeTalkToSam(auth) {
     });
 }
 
-function getServiceAccountKey(url, auth, isDrs) {
-    if (isDrs) {
+function getServiceAccountKey(url, auth, isDataObject) {
+    if (isDataObject) {
         return maybeTalkToBond(auth, url);
     } else {
         return maybeTalkToSam(auth);

--- a/martha_v1/helpers.js
+++ b/martha_v1/helpers.js
@@ -1,14 +1,15 @@
 const url = require('url');
 const config = require('../config.json');
 
-function dosToHttps(dosUri) {
-    const parsedUrl = url.parse(dosUri);
+function drsToHttps(drsUri) {
+    const parsedUrl = url.parse(drsUri);
 
     parsedUrl.protocol = 'https';
 
+    // Note: The use of "dos" in the pathname might change to "drs" at some point and break things, so be on the lookout
     if (parsedUrl.host.startsWith('dg.')) {
         parsedUrl.pathname = `/ga4gh/dos/v1/dataobjects/${parsedUrl.hostname}${parsedUrl.pathname}`;
-        parsedUrl.host = config.dosResolutionHost;
+        parsedUrl.host = config.drsResolutionHost;
     } else {
         parsedUrl.pathname = `/ga4gh/dos/v1/dataobjects${parsedUrl.pathname}`;
     }
@@ -23,6 +24,6 @@ const bondBaseUrl = () => config.bondBaseUrl;
 const samBaseUrl = () => config.samBaseUrl;
 
 
-exports.dosToHttps = dosToHttps;
+exports.drsToHttps = drsToHttps;
 exports.bondBaseUrl = bondBaseUrl;
 exports.samBaseUrl = samBaseUrl;

--- a/martha_v1/helpers.js
+++ b/martha_v1/helpers.js
@@ -1,15 +1,15 @@
 const url = require('url');
 const config = require('../config.json');
 
-function drsToHttps(drsUri) {
-    const parsedUrl = url.parse(drsUri);
+function dataObjectUrlToHttps(dataObjectUri) {
+    const parsedUrl = url.parse(dataObjectUri);
 
     parsedUrl.protocol = 'https';
 
     // Note: The use of "dos" in the pathname might change to "drs" at some point and break things, so be on the lookout
     if (parsedUrl.host.startsWith('dg.')) {
         parsedUrl.pathname = `/ga4gh/dos/v1/dataobjects/${parsedUrl.hostname}${parsedUrl.pathname}`;
-        parsedUrl.host = config.drsResolutionHost;
+        parsedUrl.host = config.dataObjectResolutionHost;
     } else {
         parsedUrl.pathname = `/ga4gh/dos/v1/dataobjects${parsedUrl.pathname}`;
     }
@@ -24,6 +24,6 @@ const bondBaseUrl = () => config.bondBaseUrl;
 const samBaseUrl = () => config.samBaseUrl;
 
 
-exports.drsToHttps = drsToHttps;
+exports.dataObjectUrlToHttps = dataObjectUrlToHttps;
 exports.bondBaseUrl = bondBaseUrl;
 exports.samBaseUrl = samBaseUrl;

--- a/martha_v1/martha_v1.js
+++ b/martha_v1/martha_v1.js
@@ -1,5 +1,5 @@
 const superagent = require('superagent');
-const { drsToHttps } = require('./helpers');
+const { dataObjectUrlToHttps } = require('./helpers');
 
 const martha_v1_handler = (req, res) => {
     let orig_url = req.body.url;
@@ -9,7 +9,7 @@ const martha_v1_handler = (req, res) => {
         pattern = JSON.parse(req.body.toString()).pattern;
     }
 
-    const http_url = drsToHttps(orig_url);
+    const http_url = dataObjectUrlToHttps(orig_url);
 
     console.log(http_url);
     superagent.get(http_url)

--- a/martha_v1/martha_v1.js
+++ b/martha_v1/martha_v1.js
@@ -1,5 +1,5 @@
 const superagent = require('superagent');
-const { dosToHttps } = require('./helpers');
+const { drsToHttps } = require('./helpers');
 
 const martha_v1_handler = (req, res) => {
     let orig_url = req.body.url;
@@ -9,7 +9,7 @@ const martha_v1_handler = (req, res) => {
         pattern = JSON.parse(req.body.toString()).pattern;
     }
 
-    const http_url = dosToHttps(orig_url);
+    const http_url = drsToHttps(orig_url);
 
     console.log(http_url);
     superagent.get(http_url)

--- a/martha_v2/martha_v2.js
+++ b/martha_v2/martha_v2.js
@@ -1,4 +1,4 @@
-const {drsToHttps, bondBaseUrl, determineBondProvider, BondProviders} = require('../common/helpers');
+const {dataObjectUrlToHttps, bondBaseUrl, determineBondProvider, BondProviders} = require('../common/helpers');
 const apiAdapter = require('../common/api_adapter');
 
 // This function counts on the request posing  data as "application/json" content-type.
@@ -33,14 +33,14 @@ function aggregateResponses(responses) {
 function martha_v2_handler(req, res) {
     const origUrl = parseRequest(req);
     if (!origUrl) {
-        res.status(400).send('Request must specify the URL of a DRS object');
+        res.status(400).send('Request must specify the URL of a DOS object');
         return;
     }
 
     console.log(`Received URL: ${origUrl}`);
-    let drsUrl;
+    let dataObjectUrl;
     try {
-        drsUrl = drsToHttps(origUrl);
+        dataObjectUrl = dataObjectUrlToHttps(origUrl);
     } catch (e) {
         console.error(new Error(e));
         res.status(400).send('The specified URL is invalid');
@@ -49,10 +49,10 @@ function martha_v2_handler(req, res) {
 
     const bondProvider = determineBondProvider(origUrl);
 
-    const drsPromise = apiAdapter.getJsonFrom(drsUrl);
+    const dataObjectPromise = apiAdapter.getJsonFrom(dataObjectUrl);
     const bondPromise = maybeTalkToBond(req, bondProvider);
 
-    return Promise.all([drsPromise, bondPromise])
+    return Promise.all([dataObjectPromise, bondPromise])
         .then((rawResults) => {
             res.status(200).send(aggregateResponses(rawResults));
         })

--- a/martha_v2/martha_v2.js
+++ b/martha_v2/martha_v2.js
@@ -1,4 +1,4 @@
-const {dosToHttps, bondBaseUrl, determineBondProvider, BondProviders} = require('../common/helpers');
+const {drsToHttps, bondBaseUrl, determineBondProvider, BondProviders} = require('../common/helpers');
 const apiAdapter = require('../common/api_adapter');
 
 // This function counts on the request posing  data as "application/json" content-type.
@@ -20,6 +20,8 @@ function maybeTalkToBond(req, provider = BondProviders.default) {
 }
 
 function aggregateResponses(responses) {
+    // Note: for backwards compatibility, we are returning the DRS object with the key, "dos".  If we want to change this, we can add a new api version for Martha_v2.
+    // When/if we change this, we might want to consider replacing "dos" with "data_object" or something like that that is unlikely to change
     const finalResult = { dos: responses[0] };
     if (responses[1]) {
         finalResult.googleServiceAccount = responses[1];
@@ -31,14 +33,14 @@ function aggregateResponses(responses) {
 function martha_v2_handler(req, res) {
     const origUrl = parseRequest(req);
     if (!origUrl) {
-        res.status(400).send('Request must specify the URL of a DOS object');
+        res.status(400).send('Request must specify the URL of a DRS object');
         return;
     }
 
     console.log(`Received URL: ${origUrl}`);
-    let dosUrl;
+    let drsUrl;
     try {
-        dosUrl = dosToHttps(origUrl);
+        drsUrl = drsToHttps(origUrl);
     } catch (e) {
         console.error(new Error(e));
         res.status(400).send('The specified URL is invalid');
@@ -47,10 +49,10 @@ function martha_v2_handler(req, res) {
 
     const bondProvider = determineBondProvider(origUrl);
 
-    const dosPromise = apiAdapter.getJsonFrom(dosUrl);
+    const drsPromise = apiAdapter.getJsonFrom(drsUrl);
     const bondPromise = maybeTalkToBond(req, bondProvider);
 
-    return Promise.all([dosPromise, bondPromise])
+    return Promise.all([drsPromise, bondPromise])
         .then((rawResults) => {
             res.status(200).send(aggregateResponses(rawResults));
         })

--- a/test/_marthaLiveEnv.js
+++ b/test/_marthaLiveEnv.js
@@ -2,30 +2,39 @@
  * This file is named with a leading `_` to prevent Ava from processing this file and looking for tests within it
  * */
 
-const _publicDosUrlsWithGS = [
-    'dos://dos-dss.ucsc-cgp-dev.org/00e6cfa9-a183-42f6-bb44-b70347106bbe'
+const _publicDrsUrlsWithGS = [
+    'dos://dos-dss.ucsc-cgp-dev.org/00e6cfa9-a183-42f6-bb44-b70347106bbe',
+    'drs://dos-dss.ucsc-cgp-dev.org/00e6cfa9-a183-42f6-bb44-b70347106bbe'
 ];
 
-const _publicDosUrlsWithoutGS = [
+const _publicDrsUrlsWithoutGS = [
     'dos://qa.dcf.planx-pla.net/206dfaa6-bcf1-4bc9-b2d0-77179f0f48fc',
     'dos://nci-crdc-staging.datacommons.io/206dfaa6-bcf1-4bc9-b2d0-77179f0f48fc',
-    'dos://dataguids.org/206dfaa6-bcf1-4bc9-b2d0-77179f0f48fc'
+    'dos://dataguids.org/206dfaa6-bcf1-4bc9-b2d0-77179f0f48fc',
+    'drs://qa.dcf.planx-pla.net/206dfaa6-bcf1-4bc9-b2d0-77179f0f48fc',
+    'drs://nci-crdc-staging.datacommons.io/206dfaa6-bcf1-4bc9-b2d0-77179f0f48fc',
+    'drs://dataguids.org/206dfaa6-bcf1-4bc9-b2d0-77179f0f48fc'
 ];
 
-const _publicDosUrls = _publicDosUrlsWithoutGS.concat(_publicDosUrlsWithGS);
+const _publicDrsUrls = _publicDrsUrlsWithoutGS.concat(_publicDrsUrlsWithGS);
 
-const _mockedDosUrlsWithGS = [
+const _mockedDrsUrlsWithGS = [
     'dos://wb-mock-drs-dev.storage.googleapis.com/0c8e7bc6-fd76-459d-947b-808b0605beb3',
     'dos://wb-mock-drs-dev.storage.googleapis.com/65e4cd14-f549-4a7f-ad0c-d29212ff6e46',
     'dos://wb-mock-drs-dev.storage.googleapis.com/drs.json',
-    'dos://wb-mock-drs-dev.storage.googleapis.com/preview_dos.json'
+    'dos://wb-mock-drs-dev.storage.googleapis.com/preview_dos.json',
+    'drs://wb-mock-drs-dev.storage.googleapis.com/0c8e7bc6-fd76-459d-947b-808b0605beb3',
+    'drs://wb-mock-drs-dev.storage.googleapis.com/65e4cd14-f549-4a7f-ad0c-d29212ff6e46',
+    'drs://wb-mock-drs-dev.storage.googleapis.com/drs.json',
+    'drs://wb-mock-drs-dev.storage.googleapis.com/preview_dos.json'
 ];
 
-const _mockDosUrlsWithoutGS = [
-    'dos://wb-mock-drs-dev.storage.googleapis.com/noGSUrl.json'
+const _mockDrsUrlsWithoutGS = [
+    'dos://wb-mock-drs-dev.storage.googleapis.com/noGSUrl.json',
+    'drs://wb-mock-drs-dev.storage.googleapis.com/noGSUrl.json'
 ];
 
-const _mockedDosUrls = _mockedDosUrlsWithGS.concat(_mockDosUrlsWithoutGS);
+const _mockedDrsUrls = _mockedDrsUrlsWithGS.concat(_mockDrsUrlsWithoutGS);
 
 function chooseBaseUrl(env) {
     let baseUrl = 'http://localhost:8010/broad-dsde-dev/us-central1';
@@ -40,9 +49,9 @@ function marthaLiveEnv(args) {
     this.env = parsedArgs.e || parsedArgs.env || 'local';
     this.useMockDrs = parsedArgs.m || parsedArgs.mock || false;
     this.baseUrl = parsedArgs.base_url || chooseBaseUrl(this.env);
-    this.dosUrls = this.useMockDrs ? _mockedDosUrls : _publicDosUrls;
-    this.dosUrlsWithGS = this.useMockDrs ? _mockedDosUrlsWithGS : _publicDosUrlsWithGS;
-    this.dosUrlsWithoutGS = this.useMockDrs ? _mockDosUrlsWithoutGS : _publicDosUrlsWithoutGS;
+    this.drsUrls = this.useMockDrs ? _mockedDrsUrls : _publicDrsUrls;
+    this.drsUrlsWithGS = this.useMockDrs ? _mockedDrsUrlsWithGS : _publicDrsUrlsWithGS;
+    this.drsUrlsWithoutGS = this.useMockDrs ? _mockDrsUrlsWithoutGS : _publicDrsUrlsWithoutGS;
 }
 
 exports.MarthaLiveEnv = marthaLiveEnv;

--- a/test/_marthaLiveEnv.js
+++ b/test/_marthaLiveEnv.js
@@ -2,12 +2,12 @@
  * This file is named with a leading `_` to prevent Ava from processing this file and looking for tests within it
  * */
 
-const _publicDrsUrlsWithGS = [
+const _publicDataObjectUrlsWithGS = [
     'dos://dos-dss.ucsc-cgp-dev.org/00e6cfa9-a183-42f6-bb44-b70347106bbe',
     'drs://dos-dss.ucsc-cgp-dev.org/00e6cfa9-a183-42f6-bb44-b70347106bbe'
 ];
 
-const _publicDrsUrlsWithoutGS = [
+const _publicDataObjectUrlsWithoutGS = [
     'dos://qa.dcf.planx-pla.net/206dfaa6-bcf1-4bc9-b2d0-77179f0f48fc',
     'dos://nci-crdc-staging.datacommons.io/206dfaa6-bcf1-4bc9-b2d0-77179f0f48fc',
     'dos://dataguids.org/206dfaa6-bcf1-4bc9-b2d0-77179f0f48fc',
@@ -16,9 +16,9 @@ const _publicDrsUrlsWithoutGS = [
     'drs://dataguids.org/206dfaa6-bcf1-4bc9-b2d0-77179f0f48fc'
 ];
 
-const _publicDrsUrls = _publicDrsUrlsWithoutGS.concat(_publicDrsUrlsWithGS);
+const _publicDataObjectUrls = _publicDataObjectUrlsWithoutGS.concat(_publicDataObjectUrlsWithGS);
 
-const _mockedDrsUrlsWithGS = [
+const _mockedDataObjectUrlsWithGS = [
     'dos://wb-mock-drs-dev.storage.googleapis.com/0c8e7bc6-fd76-459d-947b-808b0605beb3',
     'dos://wb-mock-drs-dev.storage.googleapis.com/65e4cd14-f549-4a7f-ad0c-d29212ff6e46',
     'dos://wb-mock-drs-dev.storage.googleapis.com/drs.json',
@@ -29,12 +29,12 @@ const _mockedDrsUrlsWithGS = [
     'drs://wb-mock-drs-dev.storage.googleapis.com/preview_dos.json'
 ];
 
-const _mockDrsUrlsWithoutGS = [
+const _mockDataObjectUrlsWithoutGS = [
     'dos://wb-mock-drs-dev.storage.googleapis.com/noGSUrl.json',
     'drs://wb-mock-drs-dev.storage.googleapis.com/noGSUrl.json'
 ];
 
-const _mockedDrsUrls = _mockedDrsUrlsWithGS.concat(_mockDrsUrlsWithoutGS);
+const _mockedDataObjectUrls = _mockedDataObjectUrlsWithGS.concat(_mockDataObjectUrlsWithoutGS);
 
 function chooseBaseUrl(env) {
     let baseUrl = 'http://localhost:8010/broad-dsde-dev/us-central1';
@@ -47,11 +47,11 @@ function chooseBaseUrl(env) {
 function marthaLiveEnv(args) {
     const parsedArgs = require('minimist')(args);
     this.env = parsedArgs.e || parsedArgs.env || 'local';
-    this.useMockDrs = parsedArgs.m || parsedArgs.mock || false;
+    this.useMockDataObjects = parsedArgs.m || parsedArgs.mock || false;
     this.baseUrl = parsedArgs.base_url || chooseBaseUrl(this.env);
-    this.drsUrls = this.useMockDrs ? _mockedDrsUrls : _publicDrsUrls;
-    this.drsUrlsWithGS = this.useMockDrs ? _mockedDrsUrlsWithGS : _publicDrsUrlsWithGS;
-    this.drsUrlsWithoutGS = this.useMockDrs ? _mockDrsUrlsWithoutGS : _publicDrsUrlsWithoutGS;
+    this.dataObjectUrls = this.useMockDataObjects ? _mockedDataObjectUrls : _publicDataObjectUrls;
+    this.dataObjectUrlsWithGS = this.useMockDataObjects ? _mockedDataObjectUrlsWithGS : _publicDataObjectUrlsWithGS;
+    this.dataObjectUrlsWithoutGS = this.useMockDataObjects ? _mockDataObjectUrlsWithoutGS : _publicDataObjectUrlsWithoutGS;
 }
 
 exports.MarthaLiveEnv = marthaLiveEnv;

--- a/test/common/helpers.test.js
+++ b/test/common/helpers.test.js
@@ -1,23 +1,23 @@
 const test = require('ava');
-const {drsToHttps, bondBaseUrl, samBaseUrl, BondProviders, determineBondProvider} = require('../../common/helpers');
+const {dataObjectUrlToHttps, bondBaseUrl, samBaseUrl, BondProviders, determineBondProvider} = require('../../common/helpers');
 const config = require('../../config.json');
 
-test('drsToHttps should parse dos uri', (t) => {
-    t.is(drsToHttps('dos://foo/bar'), `https://${config.drsResolutionHost}/ga4gh/dos/v1/dataobjects/bar`);
+test('dataObjectUrlToHttps should parse dos:// Data Object uri', (t) => {
+    t.is(dataObjectUrlToHttps('dos://foo/bar'), `https://${config.dataObjectResolutionHost}/ga4gh/dos/v1/dataobjects/bar`);
 });
 
-test('drsToHttps should parse drs uri', (t) => {
-    t.is(drsToHttps('drs://foo/bar'), `https://${config.drsResolutionHost}/ga4gh/dos/v1/dataobjects/bar`);
+test('dataObjectUrlToHttps should parse drs:// Data Object uri', (t) => {
+    t.is(dataObjectUrlToHttps('drs://foo/bar'), `https://${config.dataObjectResolutionHost}/ga4gh/dos/v1/dataobjects/bar`);
 });
 
 // This is a legacy test because martha_v1 treated dos urls with a "dg.*" host differently than other urls
-test('drsToHttps should parse dg dos uri to use drsResolutionHost', (t) => {
-    t.is(drsToHttps('dos://dg.2345/bar'), `https://${config.drsResolutionHost}/ga4gh/dos/v1/dataobjects/bar`);
+test('dataObjectUrlToHttps should parse dg Data Object uri to use dataObjectResolutionHost', (t) => {
+    t.is(dataObjectUrlToHttps('dos://dg.2345/bar'), `https://${config.dataObjectResolutionHost}/ga4gh/dos/v1/dataobjects/bar`);
 });
 
-test('drsToHttps should throw a Error when passed an invalid uri', (t) => {
+test('dataObjectUrlToHttps should throw a Error when passed an invalid uri', (t) => {
     t.throws(() => {
-        drsToHttps('A string that is not a valid URI');
+        dataObjectUrlToHttps('A string that is not a valid URI');
     }, Error);
 });
 

--- a/test/common/helpers.test.js
+++ b/test/common/helpers.test.js
@@ -1,19 +1,23 @@
 const test = require('ava');
-const {dosToHttps, bondBaseUrl, samBaseUrl, BondProviders, determineBondProvider} = require('../../common/helpers');
+const {drsToHttps, bondBaseUrl, samBaseUrl, BondProviders, determineBondProvider} = require('../../common/helpers');
 const config = require('../../config.json');
 
-test('dosToHttps should parse dos uri', (t) => {
-    t.is(dosToHttps('dos://foo/bar'), `https://${config.dosResolutionHost}/ga4gh/dos/v1/dataobjects/bar`);
+test('drsToHttps should parse dos uri', (t) => {
+    t.is(drsToHttps('dos://foo/bar'), `https://${config.drsResolutionHost}/ga4gh/dos/v1/dataobjects/bar`);
+});
+
+test('drsToHttps should parse drs uri', (t) => {
+    t.is(drsToHttps('drs://foo/bar'), `https://${config.drsResolutionHost}/ga4gh/dos/v1/dataobjects/bar`);
 });
 
 // This is a legacy test because martha_v1 treated dos urls with a "dg.*" host differently than other urls
-test('dosToHttps should parse dg dos uri to use dosResolutionHost', (t) => {
-    t.is(dosToHttps('dos://dg.2345/bar'), `https://${config.dosResolutionHost}/ga4gh/dos/v1/dataobjects/bar`);
+test('drsToHttps should parse dg dos uri to use drsResolutionHost', (t) => {
+    t.is(drsToHttps('dos://dg.2345/bar'), `https://${config.drsResolutionHost}/ga4gh/dos/v1/dataobjects/bar`);
 });
 
-test('dosToHttps should throw a Error when passed an invalid uri', (t) => {
+test('drsToHttps should throw a Error when passed an invalid uri', (t) => {
     t.throws(() => {
-        dosToHttps('A string that is not a valid URI');
+        drsToHttps('A string that is not a valid URI');
     }, Error);
 });
 
@@ -35,9 +39,9 @@ test('BondProviders should contain "dcf-fence" and "fence"', (t) => {
 });
 
 test('determineBondProvider should be "fence" if the URL host is "dg.4503"', (t) => {
-    t.is(determineBondProvider('dos://dg.4503/anything'), BondProviders.FENCE);
+    t.is(determineBondProvider('drs://dg.4503/anything'), BondProviders.FENCE);
 });
 
 test('determineBondProvider should return the default BondProvider if the URL host is NOT "dg.4503"', (t) => {
-    t.is(determineBondProvider('dos://some-host/anything'), BondProviders.default);
+    t.is(determineBondProvider('drs://some-host/anything'), BondProviders.default);
 });

--- a/test/fileSummaryV1/fileSummaryV1.test.js
+++ b/test/fileSummaryV1/fileSummaryV1.test.js
@@ -83,20 +83,20 @@ test.serial('fileSummaryV1Handler resolves a valid gs url into a metadata and si
     t.is(response.statusCode, 200);
 });
 
-test.serial('fileSummaryV1Handler resolves a valid dos url into metadata and signed url', async (t) => {
+test.serial('fileSummaryV1Handler resolves a valid drs url into metadata and signed url', async (t) => {
     const response = mockResponse();
-    await fileSummaryV1(mockRequest({ body: { uri: 'dos://example.com/validGS' } }), response);
+    await fileSummaryV1(mockRequest({ body: { uri: 'drs://example.com/validGS' } }), response);
     const result = response.send.lastCall.args[0];
     t.deepEqual(result, fullExpectedResult());
     t.truthy(result.signedUrl);
     t.is(response.statusCode, 200);
 });
 
-test.serial('fileSummaryV1Handler resolves a valid dos url into metadata with no signed url when not linked to Fence', async (t) => {
+test.serial('fileSummaryV1Handler resolves a valid drs url into metadata with no signed url when not linked to Fence', async (t) => {
     getServiceAccountKeyStub.restore();
     sandbox.stub(saKeys, getServiceAccountKeyMethodName).resolves();
     const response = mockResponse();
-    const mockReq = mockRequest({ body: { uri: 'dos://example.com/validGS' } });
+    const mockReq = mockRequest({ body: { uri: 'drs://example.com/validGS' } });
     await fileSummaryV1(mockReq, response);
     const result = response.send.lastCall.args[0];
     t.deepEqual(result, gsObjectMetadata());
@@ -134,7 +134,7 @@ test.serial('fileSummaryV1Handler should return 502 if it is unable to retrieve 
     getServiceAccountKeyStub.restore();
     sandbox.stub(saKeys, getServiceAccountKeyMethodName).rejects(new Error('Stubbed error getting Service Account Key'));
     const response = mockResponse();
-    await fileSummaryV1(mockRequest({ body: { uri: 'dos://example.com/validGS' } }), response);
+    await fileSummaryV1(mockRequest({ body: { uri: 'drs://example.com/validGS' } }), response);
     const result = response.send.lastCall.args[0];
     t.true(result instanceof Error);
     t.is(response.statusCode, 502);

--- a/test/fileSummaryV1/fileSummaryV1.test.js
+++ b/test/fileSummaryV1/fileSummaryV1.test.js
@@ -83,7 +83,7 @@ test.serial('fileSummaryV1Handler resolves a valid gs url into a metadata and si
     t.is(response.statusCode, 200);
 });
 
-test.serial('fileSummaryV1Handler resolves a valid drs url into metadata and signed url', async (t) => {
+test.serial('fileSummaryV1Handler resolves a valid drs:// Data Object url into metadata and signed url', async (t) => {
     const response = mockResponse();
     await fileSummaryV1(mockRequest({ body: { uri: 'drs://example.com/validGS' } }), response);
     const result = response.send.lastCall.args[0];
@@ -92,7 +92,7 @@ test.serial('fileSummaryV1Handler resolves a valid drs url into metadata and sig
     t.is(response.statusCode, 200);
 });
 
-test.serial('fileSummaryV1Handler resolves a valid drs url into metadata with no signed url when not linked to Fence', async (t) => {
+test.serial('fileSummaryV1Handler resolves a valid drs:// Data Object url into metadata with no signed url when not linked to Fence', async (t) => {
     getServiceAccountKeyStub.restore();
     sandbox.stub(saKeys, getServiceAccountKeyMethodName).resolves();
     const response = mockResponse();

--- a/test/fileSummaryV1/fileSummaryV1_live.test.js
+++ b/test/fileSummaryV1/fileSummaryV1_live.test.js
@@ -16,9 +16,9 @@
  *
  *          env         - Can be one of ['dev', 'staging', 'alpha', 'perf', 'prod'].  Used to automatically determine
  *                        the `base_url`.  Defaults to `local`.
- *          mock        - If present or set to `true`, then tests will use DRS URLs that are resolvable by the mock-drs
- *                        service.  If `mock` is absent or set to `false`, tests will use DRS URLs resolvable by the
- *                        live/public DRS resolvers.
+ *          mock        - If present or set to `true`, then tests will use Data Object URLs that are resolvable by the mock-drs
+ *                        service.  If `mock` is absent or set to `false`, tests will use Data Object URLs resolvable by the
+ *                        live/public Data Object resolvers.
  *          base_url    - The base URL (protocol and host) where the Martha functions will be called.  Set this option
  *                        if you want to override the `base_url` derived from the `env` option.  Defaults to
  *                        `http://localhost:8010/broad-dsde-dev/us-central1`.
@@ -70,33 +70,33 @@ test.cb('live_test fileSummaryV1 responds with 401 when no "authorization" heade
     supertest
         .post('/fileSummaryV1')
         .set('Content-Type', 'application/json')
-        .send({ uri: marthaLiveEnv.drsUrls[0] })
+        .send({ uri: marthaLiveEnv.dataObjectUrls[0] })
         .expect(401)
         .end(t.end);
 });
 
-// The resolved DOS objects in this list contain a 'gs://' url in the list of urls
-for (const drsUrl of marthaLiveEnv.drsUrlsWithGS) {
-    test.cb(`live_test Calling fileSummaryV1 with URL: "${drsUrl}" with an Access Token returns metadata and signed url`, (t) => {
+// The resolved Data Objects in this list contain a 'gs://' url in the list of urls
+for (const dataObjectUrl of marthaLiveEnv.dataObjectUrlsWithGS) {
+    test.cb(`live_test Calling fileSummaryV1 with URL: "${dataObjectUrl}" with an Access Token returns metadata and signed url`, (t) => {
         supertest
             .post('/fileSummaryV1')
             .set('Content-Type', 'application/json')
             .set('Authorization', `bearer ${bearerToken}`)
-            .send({uri: drsUrl})
+            .send({uri: dataObjectUrl})
             .expect(200)
             .end((err, response) => handleResponse(err, response, t));
     });
 }
 
-// The resolved DOS objects in this list do not contain a 'gs://' url in the list of urls
+// The resolved Data Objects in this list do not contain a 'gs://' url in the list of urls
 // TODO: This error scenario is not good.  When there is no gs:// url, the response should be 400 and have a helpful message, not an empty 502
-for (const drsUrl of marthaLiveEnv.drsUrlsWithoutGS) {
-    test.cb(`live_test Calling fileSummaryV1 with URL: "${drsUrl}" with an Access Token returns an error because the drs object does not contain a 'gs://' url`, (t) => {
+for (const dataObjectUrl of marthaLiveEnv.dataObjectUrlsWithoutGS) {
+    test.cb(`live_test Calling fileSummaryV1 with URL: "${dataObjectUrl}" with an Access Token returns an error because the Data Object does not contain a 'gs://' url`, (t) => {
         supertest
             .post('/fileSummaryV1')
             .set('Content-Type', 'application/json')
             .set('Authorization', `bearer ${bearerToken}`)
-            .send({uri: drsUrl})
+            .send({uri: dataObjectUrl})
             .expect(502)
             .end(t.end);
     });

--- a/test/fileSummaryV1/fileSummaryV1_live.test.js
+++ b/test/fileSummaryV1/fileSummaryV1_live.test.js
@@ -70,19 +70,19 @@ test.cb('live_test fileSummaryV1 responds with 401 when no "authorization" heade
     supertest
         .post('/fileSummaryV1')
         .set('Content-Type', 'application/json')
-        .send({ uri: marthaLiveEnv.dosUrls[0] })
+        .send({ uri: marthaLiveEnv.drsUrls[0] })
         .expect(401)
         .end(t.end);
 });
 
 // The resolved DOS objects in this list contain a 'gs://' url in the list of urls
-for (const dosUrl of marthaLiveEnv.dosUrlsWithGS) {
-    test.cb(`live_test Calling fileSummaryV1 with URL: "${dosUrl}" with an Access Token returns metadata and signed url`, (t) => {
+for (const drsUrl of marthaLiveEnv.drsUrlsWithGS) {
+    test.cb(`live_test Calling fileSummaryV1 with URL: "${drsUrl}" with an Access Token returns metadata and signed url`, (t) => {
         supertest
             .post('/fileSummaryV1')
             .set('Content-Type', 'application/json')
             .set('Authorization', `bearer ${bearerToken}`)
-            .send({uri: dosUrl})
+            .send({uri: drsUrl})
             .expect(200)
             .end((err, response) => handleResponse(err, response, t));
     });
@@ -90,13 +90,13 @@ for (const dosUrl of marthaLiveEnv.dosUrlsWithGS) {
 
 // The resolved DOS objects in this list do not contain a 'gs://' url in the list of urls
 // TODO: This error scenario is not good.  When there is no gs:// url, the response should be 400 and have a helpful message, not an empty 502
-for (const dosUrl of marthaLiveEnv.dosUrlsWithoutGS) {
-    test.cb(`live_test Calling fileSummaryV1 with URL: "${dosUrl}" with an Access Token returns an error because the dos object does not contain a 'gs://' url`, (t) => {
+for (const drsUrl of marthaLiveEnv.drsUrlsWithoutGS) {
+    test.cb(`live_test Calling fileSummaryV1 with URL: "${drsUrl}" with an Access Token returns an error because the drs object does not contain a 'gs://' url`, (t) => {
         supertest
             .post('/fileSummaryV1')
             .set('Content-Type', 'application/json')
             .set('Authorization', `bearer ${bearerToken}`)
-            .send({uri: dosUrl})
+            .send({uri: drsUrl})
             .expect(502)
             .end(t.end);
     });

--- a/test/fileSummaryV1/integration_fileSummaryV1.test.js
+++ b/test/fileSummaryV1/integration_fileSummaryV1.test.js
@@ -23,7 +23,7 @@ let scopes = 'email openid';
 let unauthorizedEmail = `ron.weasley@${emailDomain}`;
 let authorizedEmail = `hermione.owner@${emailDomain}`;
 
-let drsUri = 'dos://dg.4503/preview_dos.json';
+let dataObjectUri = 'dos://dg.4503/preview_dos.json';
 let gsUri = 'gs://wb-mock-drs-dev/public/dos_test.txt';
 // TODO: GAWB-4053 -- remove static link so bond host can be changed depending on env
 let fenceAuthLink = `https://bond-fiab.dsde-${myEnv}.broadinstitute.org:31443/api/link/v1/fence/oauthcode?oauthcode=IgnoredByMockProvider&redirect_uri=http%3A%2F%2Flocal.broadinstitute.org%2F%23fence-callback`;
@@ -49,7 +49,7 @@ test.cb('integration_fileSummaryV1 responds with 400 if a uri is not provided', 
     supertest
         .post('/fileSummaryV1')
         .set('Content-Type', 'application/json')
-        .send({ notValid: drsUri })
+        .send({ notValid: dataObjectUri })
         .expect((response) => {
             assert.strictEqual(response.statusCode, 400, 'Incorrect status code');
             assert(response.text.includes('must specify the URI'), 'Received the wrong error message');
@@ -79,7 +79,7 @@ test.cb('integration_fileSummaryV1 responds with 401 if uri is valid but no auth
     supertest
         .post('/fileSummaryV1')
         .set('Content-Type', 'application/json')
-        .send({ uri: drsUri })
+        .send({ uri: dataObjectUri })
         .expect((response) => {
             assert.strictEqual(response.statusCode, 401, 'Incorrect status code');
             assert(response.text.includes('must contain a bearer token'), 'Received the wrong error message');
@@ -90,12 +90,12 @@ test.cb('integration_fileSummaryV1 responds with 401 if uri is valid but no auth
         });
 });
 
-test.cb('integration_fileSummaryV1 responds with 200 and file metadata but no signed url if drs uri is valid but the authorization header does not contain an authorized token', (t) => {
+test.cb('integration_fileSummaryV1 responds with 200 and file metadata but no signed url if Data Object uri is valid but the authorization header does not contain an authorized token', (t) => {
     supertest
         .post('/fileSummaryV1')
         .set('Content-Type', 'application/json')
         .set('Authorization', `Bearer ${unauthorizedToken}`)
-        .send({ uri: drsUri })
+        .send({ uri: dataObjectUri })
         .expect((response) => {
             assert.strictEqual(response.statusCode, 200, 'Incorrect status code');
             assert(response.body.bucket, 'fileSummary did not return metadata');
@@ -107,12 +107,12 @@ test.cb('integration_fileSummaryV1 responds with 200 and file metadata but no si
         });
 });
 
-test.cb('integration_fileSummaryV1 responds with 200, file metadata, and a signed url if drs uri is valid and valid authorization is provided', (t) => {
+test.cb('integration_fileSummaryV1 responds with 200, file metadata, and a signed url if Data Object uri is valid and valid authorization is provided', (t) => {
     supertest
         .post('/fileSummaryV1')
         .set('Content-Type', 'application/json')
         .set('Authorization', `Bearer ${authorizedToken}`)
-        .send({ uri: drsUri })
+        .send({ uri: dataObjectUri })
         .expect((response) => {
             assert.strictEqual(response.statusCode, 200, 'Incorrect status code');
             assert(response.body.bucket, 'fileSummary did not return metadata');

--- a/test/fileSummaryV1/integration_fileSummaryV1.test.js
+++ b/test/fileSummaryV1/integration_fileSummaryV1.test.js
@@ -23,7 +23,7 @@ let scopes = 'email openid';
 let unauthorizedEmail = `ron.weasley@${emailDomain}`;
 let authorizedEmail = `hermione.owner@${emailDomain}`;
 
-let dosUri = 'dos://dg.4503/preview_dos.json';
+let drsUri = 'dos://dg.4503/preview_dos.json';
 let gsUri = 'gs://wb-mock-drs-dev/public/dos_test.txt';
 // TODO: GAWB-4053 -- remove static link so bond host can be changed depending on env
 let fenceAuthLink = `https://bond-fiab.dsde-${myEnv}.broadinstitute.org:31443/api/link/v1/fence/oauthcode?oauthcode=IgnoredByMockProvider&redirect_uri=http%3A%2F%2Flocal.broadinstitute.org%2F%23fence-callback`;
@@ -49,7 +49,7 @@ test.cb('integration_fileSummaryV1 responds with 400 if a uri is not provided', 
     supertest
         .post('/fileSummaryV1')
         .set('Content-Type', 'application/json')
-        .send({ notValid: dosUri })
+        .send({ notValid: drsUri })
         .expect((response) => {
             assert.strictEqual(response.statusCode, 400, 'Incorrect status code');
             assert(response.text.includes('must specify the URI'), 'Received the wrong error message');
@@ -79,7 +79,7 @@ test.cb('integration_fileSummaryV1 responds with 401 if uri is valid but no auth
     supertest
         .post('/fileSummaryV1')
         .set('Content-Type', 'application/json')
-        .send({ uri: dosUri })
+        .send({ uri: drsUri })
         .expect((response) => {
             assert.strictEqual(response.statusCode, 401, 'Incorrect status code');
             assert(response.text.includes('must contain a bearer token'), 'Received the wrong error message');
@@ -90,12 +90,12 @@ test.cb('integration_fileSummaryV1 responds with 401 if uri is valid but no auth
         });
 });
 
-test.cb('integration_fileSummaryV1 responds with 200 and file metadata but no signed url if dos uri is valid but the authorization header does not contain an authorized token', (t) => {
+test.cb('integration_fileSummaryV1 responds with 200 and file metadata but no signed url if drs uri is valid but the authorization header does not contain an authorized token', (t) => {
     supertest
         .post('/fileSummaryV1')
         .set('Content-Type', 'application/json')
         .set('Authorization', `Bearer ${unauthorizedToken}`)
-        .send({ uri: dosUri })
+        .send({ uri: drsUri })
         .expect((response) => {
             assert.strictEqual(response.statusCode, 200, 'Incorrect status code');
             assert(response.body.bucket, 'fileSummary did not return metadata');
@@ -107,12 +107,12 @@ test.cb('integration_fileSummaryV1 responds with 200 and file metadata but no si
         });
 });
 
-test.cb('integration_fileSummaryV1 responds with 200, file metadata, and a signed url if dos uri is valid and valid authorization is provided', (t) => {
+test.cb('integration_fileSummaryV1 responds with 200, file metadata, and a signed url if drs uri is valid and valid authorization is provided', (t) => {
     supertest
         .post('/fileSummaryV1')
         .set('Content-Type', 'application/json')
         .set('Authorization', `Bearer ${authorizedToken}`)
-        .send({ uri: dosUri })
+        .send({ uri: drsUri })
         .expect((response) => {
             assert.strictEqual(response.statusCode, 200, 'Incorrect status code');
             assert(response.body.bucket, 'fileSummary did not return metadata');

--- a/test/martha_v1/helpers.test.js
+++ b/test/martha_v1/helpers.test.js
@@ -1,17 +1,21 @@
 const test = require('ava');
-const { dosToHttps } = require('../../martha_v1/helpers');
+const { drsToHttps } = require('../../martha_v1/helpers');
 const config = require('../../config.json');
 
 test('should parse dos uri', (t) => {
-    t.is(dosToHttps('dos://foo/bar'), 'https://foo/ga4gh/dos/v1/dataobjects/bar');
+    t.is(drsToHttps('dos://foo/bar'), 'https://foo/ga4gh/dos/v1/dataobjects/bar');
 });
 
-test('should parse dg dos uri', (t) => {
-    t.is(dosToHttps('dos://dg.2345/bar'), `https://${config.dosResolutionHost}/ga4gh/dos/v1/dataobjects/dg.2345/bar`);
+test('should parse drs uri', (t) => {
+    t.is(drsToHttps('drs://foo/bar'), 'https://foo/ga4gh/dos/v1/dataobjects/bar');
+});
+
+test('should parse dg dos uri with dg. host', (t) => {
+    t.is(drsToHttps('dos://dg.2345/bar'), `https://${config.drsResolutionHost}/ga4gh/dos/v1/dataobjects/dg.2345/bar`);
 });
 
 test('should throw a TypeError when passed an invalid uri', (t) => {
     t.throws(() => {
-        dosToHttps('A string that is not a valid URI');
+        drsToHttps('A string that is not a valid URI');
     }, TypeError);
 });

--- a/test/martha_v1/helpers.test.js
+++ b/test/martha_v1/helpers.test.js
@@ -1,21 +1,21 @@
 const test = require('ava');
-const { drsToHttps } = require('../../martha_v1/helpers');
+const { dataObjectUrlToHttps } = require('../../martha_v1/helpers');
 const config = require('../../config.json');
 
-test('should parse dos uri', (t) => {
-    t.is(drsToHttps('dos://foo/bar'), 'https://foo/ga4gh/dos/v1/dataobjects/bar');
+test('should parse dos:// Data Object uri', (t) => {
+    t.is(dataObjectUrlToHttps('dos://foo/bar'), 'https://foo/ga4gh/dos/v1/dataobjects/bar');
 });
 
-test('should parse drs uri', (t) => {
-    t.is(drsToHttps('drs://foo/bar'), 'https://foo/ga4gh/dos/v1/dataobjects/bar');
+test('should parse drs:// Data Object uri', (t) => {
+    t.is(dataObjectUrlToHttps('drs://foo/bar'), 'https://foo/ga4gh/dos/v1/dataobjects/bar');
 });
 
-test('should parse dg dos uri with dg. host', (t) => {
-    t.is(drsToHttps('dos://dg.2345/bar'), `https://${config.drsResolutionHost}/ga4gh/dos/v1/dataobjects/dg.2345/bar`);
+test('should parse dg Data Object uri with dg. host', (t) => {
+    t.is(dataObjectUrlToHttps('dos://dg.2345/bar'), `https://${config.dataObjectResolutionHost}/ga4gh/dos/v1/dataobjects/dg.2345/bar`);
 });
 
 test('should throw a TypeError when passed an invalid uri', (t) => {
     t.throws(() => {
-        drsToHttps('A string that is not a valid URI');
+        dataObjectUrlToHttps('A string that is not a valid URI');
     }, TypeError);
 });

--- a/test/martha_v1/integration_v1.test.js
+++ b/test/martha_v1/integration_v1.test.js
@@ -13,7 +13,7 @@ test.cb('integration_v1 return gs link', (t) => {
     supertest
         .post('/martha_v1')
         .set('Content-Type', 'application/json')
-        .send({ 'url': 'drs://broad-dsp-drs.storage.googleapis.com/drs.json', 'pattern': 'gs://' })
+        .send({ 'url': 'drs://broad-dsp-dos.storage.googleapis.com/dos.json', 'pattern': 'gs://' })
         .expect((response) => {
             assert.strictEqual(response.statusCode, 200, 'Incorrect status code');
             assert.deepStrictEqual(response.text, 'gs://broad-public-datasets/NA12878_downsampled_for_testing/unmapped/H06JUADXX130110.1.ATCACGAT.20k_reads.bam');
@@ -42,7 +42,7 @@ test.cb('integration_v1 return 404 if no match is found', (t) => {
     supertest
         .post('/martha_v1')
         .set('Content-Type', 'application/json')
-        .send({ 'url': 'drs://broad-dsp-drs.storage.googleapis.com/drs.json', 'pattern': 'bad:pattern//' })
+        .send({ 'url': 'drs://broad-dsp-dos.storage.googleapis.com/dos.json', 'pattern': 'bad:pattern//' })
         .expect((response) => {
             assert.strictEqual(response.statusCode, 404, 'Incorrect status code');
         })

--- a/test/martha_v1/integration_v1.test.js
+++ b/test/martha_v1/integration_v1.test.js
@@ -13,7 +13,7 @@ test.cb('integration_v1 return gs link', (t) => {
     supertest
         .post('/martha_v1')
         .set('Content-Type', 'application/json')
-        .send({ 'url': 'dos://broad-dsp-dos.storage.googleapis.com/dos.json', 'pattern': 'gs://' })
+        .send({ 'url': 'drs://broad-dsp-drs.storage.googleapis.com/drs.json', 'pattern': 'gs://' })
         .expect((response) => {
             assert.strictEqual(response.statusCode, 200, 'Incorrect status code');
             assert.deepStrictEqual(response.text, 'gs://broad-public-datasets/NA12878_downsampled_for_testing/unmapped/H06JUADXX130110.1.ATCACGAT.20k_reads.bam');
@@ -42,7 +42,7 @@ test.cb('integration_v1 return 404 if no match is found', (t) => {
     supertest
         .post('/martha_v1')
         .set('Content-Type', 'application/json')
-        .send({ 'url': 'dos://broad-dsp-dos.storage.googleapis.com/dos.json', 'pattern': 'bad:pattern//' })
+        .send({ 'url': 'drs://broad-dsp-drs.storage.googleapis.com/drs.json', 'pattern': 'bad:pattern//' })
         .expect((response) => {
             assert.strictEqual(response.statusCode, 404, 'Incorrect status code');
         })

--- a/test/martha_v2/integration_v2.test.js
+++ b/test/martha_v2/integration_v2.test.js
@@ -45,14 +45,14 @@ test.before(async () => {
     await postJsonTo(fenceAuthLink, 'Bearer ' + authorizedToken);
 });
 
-test.cb('integration_v2 responds with DRS object only when no "authorization" header is provided for a public url', (t) => {
+test.cb('integration_v2 responds with Data Object only when no "authorization" header is provided for a public url', (t) => {
     supertest
         .post('/martha_v2')
         .set('Content-Type', 'application/json')
         .send({ url: publicFenceUrl })
         .expect((response) => {
             assert.strictEqual(response.statusCode, 200, 'Incorrect status code'); // not using loose equality for now, but if type coercion is wanted use equal instead of strictEqual
-            assert(response.body.drs, 'No DRS object found');
+            assert(response.body.dos, 'No Data Object found');
             assert(!response.body.googleServiceAccount, 'Response should not have a Google Service Account');
         })
         .end((error, response) => {
@@ -61,7 +61,7 @@ test.cb('integration_v2 responds with DRS object only when no "authorization" he
         });
 });
 
-test.cb('integration_v2 responds with DRS object and service account when "authorization" header is provided for a public url', (t) => {
+test.cb('integration_v2 responds with Data Object and service account when "authorization" header is provided for a public url', (t) => {
     supertest
         .post('/martha_v2')
         .set('Content-Type', 'application/json')
@@ -69,7 +69,7 @@ test.cb('integration_v2 responds with DRS object and service account when "autho
         .send({ url: publicFenceUrl })
         .expect((response) => {
             assert.strictEqual(response.statusCode, 200, 'Incorrect status code');
-            assert(response.body.drs, 'No DRS object found');
+            assert(response.body.dos, 'No Data Object found');
             assert(response.body.googleServiceAccount, 'No Google Service Account found');
         })
         .end((error, response) => {
@@ -110,14 +110,14 @@ test.cb('integration_v2 fails when "authorization" header is provided for a publ
         });
 });
 
-test.cb('integration_v2 responds with DRS object only when no "authorization" header is provided for a protected url', (t) => {
+test.cb('integration_v2 responds with Data Object only when no "authorization" header is provided for a protected url', (t) => {
     supertest
         .post('/martha_v2')
         .set('Content-Type', 'application/json')
         .send({ url: protectedFenceUrl })
         .expect((response) => {
             assert.strictEqual(response.statusCode, 200, 'Incorrect status code');
-            assert(response.body.drs, 'No DRS object found');
+            assert(response.body.dos, 'No Data Object found');
             assert(!response.body.googleServiceAccount, 'Response should not have a Google Service Account');
         })
         .end((error, response) => {
@@ -126,7 +126,7 @@ test.cb('integration_v2 responds with DRS object only when no "authorization" he
         });
 });
 
-test.cb('integration_v2 responds with DRS object and service account when "authorization" header is provided for a protected url', (t) => {
+test.cb('integration_v2 responds with Data Object and service account when "authorization" header is provided for a protected url', (t) => {
     supertest
         .post('/martha_v2')
         .set('Content-Type', 'application/json')
@@ -134,7 +134,7 @@ test.cb('integration_v2 responds with DRS object and service account when "autho
         .send({ url: protectedFenceUrl })
         .expect((response) => {
             assert.strictEqual(response.statusCode, 200, 'Incorrect status code');
-            assert(response.body.drs, 'No DRS object found');
+            assert(response.body.dos, 'No Data Object found');
             assert(response.body.googleServiceAccount, 'No Google Service Account found');
         })
         .end((error, response) => {

--- a/test/martha_v2/integration_v2.test.js
+++ b/test/martha_v2/integration_v2.test.js
@@ -45,14 +45,14 @@ test.before(async () => {
     await postJsonTo(fenceAuthLink, 'Bearer ' + authorizedToken);
 });
 
-test.cb('integration_v2 responds with DOS object only when no "authorization" header is provided for a public url', (t) => {
+test.cb('integration_v2 responds with DRS object only when no "authorization" header is provided for a public url', (t) => {
     supertest
         .post('/martha_v2')
         .set('Content-Type', 'application/json')
         .send({ url: publicFenceUrl })
         .expect((response) => {
             assert.strictEqual(response.statusCode, 200, 'Incorrect status code'); // not using loose equality for now, but if type coercion is wanted use equal instead of strictEqual
-            assert(response.body.dos, 'No DOS object found');
+            assert(response.body.drs, 'No DRS object found');
             assert(!response.body.googleServiceAccount, 'Response should not have a Google Service Account');
         })
         .end((error, response) => {
@@ -61,7 +61,7 @@ test.cb('integration_v2 responds with DOS object only when no "authorization" he
         });
 });
 
-test.cb('integration_v2 responds with DOS object and service account when "authorization" header is provided for a public url', (t) => {
+test.cb('integration_v2 responds with DRS object and service account when "authorization" header is provided for a public url', (t) => {
     supertest
         .post('/martha_v2')
         .set('Content-Type', 'application/json')
@@ -69,7 +69,7 @@ test.cb('integration_v2 responds with DOS object and service account when "autho
         .send({ url: publicFenceUrl })
         .expect((response) => {
             assert.strictEqual(response.statusCode, 200, 'Incorrect status code');
-            assert(response.body.dos, 'No DOS object found');
+            assert(response.body.drs, 'No DRS object found');
             assert(response.body.googleServiceAccount, 'No Google Service Account found');
         })
         .end((error, response) => {
@@ -110,14 +110,14 @@ test.cb('integration_v2 fails when "authorization" header is provided for a publ
         });
 });
 
-test.cb('integration_v2 responds with DOS object only when no "authorization" header is provided for a protected url', (t) => {
+test.cb('integration_v2 responds with DRS object only when no "authorization" header is provided for a protected url', (t) => {
     supertest
         .post('/martha_v2')
         .set('Content-Type', 'application/json')
         .send({ url: protectedFenceUrl })
         .expect((response) => {
             assert.strictEqual(response.statusCode, 200, 'Incorrect status code');
-            assert(response.body.dos, 'No DOS object found');
+            assert(response.body.drs, 'No DRS object found');
             assert(!response.body.googleServiceAccount, 'Response should not have a Google Service Account');
         })
         .end((error, response) => {
@@ -126,7 +126,7 @@ test.cb('integration_v2 responds with DOS object only when no "authorization" he
         });
 });
 
-test.cb('integration_v2 responds with DOS object and service account when "authorization" header is provided for a protected url', (t) => {
+test.cb('integration_v2 responds with DRS object and service account when "authorization" header is provided for a protected url', (t) => {
     supertest
         .post('/martha_v2')
         .set('Content-Type', 'application/json')
@@ -134,7 +134,7 @@ test.cb('integration_v2 responds with DOS object and service account when "autho
         .send({ url: protectedFenceUrl })
         .expect((response) => {
             assert.strictEqual(response.statusCode, 200, 'Incorrect status code');
-            assert(response.body.dos, 'No DOS object found');
+            assert(response.body.drs, 'No DRS object found');
             assert(response.body.googleServiceAccount, 'No Google Service Account found');
         })
         .end((error, response) => {

--- a/test/martha_v2/martha_v2.test.js
+++ b/test/martha_v2/martha_v2.test.js
@@ -29,7 +29,7 @@ const mockResponse = () => {
     };
 };
 
-const drsObject = { fake: 'A fake drs object' };
+const dataObject = { fake: 'A fake Data Object' };
 const googleSAKeyObject = { key: 'A Google Service Account private key json object' };
 
 const bondRegEx = /^([^/]+)\/api\/link\/v1\/([a-z-]+)\/serviceaccount\/key$/;
@@ -41,7 +41,7 @@ let sandbox = sinon.createSandbox();
 test.serial.beforeEach(() => {
     sandbox.restore(); // If one test fails, the .afterEach() block will not execute, so always clean the slate here
     getJsonFromApiStub = sandbox.stub(apiAdapter, getJsonFromApiMethodName);
-    getJsonFromApiStub.onFirstCall().resolves(drsObject);
+    getJsonFromApiStub.onFirstCall().resolves(dataObject);
     getJsonFromApiStub.onSecondCall().resolves(googleSAKeyObject);
 });
 
@@ -49,11 +49,11 @@ test.serial.afterEach(() => {
     sandbox.restore();
 });
 
-test.serial('martha_v2 resolves a valid url into a drs object and google service account key', async (t) => {
+test.serial('martha_v2 resolves a valid url into a Data Object and google service account key', async (t) => {
     const response = mockResponse();
     await martha_v2(mockRequest({ body: { 'url': 'https://example.com/validGS' } }), response);
     const result = response.send.lastCall.args[0];
-    t.deepEqual(result.dos, drsObject);
+    t.deepEqual(result.dos, dataObject);
     t.deepEqual(result.googleServiceAccount, googleSAKeyObject);
     t.is(response.statusCode, 200);
 });
@@ -68,19 +68,19 @@ test.serial('martha_v2 resolves successfully and ignores extra data submitted be
         }
     }), response);
     const result = response.send.lastCall.args[0];
-    t.deepEqual(result.dos, drsObject);
+    t.deepEqual(result.dos, dataObject);
     t.deepEqual(result.googleServiceAccount, googleSAKeyObject);
     t.is(response.statusCode, 200);
 });
 
-test.serial('martha_v2 resolves a valid url into a drs object without a service account key if no authorization header is provided', async (t) => {
+test.serial('martha_v2 resolves a valid url into a Data Object without a service account key if no authorization header is provided', async (t) => {
     const response = mockResponse();
     const mockReq = mockRequest({ body: { 'url': 'https://example.com/validGS' } });
     delete mockReq.headers.authorization;
     await martha_v2(mockReq, response);
     const result = response.send.lastCall.args[0];
     t.is(response.statusCode, 200);
-    t.deepEqual(result.dos, drsObject);
+    t.deepEqual(result.dos, dataObject);
 });
 
 test.serial('martha_v2 should return 400 if not given a url', async (t) => {
@@ -101,9 +101,9 @@ test.serial('martha_v2 should return 400 if given a \'url\' with an invalid valu
     t.is(response.statusCode, 400);
 });
 
-test.serial('martha_v2 should return 502 if drs resolution fails', async (t) => {
+test.serial('martha_v2 should return 502 if Data Object resolution fails', async (t) => {
     getJsonFromApiStub.restore();
-    sandbox.stub(apiAdapter, getJsonFromApiMethodName).rejects(new Error('DOS Resolution forced to fail by testing stub'));
+    sandbox.stub(apiAdapter, getJsonFromApiMethodName).rejects(new Error('Data Object Resolution forced to fail by testing stub'));
     const response = mockResponse();
     await martha_v2(mockRequest({ body: { 'url': 'https://example.com/validGS' } }), response);
     const result = response.send.lastCall.args[0];
@@ -121,7 +121,7 @@ test.serial('martha_v2 should return 502 if key retrieval from bond fails', asyn
     t.is(response.statusCode, 502);
 });
 
-test.serial('martha_v2 calls bond Bond with the "dcf-fence" provider when the DRS URL host is not "dg.4503"', async (t) => {
+test.serial('martha_v2 calls bond Bond with the "dcf-fence" provider when the Data Object URL host is not "dg.4503"', async (t) => {
     const response = mockResponse();
     await martha_v2(mockRequest({ body: { 'url': 'https://example.com/validGS' } }), response);
     const requestedBondUrl = getJsonFromApiStub.secondCall.args[0];
@@ -132,7 +132,7 @@ test.serial('martha_v2 calls bond Bond with the "dcf-fence" provider when the DR
     t.is(actualProvider, expectedProvider);
 });
 
-test.serial('martha_v2 calls bond Bond with the "fence" provider when the DRS URL host is "dg.4503"', async (t) => {
+test.serial('martha_v2 calls bond Bond with the "fence" provider when the Data Object URL host is "dg.4503"', async (t) => {
     const response = mockResponse();
     await martha_v2(mockRequest({ body: { 'url': 'drs://dg.4503/this_part_can_be_anything' } }), response);
     const requestedBondUrl = getJsonFromApiStub.secondCall.args[0];

--- a/test/martha_v2/martha_v2.test.js
+++ b/test/martha_v2/martha_v2.test.js
@@ -29,7 +29,7 @@ const mockResponse = () => {
     };
 };
 
-const dosObject = { fake: 'A fake dos object' };
+const drsObject = { fake: 'A fake drs object' };
 const googleSAKeyObject = { key: 'A Google Service Account private key json object' };
 
 const bondRegEx = /^([^/]+)\/api\/link\/v1\/([a-z-]+)\/serviceaccount\/key$/;
@@ -41,7 +41,7 @@ let sandbox = sinon.createSandbox();
 test.serial.beforeEach(() => {
     sandbox.restore(); // If one test fails, the .afterEach() block will not execute, so always clean the slate here
     getJsonFromApiStub = sandbox.stub(apiAdapter, getJsonFromApiMethodName);
-    getJsonFromApiStub.onFirstCall().resolves(dosObject);
+    getJsonFromApiStub.onFirstCall().resolves(drsObject);
     getJsonFromApiStub.onSecondCall().resolves(googleSAKeyObject);
 });
 
@@ -49,11 +49,11 @@ test.serial.afterEach(() => {
     sandbox.restore();
 });
 
-test.serial('martha_v2 resolves a valid url into a dos object and google service account key', async (t) => {
+test.serial('martha_v2 resolves a valid url into a drs object and google service account key', async (t) => {
     const response = mockResponse();
     await martha_v2(mockRequest({ body: { 'url': 'https://example.com/validGS' } }), response);
     const result = response.send.lastCall.args[0];
-    t.deepEqual(result.dos, dosObject);
+    t.deepEqual(result.dos, drsObject);
     t.deepEqual(result.googleServiceAccount, googleSAKeyObject);
     t.is(response.statusCode, 200);
 });
@@ -68,19 +68,19 @@ test.serial('martha_v2 resolves successfully and ignores extra data submitted be
         }
     }), response);
     const result = response.send.lastCall.args[0];
-    t.deepEqual(result.dos, dosObject);
+    t.deepEqual(result.dos, drsObject);
     t.deepEqual(result.googleServiceAccount, googleSAKeyObject);
     t.is(response.statusCode, 200);
 });
 
-test.serial('martha_v2 resolves a valid url into a dos object without a service account key if no authorization header is provided', async (t) => {
+test.serial('martha_v2 resolves a valid url into a drs object without a service account key if no authorization header is provided', async (t) => {
     const response = mockResponse();
     const mockReq = mockRequest({ body: { 'url': 'https://example.com/validGS' } });
     delete mockReq.headers.authorization;
     await martha_v2(mockReq, response);
     const result = response.send.lastCall.args[0];
     t.is(response.statusCode, 200);
-    t.deepEqual(result.dos, dosObject);
+    t.deepEqual(result.dos, drsObject);
 });
 
 test.serial('martha_v2 should return 400 if not given a url', async (t) => {
@@ -101,7 +101,7 @@ test.serial('martha_v2 should return 400 if given a \'url\' with an invalid valu
     t.is(response.statusCode, 400);
 });
 
-test.serial('martha_v2 should return 502 if dos resolution fails', async (t) => {
+test.serial('martha_v2 should return 502 if drs resolution fails', async (t) => {
     getJsonFromApiStub.restore();
     sandbox.stub(apiAdapter, getJsonFromApiMethodName).rejects(new Error('DOS Resolution forced to fail by testing stub'));
     const response = mockResponse();
@@ -121,7 +121,7 @@ test.serial('martha_v2 should return 502 if key retrieval from bond fails', asyn
     t.is(response.statusCode, 502);
 });
 
-test.serial('martha_v2 calls bond Bond with the "dcf-fence" provider when the DOS URL host is not "dg.4503"', async (t) => {
+test.serial('martha_v2 calls bond Bond with the "dcf-fence" provider when the DRS URL host is not "dg.4503"', async (t) => {
     const response = mockResponse();
     await martha_v2(mockRequest({ body: { 'url': 'https://example.com/validGS' } }), response);
     const requestedBondUrl = getJsonFromApiStub.secondCall.args[0];
@@ -132,9 +132,9 @@ test.serial('martha_v2 calls bond Bond with the "dcf-fence" provider when the DO
     t.is(actualProvider, expectedProvider);
 });
 
-test.serial('martha_v2 calls bond Bond with the "fence" provider when the DOS URL host is "dg.4503"', async (t) => {
+test.serial('martha_v2 calls bond Bond with the "fence" provider when the DRS URL host is "dg.4503"', async (t) => {
     const response = mockResponse();
-    await martha_v2(mockRequest({ body: { 'url': 'dos://dg.4503/this_part_can_be_anything' } }), response);
+    await martha_v2(mockRequest({ body: { 'url': 'drs://dg.4503/this_part_can_be_anything' } }), response);
     const requestedBondUrl = getJsonFromApiStub.secondCall.args[0];
     const matches = requestedBondUrl.match(bondRegEx);
     t.truthy(matches, 'Bond URL called does not match Bond URL regular expression');

--- a/test/martha_v2/martha_v2_live.test.js
+++ b/test/martha_v2/martha_v2_live.test.js
@@ -34,10 +34,10 @@ const execSync = require('child_process').execSync;
 let currentUser;
 let bearerToken;
 
-function assertDosObject(response, t) {
-    t.truthy(response.body.dos);
-    const dosObject = response.body.dos;
-    t.truthy(dosObject.data_object);
+function assertDrsObject(response, t) {
+    t.truthy(response.body.drs);
+    const drsObject = response.body.drs;
+    t.truthy(drsObject.data_object);
 }
 
 function assertGoogleServiceAccount(response, t) {
@@ -57,7 +57,7 @@ function handleResponse(err, response, t, skipGoogleServiceAccount = false) {
         }
         t.fail(msg);
     } else {
-        assertDosObject(response, t);
+        assertDrsObject(response, t);
         if (!skipGoogleServiceAccount) {
             assertGoogleServiceAccount(response, t);
         }
@@ -73,31 +73,31 @@ test.before(() => {
     console.log(`Martha settings: ${JSON.stringify(marthaLiveEnv)}`);
 });
 
-test.cb('live_test martha_v2 responds with DOS object only when no "authorization" header is provided', (t) => {
+test.cb('live_test martha_v2 responds with DRS object only when no "authorization" header is provided', (t) => {
     supertest
         .post('/martha_v2')
         .set('Content-Type', 'application/json')
-        .send({ url: marthaLiveEnv.dosUrls[0] })
+        .send({ url: marthaLiveEnv.drsUrls[0] })
         .expect(200)
         .end((err, response) => handleResponse(err, response, t, true));
 });
 
-test.cb('live_test martha_v2 responds with DOS object when "authorization" header is provided', (t) => {
+test.cb('live_test martha_v2 responds with DRS object when "authorization" header is provided', (t) => {
     supertest
         .post('/martha_v2')
         .set('Content-Type', 'application/json')
         .set('Authorization', `bearer ${bearerToken}`)
-        .send({ url: marthaLiveEnv.dosUrls[0] })
+        .send({ url: marthaLiveEnv.drsUrls[0] })
         .expect(200)
         .end((err, response) => handleResponse(err, response, t));
 });
 
-for (const dosUrl of marthaLiveEnv.dosUrls) {
-    test.cb(`live_test Calling martha_v2 with URL: "${dosUrl}" without an Access Token resolves to a DOS object`, (t) => {
+for (const drsUrl of marthaLiveEnv.drsUrls) {
+    test.cb(`live_test Calling martha_v2 with URL: "${drsUrl}" without an Access Token resolves to a DRS object`, (t) => {
         supertest
             .post('/martha_v2')
             .set('Content-Type', 'application/json')
-            .send({url: dosUrl})
+            .send({url: drsUrl})
             .expect(200)
             .end((err, response) => handleResponse(err, response, t, true));
     });

--- a/test/martha_v2/martha_v2_live.test.js
+++ b/test/martha_v2/martha_v2_live.test.js
@@ -16,9 +16,9 @@
  *
  *          env         - Can be one of ['dev', 'staging', 'alpha', 'perf', 'prod'].  Used to automatically determine
  *                        the `base_url`.  Defaults to `local`.
- *          mock        - If present or set to `true`, then tests will use DRS URLs that are resolvable by the mock-drs
- *                        service.  If `mock` is absent or set to `false`, tests will use DRS URLs resolvable by the
- *                        live/public DRS resolvers.
+ *          mock        - If present or set to `true`, then tests will use Data Object URLs that are resolvable by the mock-drs
+ *                        service.  If `mock` is absent or set to `false`, tests will use Data Object URLs resolvable by the
+ *                        live/public Data Object resolvers.
  *          base_url    - The base URL (protocol and host) where the Martha functions will be called.  Set this option
  *                        if you want to override the `base_url` derived from the `env` option.  Defaults to
  *                        `http://localhost:8010/broad-dsde-dev/us-central1`.
@@ -34,10 +34,10 @@ const execSync = require('child_process').execSync;
 let currentUser;
 let bearerToken;
 
-function assertDrsObject(response, t) {
-    t.truthy(response.body.drs);
-    const drsObject = response.body.drs;
-    t.truthy(drsObject.data_object);
+function assertDataObject(response, t) {
+    t.truthy(response.body.dos);
+    const dataObject = response.body.dos;
+    t.truthy(dataObject.data_object);
 }
 
 function assertGoogleServiceAccount(response, t) {
@@ -57,7 +57,7 @@ function handleResponse(err, response, t, skipGoogleServiceAccount = false) {
         }
         t.fail(msg);
     } else {
-        assertDrsObject(response, t);
+        assertDataObject(response, t);
         if (!skipGoogleServiceAccount) {
             assertGoogleServiceAccount(response, t);
         }
@@ -73,31 +73,31 @@ test.before(() => {
     console.log(`Martha settings: ${JSON.stringify(marthaLiveEnv)}`);
 });
 
-test.cb('live_test martha_v2 responds with DRS object only when no "authorization" header is provided', (t) => {
+test.cb('live_test martha_v2 responds with Data Object only when no "authorization" header is provided', (t) => {
     supertest
         .post('/martha_v2')
         .set('Content-Type', 'application/json')
-        .send({ url: marthaLiveEnv.drsUrls[0] })
+        .send({ url: marthaLiveEnv.dataObjectUrls[0] })
         .expect(200)
         .end((err, response) => handleResponse(err, response, t, true));
 });
 
-test.cb('live_test martha_v2 responds with DRS object when "authorization" header is provided', (t) => {
+test.cb('live_test martha_v2 responds with Data Object when "authorization" header is provided', (t) => {
     supertest
         .post('/martha_v2')
         .set('Content-Type', 'application/json')
         .set('Authorization', `bearer ${bearerToken}`)
-        .send({ url: marthaLiveEnv.drsUrls[0] })
+        .send({ url: marthaLiveEnv.dataObjectUrls[0] })
         .expect(200)
         .end((err, response) => handleResponse(err, response, t));
 });
 
-for (const drsUrl of marthaLiveEnv.drsUrls) {
-    test.cb(`live_test Calling martha_v2 with URL: "${drsUrl}" without an Access Token resolves to a DRS object`, (t) => {
+for (const dataObjectUrl of marthaLiveEnv.dataObjectUrls) {
+    test.cb(`live_test Calling martha_v2 with URL: "${dataObjectUrl}" without an Access Token resolves to a Data Object`, (t) => {
         supertest
             .post('/martha_v2')
             .set('Content-Type', 'application/json')
-            .send({url: drsUrl})
+            .send({url: dataObjectUrl})
             .expect(200)
             .end((err, response) => handleResponse(err, response, t, true));
     });


### PR DESCRIPTION
Perhaps biting off more than necessary, but I also refactored variables and such to refer to `dataObject` rather than `dos` or `drs`.  This is potentially out of scope, so if it turns out it's causing any issues, I'm going to roll it back and just make the protocol acceptance change.