### PR TITLE
For HCA return only the cloud native URL

### DIFF
--- a/common/helpers.js
+++ b/common/helpers.js
@@ -76,6 +76,7 @@ function dataObjectUriToHttps(dataObjectUri) {
 const BondProviders = Object.freeze({
     FENCE: 'fence',
     DCF_FENCE: 'dcf-fence',
+    HCA: 'hca', // Human Cell Atlas
     get default() {
         return this.DCF_FENCE;
     }
@@ -85,6 +86,8 @@ function determineBondProvider(urlString) {
     const url = URL.parse(urlString);
     if (url.host === 'dg.4503') {
         return BondProviders.FENCE;
+    } else if (url.host.endswith('.humancellatlas.org')) {
+        return BondProviders.HCA;
     } else {
         return BondProviders.default;
     }

--- a/common/helpers.js
+++ b/common/helpers.js
@@ -86,7 +86,7 @@ function determineBondProvider(urlString) {
     const url = URL.parse(urlString);
     if (url.host === 'dg.4503') {
         return BondProviders.FENCE;
-    } else if (url.host.endswith('.humancellatlas.org')) {
+    } else if (url.host.endsWith('.humancellatlas.org')) {
         return BondProviders.HCA;
     } else {
         return BondProviders.default;

--- a/fileSummaryV1/service_account_keys.js
+++ b/fileSummaryV1/service_account_keys.js
@@ -3,15 +3,19 @@ const apiAdapter = require('../common/api_adapter');
 
 function maybeTalkToBond(auth, url) {
     const provider = determineBondProvider(url);
-    return apiAdapter.getJsonFrom(
-        `${bondBaseUrl()}/api/link/v1/${provider}/serviceaccount/key`,
-        auth
-    ).then(
-        (res) => res.data
-    ).catch(() => {
-        console.error(new Error('Unable to retrieve Service Account Key from Bond'));
+    if (provider === BondProviders.HCA) {
         return Promise.resolve();
-    });
+    } else {
+        return apiAdapter.getJsonFrom(
+            `${bondBaseUrl()}/api/link/v1/${provider}/serviceaccount/key`,
+            auth
+        ).then(
+            (res) => res.data
+        ).catch(() => {
+            console.error(new Error('Unable to retrieve Service Account Key from Bond'));
+            return Promise.resolve();
+        });
+    }
 }
 
 function maybeTalkToSam(auth) {

--- a/fileSummaryV1/service_account_keys.js
+++ b/fileSummaryV1/service_account_keys.js
@@ -1,21 +1,22 @@
-const {bondBaseUrl, samBaseUrl, determineBondProvider} = require('../common/helpers');
+const {bondBaseUrl, samBaseUrl, determineBondProvider, BondProviders} = require('../common/helpers');
 const apiAdapter = require('../common/api_adapter');
 
 function maybeTalkToBond(auth, url) {
     const provider = determineBondProvider(url);
+
     if (provider === BondProviders.HCA) {
         return Promise.resolve();
-    } else {
-        return apiAdapter.getJsonFrom(
-            `${bondBaseUrl()}/api/link/v1/${provider}/serviceaccount/key`,
-            auth
-        ).then(
-            (res) => res.data
-        ).catch(() => {
-            console.error(new Error('Unable to retrieve Service Account Key from Bond'));
-            return Promise.resolve();
-        });
     }
+
+    return apiAdapter.getJsonFrom(
+        `${bondBaseUrl()}/api/link/v1/${provider}/serviceaccount/key`,
+        auth
+    ).then(
+        (res) => res.data
+    ).catch(() => {
+        console.error(new Error('Unable to retrieve Service Account Key from Bond'));
+        return Promise.resolve();
+    });
 }
 
 function maybeTalkToSam(auth) {

--- a/handlers/getSignedUrlV1.js
+++ b/handlers/getSignedUrlV1.js
@@ -1,5 +1,5 @@
 const { Storage } = require('@google-cloud/storage');
-const { getJsonFrom } = require('../common/api_adapter');
+const apiAdapter = require('../common/api_adapter');
 const { bondBaseUrl, promiseHandler, Response, samBaseUrl, determineBondProvider, BondProviders } = require('../common/helpers');
 
 const getSignedUrlV1 = promiseHandler(async (req) => {
@@ -8,10 +8,10 @@ const getSignedUrlV1 = promiseHandler(async (req) => {
     const provider = dataObjectUri && determineBondProvider(dataObjectUri);
     try {
         const credentials = (provider && provider !== BondProviders.HCA) ?
-            (await getJsonFrom(`${bondBaseUrl()}/api/link/v1/${provider}/serviceaccount/key`, auth)).data :
-            await getJsonFrom(`${samBaseUrl()}/api/google/v1/user/petServiceAccount/key`, auth);
+            (await apiAdapter.getJsonFrom(`${bondBaseUrl()}/api/link/v1/${provider}/serviceaccount/key`, auth)).data :
+            await apiAdapter.getJsonFrom(`${samBaseUrl()}/api/google/v1/user/petServiceAccount/key`, auth);
         const storage = new Storage({ credentials });
-        const [url] = await storage.bucket(bucket).file(object).getSignedUrl({
+        const url = await storage.bucket(bucket).file(object).getSignedUrl({
             version: 'v4',
             action: 'read',
             expires: Date.now() + 36e5

--- a/handlers/getSignedUrlV1.js
+++ b/handlers/getSignedUrlV1.js
@@ -1,13 +1,13 @@
 const { Storage } = require('@google-cloud/storage');
 const { getJsonFrom } = require('../common/api_adapter');
-const { bondBaseUrl, promiseHandler, Response, samBaseUrl, determineBondProvider } = require('../common/helpers');
+const { bondBaseUrl, promiseHandler, Response, samBaseUrl, determineBondProvider, BondProviders } = require('../common/helpers');
 
 const getSignedUrlV1 = promiseHandler(async (req) => {
     const { bucket, object, dataObjectUri } = req.body || {};
     const auth = req.headers.authorization;
     const provider = dataObjectUri && determineBondProvider(dataObjectUri);
     try {
-        const credentials = provider ?
+        const credentials = (provider && provider !== BondProviders.HCA) ?
             (await getJsonFrom(`${bondBaseUrl()}/api/link/v1/${provider}/serviceaccount/key`, auth)).data :
             await getJsonFrom(`${samBaseUrl()}/api/google/v1/user/petServiceAccount/key`, auth);
         const storage = new Storage({ credentials });

--- a/handlers/getSignedUrlV1.js
+++ b/handlers/getSignedUrlV1.js
@@ -11,7 +11,7 @@ const getSignedUrlV1 = promiseHandler(async (req) => {
             (await apiAdapter.getJsonFrom(`${bondBaseUrl()}/api/link/v1/${provider}/serviceaccount/key`, auth)).data :
             await apiAdapter.getJsonFrom(`${samBaseUrl()}/api/google/v1/user/petServiceAccount/key`, auth);
         const storage = new Storage({ credentials });
-        const url = await storage.bucket(bucket).file(object).getSignedUrl({
+        const [url] = await storage.bucket(bucket).file(object).getSignedUrl({
             version: 'v4',
             action: 'read',
             expires: Date.now() + 36e5

--- a/martha_v2/martha_v2.js
+++ b/martha_v2/martha_v2.js
@@ -13,7 +13,7 @@ function maybeTalkToBond(req, provider = BondProviders.default) {
     let myPromise;
     // Currently HCA data access does not require additional credentials.
     // The HCA checkout buckets allow object read access for GROUP_All_Users@firecloud.org.
-    if (req && req.headers && req.headers.authorization && provider != BondProviders.HCA) {
+    if (req && req.headers && req.headers.authorization && provider !== BondProviders.HCA) {
         myPromise = apiAdapter.getJsonFrom(`${bondBaseUrl()}/api/link/v1/${provider}/serviceaccount/key`, req.headers.authorization);
     } else {
         myPromise = Promise.resolve();

--- a/martha_v2/martha_v2.js
+++ b/martha_v2/martha_v2.js
@@ -11,7 +11,9 @@ function parseRequest(req) {
 
 function maybeTalkToBond(req, provider = BondProviders.default) {
     let myPromise;
-    if (req && req.headers && req.headers.authorization) {
+    // Currently HCA data access does not require additional credentials.
+    // The HCA checkout buckets allow object read access for GROUP_All_Users@firecloud.org.
+    if (req && req.headers && req.headers.authorization && provider != BondProviders.HCA) {
         myPromise = apiAdapter.getJsonFrom(`${bondBaseUrl()}/api/link/v1/${provider}/serviceaccount/key`, req.headers.authorization);
     } else {
         myPromise = Promise.resolve();

--- a/test/common/helpers.test.js
+++ b/test/common/helpers.test.js
@@ -105,6 +105,15 @@ test('determineBondProvider should be "fence" if the URL host is "dg.4503"', (t)
     t.is(determineBondProvider('drs://dg.4503/anything'), BondProviders.FENCE);
 });
 
-test('determineBondProvider should return the default BondProvider if the URL host is NOT "dg.4503"', (t) => {
+test('determineBondProvider should be "HCA" if the URL host ends with ".humancellatlas.org"', (t) => {
+    t.is(determineBondProvider('drs://someservice.humancellatlas.org'), BondProviders.HCA);
+});
+
+test('determineBondProvider should return the default BondProvider if the URL host does not end with ' +
+    'exactly ".humancellatlas.org"', (t) => {
+    t.is(determineBondProvider('drs://someservice.spoofhumancellatlas.org'), BondProviders.default);
+});
+
+test('determineBondProvider should return the default BondProvider if the URL host is NOT "dg.4503" or HCA', (t) => {
     t.is(determineBondProvider('drs://some-host/anything'), BondProviders.default);
 });

--- a/test/getSignedUrlV1/getSignedUrlV1.test.js
+++ b/test/getSignedUrlV1/getSignedUrlV1.test.js
@@ -51,7 +51,7 @@ test.serial.afterEach(() => {
 
 test.serial('Valid bucket and object(only) returns signed URL using SA key from SAM', async (t) => {
     getJsonFromApiStub.resolves(fakeSAKey);
-    getSignedUrlStub.resolves(fakeSignedUrl);
+    getSignedUrlStub.resolves([fakeSignedUrl]);
     const response = mockResponse();
     await getSignedUrlV1(mockRequest({
         body: {
@@ -67,7 +67,7 @@ test.serial('Valid bucket and object(only) returns signed URL using SA key from 
 
 test.serial('Valid bucket, object, and Data GUID dataObjectUri returns signed URL using SA key from Bond', async (t) => {
     getJsonFromApiStub.resolves(fakeSAKey);
-    getSignedUrlStub.resolves(fakeSignedUrl);
+    getSignedUrlStub.resolves([fakeSignedUrl]);
     const response = mockResponse();
     await getSignedUrlV1(mockRequest({
         body: {
@@ -84,7 +84,7 @@ test.serial('Valid bucket, object, and Data GUID dataObjectUri returns signed UR
 
 test.serial('Valid bucket, object, and HCA dataObjectUri returns signed URL using SA key from SAM', async (t) => {
     getJsonFromApiStub.resolves(fakeSAKey);
-    getSignedUrlStub.resolves(fakeSignedUrl);
+    getSignedUrlStub.resolves([fakeSignedUrl]);
     const response = mockResponse();
     await getSignedUrlV1(mockRequest({
         body: {

--- a/test/getSignedUrlV1/getSignedUrlV1.test.js
+++ b/test/getSignedUrlV1/getSignedUrlV1.test.js
@@ -1,0 +1,100 @@
+/**
+ * When writing/testing GCF functions, see:
+ * - https://cloud.google.com/functions/docs/monitoring/error-reporting
+ * - https://cloud.google.com/functions/docs/bestpractices/testing
+ *
+ * NOTE: Any tests in this file that rely on the before/after stubs need to be run sequentially, see:
+ * https://github.com/avajs/ava/issues/1066
+ */
+
+const test = require('ava');
+const sinon = require('sinon');
+const getSignedUrlV1 = require('../../handlers/getSignedUrlV1');
+const apiAdapter = require('../../common/api_adapter');
+const storageFile = require('@google-cloud/storage').File;
+
+const mockRequest = (req) => {
+    req.method = 'POST';
+    req.headers = {authorization: 'bearer abc123'};
+    return req;
+};
+
+const mockResponse = () => {
+    return {
+        status(s) {
+            this.statusCode = s;
+            return this;
+        },
+        send: sinon.stub(),
+        setHeader: sinon.stub()
+    };
+};
+
+const fakeSignedUrl = 'http://i.am.a.signed.url.com/totallyMadeUp';
+const fakeSAKey = {key: 'I am not real'};
+const bondSAKeyUrlRegEx = /^([^/]+)\/api\/link\/v1\/([a-z-]+)\/serviceaccount\/key$/;
+const samPetSAKeyUrlRegEx = /^.*\/user\/petServiceAccount\/key$/;
+
+let getJsonFromApiStub;
+let getSignedUrlStub;
+let sandbox = sinon.createSandbox();
+
+test.serial.beforeEach(() => {
+    sandbox.restore(); // If one test fails, the .afterEach() block will not execute, so always clean the slate here
+    getJsonFromApiStub = sandbox.stub(apiAdapter, 'getJsonFrom');
+    getSignedUrlStub = sandbox.stub(storageFile.prototype, 'getSignedUrl');
+});
+
+test.serial.afterEach(() => {
+    sandbox.restore();
+});
+
+test.serial('Valid bucket and object(only) returns signed URL using SA key from SAM', async (t) => {
+    getJsonFromApiStub.resolves(fakeSAKey);
+    getSignedUrlStub.resolves(fakeSignedUrl);
+    const response = mockResponse();
+    await getSignedUrlV1(mockRequest({
+        body: {
+            bucket: 'testBucket',
+            object: 'testObjectKey',
+        }
+    }), response);
+    t.regex(getJsonFromApiStub.firstCall.args[0], samPetSAKeyUrlRegEx); // User SA key obtained from SAM
+    t.is(response.statusCode, 200);
+    const result = response.send.lastCall.args[0];
+    t.is(fakeSignedUrl, result.url);
+});
+
+test.serial('Valid bucket, object, and Data GUID dataObjectUri returns signed URL using SA key from Bond', async (t) => {
+    getJsonFromApiStub.resolves(fakeSAKey);
+    getSignedUrlStub.resolves(fakeSignedUrl);
+    const response = mockResponse();
+    await getSignedUrlV1(mockRequest({
+        body: {
+            bucket: 'testBucket',
+            object: 'testObjectKey',
+            dataObjectUri: 'drs://dg.4503/this_part_can_be_anything'
+        }
+    }), response);
+    t.regex(getJsonFromApiStub.firstCall.args[0], bondSAKeyUrlRegEx); // User SA key obtained from Bond/Fence
+    t.is(response.statusCode, 200);
+    const result = response.send.lastCall.args[0];
+    t.is(fakeSignedUrl, result.url);
+});
+
+test.serial('Valid bucket, object, and HCA dataObjectUri returns signed URL using SA key from SAM', async (t) => {
+    getJsonFromApiStub.resolves(fakeSAKey);
+    getSignedUrlStub.resolves(fakeSignedUrl);
+    const response = mockResponse();
+    await getSignedUrlV1(mockRequest({
+        body: {
+            bucket: 'testBucket',
+            object: 'testObjectKey',
+            dataObjectUri: 'drs://someservice.humancellatlas.org/this_part_can_be_anything'
+        }
+    }), response);
+    t.regex(getJsonFromApiStub.firstCall.args[0], samPetSAKeyUrlRegEx); // User SA key obtained from SAM
+    t.is(response.statusCode, 200);
+    const result = response.send.lastCall.args[0];
+    t.is(fakeSignedUrl, result.url);
+});

--- a/test/martha_v2/martha_v2.test.js
+++ b/test/martha_v2/martha_v2.test.js
@@ -142,3 +142,13 @@ test.serial('martha_v2 calls bond Bond with the "fence" provider when the Data O
     const actualProvider = matches[2];
     t.is(actualProvider, expectedProvider);
 });
+
+test.serial('martha_v2 does not call Bond or return SA key when the Data Object URL host endswith ".humancellatlas.org', async (t) => {
+    const response = mockResponse();
+    await martha_v2(mockRequest({ body: { 'url': 'drs://someservice.humancellatlas.org/this_part_can_be_anything' } }), response);
+    const result = response.send.lastCall.args[0];
+    t.true(getJsonFromApiStub.calledOnce); // Bond was not called to get SA key
+    t.deepEqual(result.dos, dataObject);
+    t.is(result.googleServiceAccount, undefined);
+    t.is(response.statusCode, 200);
+});

--- a/test/martha_v2/martha_v2.test.js
+++ b/test/martha_v2/martha_v2.test.js
@@ -149,6 +149,6 @@ test.serial('martha_v2 does not call Bond or return SA key when the Data Object 
     const result = response.send.lastCall.args[0];
     t.true(getJsonFromApiStub.calledOnce); // Bond was not called to get SA key
     t.deepEqual(result.dos, dataObject);
-    t.is(result.googleServiceAccount, undefined);
+    t.falsy(result.googleServiceAccount);
     t.is(response.statusCode, 200);
 });


### PR DESCRIPTION
Currently, all Human Cell Atlas (HCA) is open access, and
no user-specific access control is performed.
The HCA checkout buckets, from which the data is accessed,
grant object read permission to GROUP_All_Users@firecloud.org,
so no additional credentials are required or available.
Therefore, for HCA data access, return only
the cloud-native URL, and bypass the request to Bond.
Both the `martha_v2` and `fileSummaryV1` endpoints have been updated to support this behavior.

The new `getSignedUrlV1` endpoint has been updated to obtain a user pet SA key from SAM for HCA DRS URIs.

The unit tests have been augmented to cover the "happy path" through all functional code changes, and most other paths are already covered by existing tests.

For more information, please see: [Terra/Cromwell Access to Files Identified by DRS URIs for the HCA/Terra MVP](https://docs.google.com/document/d/18WDYr3uS82Eu1GhHmeH6PX7tFY6Zk8piKd3ixOoE8Bg)

Resolves DataBiosphere/azul#982.
Partially resolves DataBiosphere/azul#1090, as changes to Cromwell are also needed for that one.

