### PR TITLE
Better error handling and additional logging [WA-128]

### DIFF
--- a/common/api_adapter.js
+++ b/common/api_adapter.js
@@ -39,8 +39,8 @@ async function getJsonFrom(url, authorization, retryAttempt = 1, delay = INITIAL
          and throwing it in `try` is so that it can be caught locally and be retried.
          */
         if (Object.keys(body).length === 0) {
-            console.log(`Received an empty JSON body while trying to resolve url '${url}'. Creating a response with ` +
-            'status 500 and will retry.');
+            console.log(`Received an empty JSON body while trying to resolve url '${url}'. Attempt ${retryAttempt}. ` +
+                'Creating a response with status 500.');
 
             const errorMsg = `Something went wrong while trying to resolve url '${url}'. It came back with empty JSON body!`;
             const errorResponseObj = {

--- a/common/api_adapter.js
+++ b/common/api_adapter.js
@@ -40,7 +40,7 @@ async function getJsonFrom(url, authorization, retryAttempt = 1, delay = INITIAL
          */
         if (Object.keys(body).length === 0) {
             console.log(`Received an empty JSON body while trying to resolve url '${url}'. Creating a response with ` +
-            `status 500 and will retry.`);
+            'status 500 and will retry.');
 
             const errorMsg = `Something went wrong while trying to resolve url '${url}'. It came back with empty JSON body!`;
             const errorResponseObj = {
@@ -51,7 +51,7 @@ async function getJsonFrom(url, authorization, retryAttempt = 1, delay = INITIAL
             };
             throw new Response(500, errorResponseObj);
         }
-        else return body;
+        else { return body; }
     } catch (error) {
         // TODO: capture error on lines 56 and 58 in order to give a more detailed idea of
         //  what went wrong where (see https://broadworkbench.atlassian.net/browse/WA-13)

--- a/common/api_adapter.js
+++ b/common/api_adapter.js
@@ -51,7 +51,10 @@ async function getJsonFrom(url, authorization, retryAttempt = 1, delay = INITIAL
             };
             throw new Response(500, errorResponseObj);
         }
-        else { return body; }
+        else {
+            console.log(`Successfully received response from url '${url}'.`);
+            return body;
+        }
     } catch (error) {
         // TODO: capture error on lines 56 and 58 in order to give a more detailed idea of
         //  what went wrong where (see https://broadworkbench.atlassian.net/browse/WA-13)

--- a/common/helpers.js
+++ b/common/helpers.js
@@ -83,7 +83,7 @@ function dataObjectUriToHttps(dataObjectUri) {
     };
 
     const output = url.format(resolutionUrlParts);
-    console.log(`${dataObjectUri} -> ${output}`);
+    console.log(`Converting DRS URI to HTTPS: ${dataObjectUri} -> ${output}`);
     return output;
 }
 

--- a/martha_v2/martha_v2.js
+++ b/martha_v2/martha_v2.js
@@ -14,11 +14,7 @@ async function maybeTalkToBond(req, provider = BondProviders.default) {
     // The HCA checkout buckets allow object read access for GROUP_All_Users@firecloud.org.
     if (req && req.headers && req.headers.authorization && provider !== BondProviders.HCA) {
         try {
-            const {body} = await apiAdapter.getJsonFrom(
-                `${bondBaseUrl()}/api/link/v1/${provider}/serviceaccount/key`,
-                req.headers.authorization
-            );
-            return body;
+            return await apiAdapter.getJsonFrom(`${bondBaseUrl()}/api/link/v1/${provider}/serviceaccount/key`, req.headers.authorization);
         } catch (error) {
             console.log(`Received error while fetching service account from Bond for provider '${provider}'.`);
             console.error(error);
@@ -67,7 +63,7 @@ function martha_v2_handler(req, res) {
             res.status(200).send(aggregateResponses(rawResults));
         })
         .catch((err) => {
-            console.log('martha_v2: Received error while either contacting Bond or resolving drs url.');
+            console.log('Received error while either contacting Bond or resolving drs url.');
             console.error(err);
             res.status(502).send(err);
         });

--- a/martha_v2/martha_v2.js
+++ b/martha_v2/martha_v2.js
@@ -9,16 +9,24 @@ function parseRequest(req) {
     }
 }
 
-function maybeTalkToBond(req, provider = BondProviders.default) {
-    let myPromise;
+async function maybeTalkToBond(req, provider = BondProviders.default) {
     // Currently HCA data access does not require additional credentials.
     // The HCA checkout buckets allow object read access for GROUP_All_Users@firecloud.org.
     if (req && req.headers && req.headers.authorization && provider !== BondProviders.HCA) {
-        myPromise = apiAdapter.getJsonFrom(`${bondBaseUrl()}/api/link/v1/${provider}/serviceaccount/key`, req.headers.authorization);
+        try {
+            const {body} = await apiAdapter.getJsonFrom(
+                `${bondBaseUrl()}/api/link/v1/${provider}/serviceaccount/key`,
+                req.headers.authorization
+            );
+            return body;
+        } catch (error) {
+            console.log(`Received error while fetching service account from Bond for provider '${provider}'.`);
+            console.error(error);
+            throw error;
+        }
     } else {
-        myPromise = Promise.resolve();
+        return Promise.resolve();
     }
-    return myPromise;
 }
 
 function aggregateResponses(responses) {
@@ -59,6 +67,7 @@ function martha_v2_handler(req, res) {
             res.status(200).send(aggregateResponses(rawResults));
         })
         .catch((err) => {
+            console.log(`martha_v2: Received error while either contacting Bond or resolving drs url.`);
             console.error(err);
             res.status(502).send(err);
         });

--- a/martha_v2/martha_v2.js
+++ b/martha_v2/martha_v2.js
@@ -67,7 +67,7 @@ function martha_v2_handler(req, res) {
             res.status(200).send(aggregateResponses(rawResults));
         })
         .catch((err) => {
-            console.log(`martha_v2: Received error while either contacting Bond or resolving drs url.`);
+            console.log('martha_v2: Received error while either contacting Bond or resolving drs url.');
             console.error(err);
             res.status(502).send(err);
         });

--- a/package-lock.json
+++ b/package-lock.json
@@ -273,7 +273,7 @@
     "@types/events": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@types/events/-/events-3.0.0.tgz",
-      "integrity": "sha512-EaObqwIvayI5a8dCzhFrjKzVwKLxjoG9T6Ppd5CEo07LRKfQ8Yokw54r5+Wq7FaBQ+yXRvQAYPrHwya1/UFt9g==",
+      "integrity": "sha1-KGLz9Yqaf3w+eNefEw3U1xwlwqc=",
       "dev": true
     },
     "@types/form-data": {
@@ -287,7 +287,7 @@
     "@types/glob": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.1.1.tgz",
-      "integrity": "sha512-1Bh06cbWJUHMC97acuD6UMG29nMt0Aqz1vF3guLfG+kHHJhy3AyohZFFxYk2f7Q1SQIrNwvncxAE0N/9s70F2w==",
+      "integrity": "sha1-qlmhxuP7xCHgfM0xqUTDDrpSFXU=",
       "dev": true,
       "requires": {
         "@types/events": "*",
@@ -298,7 +298,7 @@
     "@types/minimatch": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.3.tgz",
-      "integrity": "sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA==",
+      "integrity": "sha1-PcoOPzOyAPx9ETnAzZbBJoyt/Z0=",
       "dev": true
     },
     "@types/node": {
@@ -1147,7 +1147,7 @@
         "ms": {
           "version": "2.1.2",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "integrity": "sha1-0J0fNXtEP0kzgqjrPM0YOHKuYAk=",
           "dev": true
         }
       }
@@ -1170,7 +1170,7 @@
     "deep-extend": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
-      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+      "integrity": "sha1-xPp8lUBKF6nD6Mp+FTcxK3NjMKw=",
       "dev": true
     },
     "defaults": {
@@ -1948,7 +1948,7 @@
     "is-error": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/is-error/-/is-error-2.2.2.tgz",
-      "integrity": "sha512-IOQqts/aHWbiisY5DuPJQ0gcbvaLFCa7fBa9xoLfxBZvQ+ZI/Zh9xoI7Gk+G64N0FdK4AbibytHht2tWgpJWLg==",
+      "integrity": "sha1-wQreGHs8k1EMVHClVngz7iVkmEM=",
       "dev": true
     },
     "is-extglob": {
@@ -1966,7 +1966,7 @@
     "is-glob": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
-      "integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
+      "integrity": "sha1-dWfb6fL14kZ7x3q4PEopSCQHpdw=",
       "dev": true,
       "requires": {
         "is-extglob": "^2.1.1"
@@ -2079,7 +2079,7 @@
     "js-yaml": {
       "version": "3.13.1",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
-      "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
+      "integrity": "sha1-r/FRswv9+o5J4F2iLnQV6d+jeEc=",
       "dev": true,
       "requires": {
         "argparse": "^1.0.7",
@@ -2583,7 +2583,7 @@
     "p-try": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
-      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+      "integrity": "sha1-yyhoVA4xPWHeWPr741zpAE1VQOY=",
       "dev": true
     },
     "package-json": {
@@ -2619,7 +2619,7 @@
     "parse-ms": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/parse-ms/-/parse-ms-2.1.0.tgz",
-      "integrity": "sha512-kHt7kzLoS9VBZfUsiKjv43mr91ea+U05EyKkEtqp7vNbHxmaVuEqN7XxeEVnGrMtYOAxGrDElSi96K7EgO1zCA==",
+      "integrity": "sha1-NIVlp1PUOR+lJAKZVrFyy3dTCX0=",
       "dev": true
     },
     "path-exists": {
@@ -2677,13 +2677,13 @@
     "pify": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
-      "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
+      "integrity": "sha1-SyzSXFDVmHNcUCkiJP2MbfQeMjE=",
       "dev": true
     },
     "pkg-conf": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/pkg-conf/-/pkg-conf-3.1.0.tgz",
-      "integrity": "sha512-m0OTbR/5VPNPqO1ph6Fqbj7Hv6QU7gR/tQW40ZqrL1rjgCU85W6C1bJn0BItuJqnR98PWzw7Z8hHeChD1WrgdQ==",
+      "integrity": "sha1-2fnHXqG64Od5OM3gRbJ22sfMaa4=",
       "dev": true,
       "requires": {
         "find-up": "^3.0.0",
@@ -2810,7 +2810,7 @@
     "rc": {
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
-      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+      "integrity": "sha1-zZJL9SAKB1uDwYjNa54hG3/A0+0=",
       "dev": true,
       "requires": {
         "deep-extend": "^0.6.0",
@@ -3529,7 +3529,7 @@
     "type-fest": {
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.3.1.tgz",
-      "integrity": "sha512-cUGJnCdr4STbePCgqNFbpVNCepa+kAVohJs1sLhxzdH+gnEoOd8VhbYa7pD3zZYGiURWM2xzEII3fQcRizDkYQ==",
+      "integrity": "sha1-Y9ANIE4FlHT+Xht8ARESu9HcKeE=",
       "dev": true
     },
     "typedarray": {


### PR DESCRIPTION
This PR closes: https://broadworkbench.atlassian.net/browse/WA-128

In case that Martha receives an empty JSON body from Bond or the external DRS Resolver, it will catch it, and create a new response with status 500 so that it can be retired. The final response that is returned upstream will be this (for now), which is similar to the format when Martha receives 401 or 404. 
```
{
    "status": 500,
    "data": {
        "response": {
            "status": 500,
            "text": "Something went wrong while trying to resolve url '127.0.0.1:8080/api/link/v1/dcf-fence/serviceaccount/key'. It came back with empty JSON body!"
        }
    }
}
```
This response should be standardized in `martha_v3` as part of ticket [Martha V3: Decide and implement a standard response schema](https://broadworkbench.atlassian.net/browse/WA-160).