### PR TITLE
WA-125 Modify Martha integration tests to not rely on particular status codes from Bond.

### DIFF
--- a/test/martha_v2/integration_v2.test.js
+++ b/test/martha_v2/integration_v2.test.js
@@ -85,8 +85,7 @@ test.cb('integration_v2 fails when "authorization" header is provided for a publ
         .set('Authorization', `Bearer ${unauthorizedToken}`)
         .send({ url: publicFenceUrl })
         .expect((response) => {
-            assert.strictEqual(response.statusCode, 502, 'Incorrect status code');
-            assert.strictEqual(response.body.status, 400, 'User should not be authorized with provider');
+            assert.strictEqual(response.statusCode, 502, 'User should not be authorized with provider');
         })
         .end((error, response) => {
             if (error) { t.log(response.body); }
@@ -101,8 +100,7 @@ test.cb('integration_v2 fails when "authorization" header is provided for a publ
         .set('Authorization', `Bearer badToken`)
         .send({ url: publicFenceUrl })
         .expect((response) => {
-            assert.strictEqual(response.statusCode, 502, 'Incorrect status code');
-            assert.strictEqual(response.body.status, 401, 'Bond should not have authenticated this token');
+            assert.strictEqual(response.statusCode, 502, 'Bond should not have authenticated this token');
         })
         .end((error, response) => {
             if (error) { t.log(response.body); }
@@ -150,8 +148,7 @@ test.cb('integration_v2 fails when "authorization" header is provided for a prot
         .set('Authorization', `Bearer ${unauthorizedToken}`)
         .send({ url: protectedFenceUrl })
         .expect((response) => {
-            assert.strictEqual(response.statusCode, 502, 'Incorrect status code');
-            assert.strictEqual(response.body.status, 400, 'User should not be authorized with provider');
+            assert.strictEqual(response.statusCode, 502, 'User should not be authorized with provider');
         })
         .end((error, response) => {
             if (error) { t.log(response.body); }
@@ -166,8 +163,7 @@ test.cb('integration_v2 fails when "authorization" header is provided for a prot
         .set('Authorization', 'Bearer badToken')
         .send({ url: protectedFenceUrl })
         .expect((response) => {
-            assert.strictEqual(response.statusCode, 502, 'Incorrect status code');
-            assert.strictEqual(response.body.status, 401, 'Bond should not have authenticated this token');
+            assert.strictEqual(response.statusCode, 502, 'Bond should not have authenticated this token');
         })
         .end((error, response) => {
             if (error) { t.log(response.body); }


### PR DESCRIPTION
Martha does not care what error code Bond returns other than these integration tests. We can have the tests be less brittle to changes in error codes and just verify that the requests fail in these casees. Fixing this now as these integration tests are failing due to changes in Bond error codes.