### PR TITLE
Support for STAGE 

### DIFF
--- a/common/helpers.js
+++ b/common/helpers.js
@@ -48,6 +48,18 @@ function determinePathname(someUrl) {
     }
 }
 
+/**
+ * URI Scheme and Host parts are case insensitive:  https://stackoverflow.com/questions/15641694/are-uris-case-insensitive
+ * When parsing a DOS URI into a resolvable HTTP URL, we use the Host part from the DOS URI in the Path part of the
+ * resolution URL and that requires that the case be preserved.
+ * @param parsedUrl
+ * @param rawUrl
+ */
+function preserveHostnameCase(parsedUrl, rawUrl) {
+    const hostnameRegExp = new RegExp(parsedUrl.hostname, 'i');
+    parsedUrl.hostname = hostnameRegExp.exec(rawUrl)[0]
+}
+
 // 3 Scenarios we need to account for:
 //      1. host part starts with "dg."
 //      2. host part DOES NOT start with "dg." AND path part is FALSY
@@ -57,6 +69,8 @@ function dataObjectUriToHttps(dataObjectUri) {
     if (parsedUrl.pathname === '/') {
         parsedUrl.pathname = null;
     }
+
+    preserveHostnameCase(parsedUrl, dataObjectUri);
 
     validateDataObjectUrl(parsedUrl);
 

--- a/common/helpers.js
+++ b/common/helpers.js
@@ -96,9 +96,15 @@ const BondProviders = Object.freeze({
     }
 });
 
+const PROD_DATASTAGE_NAMESPACE    = 'dg.4503';
+const STAGING_DATASTAGE_NAMESPACE = 'dg.712c';
+const DATASTAGE_NAMESPACES = [PROD_DATASTAGE_NAMESPACE, STAGING_DATASTAGE_NAMESPACE];
+
+// We are explicitly listing the DOS/DRS host/namespaces here for both production and staging environments.
+// At some point we expect to have a more sophisticated way to do this, but for now, we have to do it this way.
 function determineBondProvider(urlString) {
     const url = URL.parse(urlString);
-    if (url.host === 'dg.4503') {
+    if (DATASTAGE_NAMESPACES.includes(url.hostname.toLowerCase())) {
         return BondProviders.FENCE;
     } else if (url.host.endsWith('.humancellatlas.org')) {
         return BondProviders.HCA;

--- a/config.json.ctmpl
+++ b/config.json.ctmpl
@@ -3,7 +3,7 @@
 {{with $dnsDomain := env "DNS_DOMAIN"}}
 
 {
-    "dataObjectResolutionHost": {{if eq $runContext "fiab"}}"wb-mock-drs-dev.storage.googleapis.com"{{else if eq $environment "prod"}}"datastage.io"{{else}}"staging.datastage.io"{{end}},
+    "dataObjectResolutionHost": {{if eq $runContext "fiab"}}"wb-mock-drs-dev.storage.googleapis.com"{{else if eq $environment "prod"}}"gen3.datastage.io"{{else}}"staging.datastage.io"{{end}},
     "bondBaseUrl": {{if eq $runContext "fiab"}}"bond-fiab.{{$dnsDomain}}"{{else}}"broad-bond-{{$environment}}.appspot.com"{{end}},
     "samBaseUrl": {{if eq $runContext "fiab"}}"https://sam-fiab.{{$dnsDomain}}"{{else}}"https://sam.dsde-{{$environment}}.broadinstitute.org"{{end}}
 }

--- a/config.json.ctmpl
+++ b/config.json.ctmpl
@@ -3,7 +3,7 @@
 {{with $dnsDomain := env "DNS_DOMAIN"}}
 
 {
-    "dataObjectResolutionHost": {{if eq $runContext "fiab"}}"wb-mock-drs-dev.storage.googleapis.com"{{else if eq $environment "prod"}}"datastage.io"{{else}}"staging.dataguids.org"{{end}},
+    "dataObjectResolutionHost": {{if eq $runContext "fiab"}}"wb-mock-drs-dev.storage.googleapis.com"{{else if eq $environment "prod"}}"datastage.io"{{else}}"staging.datastage.io"{{end}},
     "bondBaseUrl": {{if eq $runContext "fiab"}}"bond-fiab.{{$dnsDomain}}"{{else}}"broad-bond-{{$environment}}.appspot.com"{{end}},
     "samBaseUrl": {{if eq $runContext "fiab"}}"https://sam-fiab.{{$dnsDomain}}"{{else}}"https://sam.dsde-{{$environment}}.broadinstitute.org"{{end}}
 }

--- a/config.json.ctmpl
+++ b/config.json.ctmpl
@@ -3,7 +3,7 @@
 {{with $dnsDomain := env "DNS_DOMAIN"}}
 
 {
-    "dataObjectResolutionHost": {{if or (eq $runContext "fiab") (eq $environment "dev")}}"wb-mock-drs-dev.storage.googleapis.com"{{else}}"dataguids.org"{{end}},
+    "dataObjectResolutionHost": {{if eq $runContext "fiab"}}"wb-mock-drs-dev.storage.googleapis.com"{{else if eq $environment "dev"}}"https://staging.datastage.io"{{else}}"dataguids.org"{{end}},
     "bondBaseUrl": {{if eq $runContext "fiab"}}"bond-fiab.{{$dnsDomain}}"{{else}}"broad-bond-{{$environment}}.appspot.com"{{end}},
     "samBaseUrl": {{if eq $runContext "fiab"}}"https://sam-fiab.{{$dnsDomain}}"{{else}}"https://sam.dsde-{{$environment}}.broadinstitute.org"{{end}}
 }

--- a/config.json.ctmpl
+++ b/config.json.ctmpl
@@ -3,7 +3,7 @@
 {{with $dnsDomain := env "DNS_DOMAIN"}}
 
 {
-    "dataObjectResolutionHost": {{if eq $runContext "fiab"}}"wb-mock-drs-dev.storage.googleapis.com"{{else if eq $environment "dev"}}"staging.datastage.io"{{else}}"dataguids.org"{{end}},
+    "dataObjectResolutionHost": {{if eq $runContext "fiab"}}"staging.datastage.io"{{else if eq $environment "dev"}}"staging.datastage.io"{{else}}"dataguids.org"{{end}},
     "bondBaseUrl": {{if eq $runContext "fiab"}}"bond-fiab.{{$dnsDomain}}"{{else}}"broad-bond-{{$environment}}.appspot.com"{{end}},
     "samBaseUrl": {{if eq $runContext "fiab"}}"https://sam-fiab.{{$dnsDomain}}"{{else}}"https://sam.dsde-{{$environment}}.broadinstitute.org"{{end}}
 }

--- a/config.json.ctmpl
+++ b/config.json.ctmpl
@@ -3,7 +3,7 @@
 {{with $dnsDomain := env "DNS_DOMAIN"}}
 
 {
-    "dataObjectResolutionHost": {{if eq $runContext "fiab"}}"wb-mock-drs-dev.storage.googleapis.com"{{else if eq $environment "dev"}}"staging.datastage.io"{{else}}"dataguids.org"{{end}},
+    "dataObjectResolutionHost": {{if eq $runContext "fiab"}}"wb-mock-drs-dev.storage.googleapis.com"{{else if eq $environment "prod"}}"datastage.io"{{else}}"staging.dataguids.org"{{end}},
     "bondBaseUrl": {{if eq $runContext "fiab"}}"bond-fiab.{{$dnsDomain}}"{{else}}"broad-bond-{{$environment}}.appspot.com"{{end}},
     "samBaseUrl": {{if eq $runContext "fiab"}}"https://sam-fiab.{{$dnsDomain}}"{{else}}"https://sam.dsde-{{$environment}}.broadinstitute.org"{{end}}
 }

--- a/config.json.ctmpl
+++ b/config.json.ctmpl
@@ -3,7 +3,7 @@
 {{with $dnsDomain := env "DNS_DOMAIN"}}
 
 {
-    "dataObjectResolutionHost": {{if eq $runContext "fiab"}}"staging.datastage.io"{{else if eq $environment "dev"}}"staging.datastage.io"{{else}}"dataguids.org"{{end}},
+    "dataObjectResolutionHost": {{if eq $runContext "fiab"}}"wb-mock-drs-dev.storage.googleapis.com"{{else if eq $environment "dev"}}"staging.datastage.io"{{else}}"dataguids.org"{{end}},
     "bondBaseUrl": {{if eq $runContext "fiab"}}"bond-fiab.{{$dnsDomain}}"{{else}}"broad-bond-{{$environment}}.appspot.com"{{end}},
     "samBaseUrl": {{if eq $runContext "fiab"}}"https://sam-fiab.{{$dnsDomain}}"{{else}}"https://sam.dsde-{{$environment}}.broadinstitute.org"{{end}}
 }

--- a/config.json.ctmpl
+++ b/config.json.ctmpl
@@ -3,7 +3,7 @@
 {{with $dnsDomain := env "DNS_DOMAIN"}}
 
 {
-    "dataObjectResolutionHost": {{if eq $runContext "fiab"}}"wb-mock-drs-dev.storage.googleapis.com"{{else if eq $environment "dev"}}"https://staging.datastage.io"{{else}}"dataguids.org"{{end}},
+    "dataObjectResolutionHost": {{if eq $runContext "fiab"}}"wb-mock-drs-dev.storage.googleapis.com"{{else if eq $environment "dev"}}"staging.datastage.io"{{else}}"dataguids.org"{{end}},
     "bondBaseUrl": {{if eq $runContext "fiab"}}"bond-fiab.{{$dnsDomain}}"{{else}}"broad-bond-{{$environment}}.appspot.com"{{end}},
     "samBaseUrl": {{if eq $runContext "fiab"}}"https://sam-fiab.{{$dnsDomain}}"{{else}}"https://sam.dsde-{{$environment}}.broadinstitute.org"{{end}}
 }

--- a/test/common/helpers.test.js
+++ b/test/common/helpers.test.js
@@ -10,7 +10,6 @@ test('dataObjectUriToHttps should parse dos:// Data Object uri', (t) => {
 });
 
 test('dataObjectUriToHttps should parse dos:// Data Object uri and preserve case', (t) => {
-    console.log("I am the test here!!!!");
     t.is(dataObjectUriToHttps('dos://FoO/BAR'), 'https://FoO/ga4gh/dos/v1/dataobjects/BAR');
 });
 

--- a/test/common/helpers.test.js
+++ b/test/common/helpers.test.js
@@ -113,6 +113,14 @@ test('determineBondProvider should be "fence" if the URL host is "dg.4503"', (t)
     t.is(determineBondProvider('drs://dg.4503/anything'), BondProviders.FENCE);
 });
 
+test('determineBondProvider should be "fence" if the URL host is "dg.712C"', (t) => {
+    t.is(determineBondProvider('drs://dg.712C/anything'), BondProviders.FENCE);
+});
+
+test('determineBondProvider should be "dcf-fence" if the URL host is "dg.foo"', (t) => {
+    t.is(determineBondProvider('drs://dg.foo/anything'), BondProviders.DCF_FENCE);
+});
+
 test('determineBondProvider should be "HCA" if the URL host ends with ".humancellatlas.org"', (t) => {
     t.is(determineBondProvider('drs://someservice.humancellatlas.org'), BondProviders.HCA);
 });

--- a/test/common/helpers.test.js
+++ b/test/common/helpers.test.js
@@ -9,6 +9,11 @@ test('dataObjectUriToHttps should parse dos:// Data Object uri', (t) => {
     t.is(dataObjectUriToHttps('dos://foo/bar'), 'https://foo/ga4gh/dos/v1/dataobjects/bar');
 });
 
+test('dataObjectUriToHttps should parse dos:// Data Object uri and preserve case', (t) => {
+    console.log("I am the test here!!!!");
+    t.is(dataObjectUriToHttps('dos://FoO/BAR'), 'https://FoO/ga4gh/dos/v1/dataobjects/BAR');
+});
+
 test('dataObjectUriToHttps should parse drs:// Data Object uri', (t) => {
     t.is(dataObjectUriToHttps('drs://foo/bar'), 'https://foo/ga4gh/dos/v1/dataobjects/bar');
 });
@@ -33,6 +38,10 @@ test('dataObjectUriToHttps should parse drs:// Data Object uri when host include
  */
 test('dataObjectUriToHttps should parse "dos://dg." Data Object uri to use dataObjectResolutionHost', (t) => {
     t.is(dataObjectUriToHttps('dos://dg.2345/bar'), `https://${config.dataObjectResolutionHost}/ga4gh/dos/v1/dataobjects/dg.2345/bar`);
+});
+
+test('dataObjectUriToHttps should parse "dos://dg." Data Object uri to use dataObjectResolutionHost and preserve case', (t) => {
+    t.is(dataObjectUriToHttps('dos://dg.2345AbCdE/bAr'), `https://${config.dataObjectResolutionHost}/ga4gh/dos/v1/dataobjects/dg.2345AbCdE/bAr`);
 });
 
 test('dataObjectUriToHttps should parse "drs://dg." Data Object uri to use dataObjectResolutionHost', (t) => {


### PR DESCRIPTION
Changed config so that Martha dev uses `staging.datastage.io` as the default DOS resolver.  Production still uses `dataguids.org`.  

@abaumann - What should the resolution hosts be? 
1. Should production be `datastage.io`?  Or `dataguids.org`?
2. Should we allow for both?  For example, today, we have conditional logic to determine the DOS Resolver host here: https://github.com/broadinstitute/martha/blob/3b9298f5a90180c55f659e023ccd43082e3a5e51/common/helpers.js#L39 . Should this be augmented/changed to support `datastage.io` AND `dataguids.org`?  If so, how?