### PR TITLE
Jade Data Repo integration DRS v1.0 prefix [WA-178]

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,9 @@ the underlying resource. The Google Service Account information will only be inc
 Staging: https://us-central1-broad-dsde-staging.cloudfunctions.net/martha_v2
 Production: https://us-central1-broad-dsde-prod.cloudfunctions.net/martha_v2
 
+# Martha v3
+Currently is in development stage. Please do not use it.
+
 # File Summary v1
 The file summary service will return metadata and a signed download URL good for one hour (in the case of a DOS URI,
 only if the caller is linked in Bond).

--- a/common/helpers.js
+++ b/common/helpers.js
@@ -2,10 +2,23 @@ const url = require('url');
 const config = require('../config.json');
 
 const dataGuidsHostPrefix = 'dg.';
-const dataObjectPathPrefix = '/ga4gh/dos/v1/dataobjects/';
+const dosDataObjectPathPrefix = '/ga4gh/dos/v1/dataobjects/';
+const drsDataObjectPathPrefix = '/ga4gh/drs/v1/objects/';
+const jadeDataRepoHostRegex = /jade(-terra)?.datarepo-(dev|prod).broadinstitute.org/;
+
+// Regex drops any leading or trailing "/" characters and gives the path out of capture group 1
+const pathSlashRegex = /^\/?([^/]+.*?)\/?$/;
+
+const samBaseUrl = () => config.samBaseUrl;
+const jadeDataRepoUrl = () => config.jadeDataRepoBaseUrl;
+
 
 function hasDataGuidsHost(someUrl) {
     return someUrl.host.startsWith(dataGuidsHostPrefix);
+}
+
+function hasJadeDataRepoHost(someUrl) {
+    return someUrl.host === jadeDataRepoUrl();
 }
 
 function isDataGuidsUrl(someUrl) {
@@ -13,13 +26,23 @@ function isDataGuidsUrl(someUrl) {
 }
 
 function validateDataObjectUrl(someUrl) {
-    if (hasDataGuidsHost(someUrl) && !someUrl.pathname) {
-        throw new Error(`Data Object URIs with '${dataGuidsHostPrefix}*' host are required to have a path: "${url.format(someUrl)}"`);
+    const hasJDRHost = hasJadeDataRepoHost(someUrl);
+
+    if ((hasDataGuidsHost(someUrl) || hasJDRHost) && !someUrl.pathname) {
+        throw new Error(`Data Object URIs with either '${dataGuidsHostPrefix}*' or '${jadeDataRepoUrl()}' as host are required to have a path: "${url.format(someUrl)}"`);
+    }
+
+    /*
+        This is to notify the user that they have passed data object with a JDR host not supported in this env. If we don't check this condition,
+        then in `determinePathname` function, since the host will not match to the JDR host supported by this env, it will form the HTTPS url with
+        dosDataObjectPathPrefix i.e https://jade-data-repo-host/ga4gh/dos/v1/dataobjects/url-here, and contact JDR eventually which will result in
+        an error. And it might be difficult for the user to understand the cause of this error.
+     */
+    if (jadeDataRepoHostRegex.test(someUrl.host) && !hasJDRHost) {
+        throw new Error(`Data Object URI belongs to a different Jade Data Repo host. This version supports '${jadeDataRepoUrl()}'. URL passed: '${url.format(someUrl)}'`)
     }
 }
 
-// Regex drops any leading or trailing "/" characters and gives the path out of capture group 1
-const pathSlashRegex = /^\/?([^/]+.*?)\/?$/;
 /**
  *  Filter off the null entries first (because `regex.exec(null)` is TRUTHY, because of course it is)
  *  Then run the regex to get the path part without leading or trailing slashes
@@ -41,9 +64,11 @@ function determineHostname(someUrl) {
 
 function determinePathname(someUrl) {
     if (isDataGuidsUrl(someUrl)) {
-        return constructPath([dataObjectPathPrefix, someUrl.hostname, someUrl.pathname]);
+        return constructPath([dosDataObjectPathPrefix, someUrl.hostname, someUrl.pathname]);
+    } else if (hasJadeDataRepoHost(someUrl)) {
+        return constructPath([drsDataObjectPathPrefix, someUrl.pathname])
     } else {
-        return constructPath([dataObjectPathPrefix, someUrl.pathname]);
+        return constructPath([dosDataObjectPathPrefix, someUrl.pathname]);
     }
 }
 
@@ -86,6 +111,14 @@ function dataObjectUriToHttps(dataObjectUri) {
     return output;
 }
 
+// This function counts on the request posing  data as "application/json" content-type.
+// See: https://cloud.google.com/functions/docs/writing/http#parsing_http_requests for more details
+function parseRequest(req) {
+    if (req && req.body) {
+        return req.body.url;
+    }
+}
+
 class FileInfoResponse {
     constructor(contentType, size, timeCreated, updated, md5Hash, bucket, name, gsUri, signedUrl) {
         this.contentType = contentType || '';
@@ -114,7 +147,6 @@ function convertToFileInfoResponse (contentType, size, timeCreated, updated, md5
     );
 }
 
-const samBaseUrl = () => config.samBaseUrl;
 
 class Response {
     constructor(status, data) {
@@ -135,4 +167,4 @@ const promiseHandler = (fn) => (req, res) => {
     return fn(req, res).then(handleValue, handleValue);
 };
 
-module.exports = {dataObjectUriToHttps, convertToFileInfoResponse, samBaseUrl, Response, promiseHandler};
+module.exports = {dataObjectUriToHttps, convertToFileInfoResponse, samBaseUrl, jadeDataRepoUrl, Response, promiseHandler, parseRequest};

--- a/common/helpers.js
+++ b/common/helpers.js
@@ -98,7 +98,7 @@ function dataObjectUriToHttps(dataObjectUri) {
     return output;
 }
 
-// This function counts on the request posing  data as "application/json" content-type.
+// This function counts on the request posing data as "application/json" content-type.
 // See: https://cloud.google.com/functions/docs/writing/http#parsing_http_requests for more details
 function parseRequest(req) {
     if (req && req.body) {

--- a/common/helpers.js
+++ b/common/helpers.js
@@ -39,7 +39,7 @@ function validateDataObjectUrl(someUrl) {
         an error. And it might be difficult for the user to understand the cause of this error.
      */
     if (jadeDataRepoHostRegex.test(someUrl.host) && !hasJDRHost) {
-        throw new Error(`Data Object URI belongs to a different Jade Data Repo host. This version supports '${jadeDataRepoUrl()}'. URL passed: '${url.format(someUrl)}'`)
+        throw new Error(`Data Object URI belongs to a different Jade Data Repo host. This version supports '${jadeDataRepoUrl()}'. URL passed: '${url.format(someUrl)}'`);
     }
 }
 
@@ -66,7 +66,7 @@ function determinePathname(someUrl) {
     if (isDataGuidsUrl(someUrl)) {
         return constructPath([dosDataObjectPathPrefix, someUrl.hostname, someUrl.pathname]);
     } else if (hasJadeDataRepoHost(someUrl)) {
-        return constructPath([drsDataObjectPathPrefix, someUrl.pathname])
+        return constructPath([drsDataObjectPathPrefix, someUrl.pathname]);
     } else {
         return constructPath([dosDataObjectPathPrefix, someUrl.pathname]);
     }

--- a/config.json
+++ b/config.json
@@ -5,5 +5,6 @@
 {
     "dataObjectResolutionHost": "staging.gen3.biodatacatalyst.nhlbi.nih.gov",
     "bondBaseUrl": "broad-bond-dev.appspot.com",
-    "samBaseUrl": "https://sam.dsde-dev.broadinstitute.org"
+    "samBaseUrl": "https://sam.dsde-dev.broadinstitute.org",
+    "jadeDataRepoBaseUrl": "jade.datarepo-dev.broadinstitute.org"
 }

--- a/config.json
+++ b/config.json
@@ -5,6 +5,5 @@
 {
     "dataObjectResolutionHost": "staging.gen3.biodatacatalyst.nhlbi.nih.gov",
     "bondBaseUrl": "broad-bond-dev.appspot.com",
-    "samBaseUrl": "https://sam.dsde-dev.broadinstitute.org",
-    "jadeDataRepoBaseUrl": "jade.datarepo-dev.broadinstitute.org"
+    "samBaseUrl": "https://sam.dsde-dev.broadinstitute.org"
 }

--- a/config.json.ctmpl
+++ b/config.json.ctmpl
@@ -5,7 +5,6 @@
 {
     "dataObjectResolutionHost": {{if eq $runContext "fiab"}}"wb-mock-drs-dev.storage.googleapis.com"{{else if eq $environment "prod"}}"gen3.biodatacatalyst.nhlbi.nih.gov"{{else}}"staging.gen3.biodatacatalyst.nhlbi.nih.gov"{{end}},
     "bondBaseUrl": {{if eq $runContext "fiab"}}"bond-fiab.{{$dnsDomain}}"{{else}}"https://broad-bond-{{$environment}}.appspot.com"{{end}},
-    "samBaseUrl": {{if eq $runContext "fiab"}}"https://sam-fiab.{{$dnsDomain}}"{{else}}"https://sam.dsde-{{$environment}}.broadinstitute.org"{{end}},
-    "jadeDataRepoUrl": {{if eq $environment "prod"}}"jade-terra.datarepo-prod.broadinstitute.org"{{else}}"jade.datarepo-dev.broadinstitute.org"{{end}}
+    "samBaseUrl": {{if eq $runContext "fiab"}}"https://sam-fiab.{{$dnsDomain}}"{{else}}"https://sam.dsde-{{$environment}}.broadinstitute.org"{{end}}
 }
 {{end}}{{end}}{{end}}

--- a/config.json.ctmpl
+++ b/config.json.ctmpl
@@ -5,6 +5,7 @@
 {
     "dataObjectResolutionHost": {{if eq $runContext "fiab"}}"wb-mock-drs-dev.storage.googleapis.com"{{else if eq $environment "prod"}}"gen3.biodatacatalyst.nhlbi.nih.gov"{{else}}"staging.gen3.biodatacatalyst.nhlbi.nih.gov"{{end}},
     "bondBaseUrl": {{if eq $runContext "fiab"}}"bond-fiab.{{$dnsDomain}}"{{else}}"https://broad-bond-{{$environment}}.appspot.com"{{end}},
-    "samBaseUrl": {{if eq $runContext "fiab"}}"https://sam-fiab.{{$dnsDomain}}"{{else}}"https://sam.dsde-{{$environment}}.broadinstitute.org"{{end}}
+    "samBaseUrl": {{if eq $runContext "fiab"}}"https://sam-fiab.{{$dnsDomain}}"{{else}}"https://sam.dsde-{{$environment}}.broadinstitute.org"{{end}},
+    "jadeDataRepoUrl": {{if eq $environment "prod"}}"jade-terra.datarepo-prod.broadinstitute.org"{{else}}"jade.datarepo-dev.broadinstitute.org"{{end}}
 }
 {{end}}{{end}}{{end}}

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -45,6 +45,7 @@ EXPOSE 8008 8010
 # ENTRYPOINT to be the the `functions start` command.  Deployed functions persist across emulator restarts.
 RUN functions start \
     && functions deploy martha_v2 --trigger-http \
+    && functions deploy martha_v3 --trigger-http \
     && functions deploy fileSummaryV1 --trigger-http \
     && functions deploy getSignedUrlV1 --trigger-http \
     && functions stop

--- a/index.js
+++ b/index.js
@@ -5,11 +5,16 @@
 
 const corsMiddleware = require('cors')();
 const { marthaV2Handler } = require('./martha/martha_v2');
+const { marthaV3Handler } = require('./martha/martha_v3');
 const { fileSummaryV1Handler } = require('./fileSummaryV1/fileSummaryV1');
 const getSignedUrlV1 = require('./handlers/getSignedUrlV1');
 
 exports.martha_v2 = (req, res) => {
     corsMiddleware(req, res, () => marthaV2Handler(req, res));
+};
+
+exports.martha_v3 = (req, res) => {
+    corsMiddleware(req, res, () => marthaV3Handler(req, res));
 };
 
 exports.fileSummaryV1 = (req, res) => {

--- a/martha/martha_v3.js
+++ b/martha/martha_v3.js
@@ -30,10 +30,12 @@ function aggregateResponses(responses) {
     return finalResult;
 }
 
-function marthaV2Handler(req, res) {
+function marthaV3Handler(req, res) {
     const dataObjectUri = parseRequest(req);
+
     if (!dataObjectUri) {
-        res.status(400).send('Request must specify the URL of a DOS object');
+        console.error(new Error('Request did not specify the URL of a DRS object'));
+        res.status(400).send('Request must specify the URL of a DRS object');
         return;
     }
 
@@ -63,4 +65,4 @@ function marthaV2Handler(req, res) {
         });
 }
 
-exports.marthaV2Handler = marthaV2Handler;
+exports.marthaV3Handler = marthaV3Handler;

--- a/test/common/helpers.test.js
+++ b/test/common/helpers.test.js
@@ -127,9 +127,8 @@ test('should parse Data Object uri with host that looks like jade data repo host
         `https://jade-data-repo.datarepo-dev.broadinstitute.org/ga4gh/dos/v1/dataobjects/v1_anything`
     );
 });
-
 /**
- * End Scenario 3
+ * End Scenario 4
  */
 
 test('dataObjectUriToHttps should throw a Error when passed an invalid uri', (t) => {

--- a/test/common/helpers.test.js
+++ b/test/common/helpers.test.js
@@ -56,11 +56,14 @@ test('dataObjectUriToHttps should parse "drs://dg." Data Object uri with query p
 });
 
 test('dataObjectUriToHttps should throw an error when given a "dg.*" host with no path', (t) => {
-    try {
-        dataObjectUriToHttps('dos://dg.4503');
-    } catch(error) {
-        t.is(error.message, 'Data Object URIs with either \'dg.*\' or \'/jade.*\\.datarepo-.*\\.broadinstitute\\.org/\' as host are required to have a path: "dos://dg.4503"');
-    }
+    t.throws(
+        () => dataObjectUriToHttps('dos://dg.4503'),
+        {
+            instanceOf: Error,
+            message: 'Data Object URIs with either \'dg.*\' or \'/jade.*\\.datarepo-.*\\.broadinstitute\\.org/\' as host are required to have a path: "dos://dg.4503"'
+        },
+        'Should have thrown error but didnt!'
+    );
 });
 /**
  * End Scenario 2
@@ -113,11 +116,14 @@ test('should parse Data Object uri with jade data repo PROD as host', (t) => {
 });
 
 test('should throw error when given jade data repo host and no path', (t) => {
-    try {
-        dataObjectUriToHttps('drs://jade.datarepo-dev.broadinstitute.org/');
-    } catch(error) {
-        t.is(error.message, 'Data Object URIs with either \'dg.*\' or \'/jade.*\\.datarepo-.*\\.broadinstitute\\.org/\' as host are required to have a path: "drs://jade.datarepo-dev.broadinstitute.org"');
-    }
+    t.throws(
+        () => dataObjectUriToHttps('drs://jade.datarepo-dev.broadinstitute.org/'),
+        {
+            instanceOf: Error,
+            message: 'Data Object URIs with either \'dg.*\' or \'/jade.*\\.datarepo-.*\\.broadinstitute\\.org/\' as host are required to have a path: "drs://jade.datarepo-dev.broadinstitute.org"'
+        },
+        'Should have thrown error but didnt!'
+    );
 });
 
 test('should parse Data Object uri with host that looks like jade data repo host', (t) => {
@@ -131,11 +137,14 @@ test('should parse Data Object uri with host that looks like jade data repo host
  */
 
 test('dataObjectUriToHttps should throw a Error when passed an invalid uri', (t) => {
-    try {
-        dataObjectUriToHttps('A string that is not a valid URI');
-    } catch(error) {
-        t.is(error.message, 'Cannot read property \'0\' of null');
-    }
+    t.throws(
+        () => dataObjectUriToHttps('A string that is not a valid URI'),
+        {
+            instanceOf: Error,
+            message: 'Cannot read property \'0\' of null'
+        },
+        'Should have thrown error but didnt!'
+    );
 });
 
 test('samBaseUrl should come from the config json', (t) => {

--- a/test/common/helpers.test.js
+++ b/test/common/helpers.test.js
@@ -1,5 +1,5 @@
 const test = require('ava');
-const {dataObjectUriToHttps, samBaseUrl, jadeDataRepoUrl} = require('../../common/helpers');
+const {dataObjectUriToHttps, samBaseUrl} = require('../../common/helpers');
 const config = require('../../config.json');
 
 /**
@@ -59,7 +59,7 @@ test('dataObjectUriToHttps should throw an error when given a "dg.*" host with n
     try {
         dataObjectUriToHttps('dos://dg.4503');
     } catch(error) {
-        t.is(error.message, 'Data Object URIs with either \'dg.*\' or \'jade.datarepo-dev.broadinstitute.org\' as host are required to have a path: "dos://dg.4503"');
+        t.is(error.message, 'Data Object URIs with either \'dg.*\' or \'/jade.*\\.datarepo-.*\\.broadinstitute\\.org/\' as host are required to have a path: "dos://dg.4503"');
     }
 });
 /**
@@ -91,40 +91,39 @@ test('should parse "drs://dg." Data Object uri with only a host part with a quer
 /**
  * Begin Scenario 4: data objects uri with jade data repo host
  */
-test('should parse Data Object uri with jade data repo as host', (t) => {
+test('should parse Data Object uri with jade data repo DEV as host', (t) => {
     t.is(
         dataObjectUriToHttps('drs://jade.datarepo-dev.broadinstitute.org/973b5e79-6433-40ce-bf38-686ab7f17820'),
         'https://jade.datarepo-dev.broadinstitute.org/ga4gh/drs/v1/objects/973b5e79-6433-40ce-bf38-686ab7f17820'
     );
 });
 
-test('should parse Data Object uri with jade data repo as host and path with snapshot id', (t) => {
+test('should parse Data Object uri with jade data repo DEV as host and path with snapshot id', (t) => {
     t.is(
         dataObjectUriToHttps('drs://jade.datarepo-dev.broadinstitute.org/v1_c78919df-5d71-414b-ad29-7c3c0d810657_973b5e79-6433-40ce-bf38-686ab7f17820'),
         'https://jade.datarepo-dev.broadinstitute.org/ga4gh/drs/v1/objects/v1_c78919df-5d71-414b-ad29-7c3c0d810657_973b5e79-6433-40ce-bf38-686ab7f17820'
     );
 });
 
-test('should throw error if Data Object uri belongs to jade data repo hosts but not the one mentioned in config', (t) => {
-    try {
-        dataObjectUriToHttps('drs://jade-terra.datarepo-prod.broadinstitute.org/anything');
-    } catch(error) {
-        t.is(error.message, 'Data Object URI belongs to a different Jade Data Repo host. This version supports \'jade.datarepo-dev.broadinstitute.org\'. URL passed: \'drs://jade-terra.datarepo-prod.broadinstitute.org/anything\'');
-    }
+test('should parse Data Object uri with jade data repo PROD as host', (t) => {
+    t.is(
+        dataObjectUriToHttps('drs://jade-terra.datarepo-prod.broadinstitute.org/anything'),
+        'https://jade-terra.datarepo-prod.broadinstitute.org/ga4gh/drs/v1/objects/anything'
+    );
 });
 
 test('should throw error when given jade data repo host and no path', (t) => {
     try {
         dataObjectUriToHttps('drs://jade.datarepo-dev.broadinstitute.org/');
     } catch(error) {
-        t.is(error.message, 'Data Object URIs with either \'dg.*\' or \'jade.datarepo-dev.broadinstitute.org\' as host are required to have a path: "drs://jade.datarepo-dev.broadinstitute.org"');
+        t.is(error.message, 'Data Object URIs with either \'dg.*\' or \'/jade.*\\.datarepo-.*\\.broadinstitute\\.org/\' as host are required to have a path: "drs://jade.datarepo-dev.broadinstitute.org"');
     }
 });
 
-test('should parse Data Object uri with host that looks like jade data repo host and use dos object prefix', (t) => {
+test('should parse Data Object uri with host that looks like jade data repo host', (t) => {
     t.is(
         dataObjectUriToHttps('drs://jade-data-repo.datarepo-dev.broadinstitute.org/v1_anything'),
-        'https://jade-data-repo.datarepo-dev.broadinstitute.org/ga4gh/dos/v1/dataobjects/v1_anything'
+        'https://jade-data-repo.datarepo-dev.broadinstitute.org/ga4gh/drs/v1/objects/v1_anything'
     );
 });
 /**
@@ -141,8 +140,4 @@ test('dataObjectUriToHttps should throw a Error when passed an invalid uri', (t)
 
 test('samBaseUrl should come from the config json', (t) => {
     t.is(samBaseUrl(), config.samBaseUrl);
-});
-
-test('jade data repo base url should come from the config json', (t) => {
-    t.is(jadeDataRepoUrl(), config.jadeDataRepoBaseUrl);
 });

--- a/test/common/helpers.test.js
+++ b/test/common/helpers.test.js
@@ -1,5 +1,5 @@
 const test = require('ava');
-const {dataObjectUriToHttps, samBaseUrl} = require('../../common/helpers');
+const {dataObjectUriToHttps, samBaseUrl, jadeDataRepoUrl} = require('../../common/helpers');
 const config = require('../../config.json');
 
 /**
@@ -59,7 +59,7 @@ test('dataObjectUriToHttps should throw an error when given a "dg.*" host with n
     try {
         dataObjectUriToHttps('dos://dg.4503');
     } catch(error) {
-        t.is(error.message, 'Data Object URIs with \'dg.*\' host are required to have a path: "dos://dg.4503"');
+        t.is(error.message, 'Data Object URIs with either \'dg.*\' or \'jade.datarepo-dev.broadinstitute.org\' as host are required to have a path: "dos://dg.4503"');
     }
 });
 /**
@@ -88,6 +88,50 @@ test('should parse "drs://dg." Data Object uri with only a host part with a quer
  * End Scenario 3
  */
 
+/**
+ * Begin Scenario 4: data objects uri with jade data repo host
+ */
+test('should parse Data Object uri with jade data repo as host', (t) => {
+    t.is(
+        dataObjectUriToHttps(`drs://jade.datarepo-dev.broadinstitute.org/973b5e79-6433-40ce-bf38-686ab7f17820`),
+        `https://jade.datarepo-dev.broadinstitute.org/ga4gh/drs/v1/objects/973b5e79-6433-40ce-bf38-686ab7f17820`
+    );
+});
+
+test('should parse Data Object uri with jade data repo as host and path with snapshot id', (t) => {
+    t.is(
+        dataObjectUriToHttps(`drs://jade.datarepo-dev.broadinstitute.org/v1_c78919df-5d71-414b-ad29-7c3c0d810657_973b5e79-6433-40ce-bf38-686ab7f17820`),
+        `https://jade.datarepo-dev.broadinstitute.org/ga4gh/drs/v1/objects/v1_c78919df-5d71-414b-ad29-7c3c0d810657_973b5e79-6433-40ce-bf38-686ab7f17820`
+    );
+});
+
+test('should throw error if Data Object uri belongs to jade data repo hosts but not the one mentioned in config', (t) => {
+    try {
+        dataObjectUriToHttps(`drs://jade-terra.datarepo-prod.broadinstitute.org/anything`)
+    } catch(error) {
+        t.is(error.message, 'Data Object URI belongs to a different Jade Data Repo host. This version supports \'jade.datarepo-dev.broadinstitute.org\'. URL passed: \'drs://jade-terra.datarepo-prod.broadinstitute.org/anything\'')
+    }
+});
+
+test('should throw error when given jade data repo host and no path', (t) => {
+    try {
+        dataObjectUriToHttps(`drs://jade.datarepo-dev.broadinstitute.org/`);
+    } catch(error) {
+        t.is(error.message, 'Data Object URIs with either \'dg.*\' or \'jade.datarepo-dev.broadinstitute.org\' as host are required to have a path: "drs://jade.datarepo-dev.broadinstitute.org"');
+    }
+});
+
+test('should parse Data Object uri with host that looks like jade data repo host and use dos object prefix', (t) => {
+    t.is(
+        dataObjectUriToHttps(`drs://jade-data-repo.datarepo-dev.broadinstitute.org/v1_anything`),
+        `https://jade-data-repo.datarepo-dev.broadinstitute.org/ga4gh/dos/v1/dataobjects/v1_anything`
+    );
+});
+
+/**
+ * End Scenario 3
+ */
+
 test('dataObjectUriToHttps should throw a Error when passed an invalid uri', (t) => {
     try {
         dataObjectUriToHttps('A string that is not a valid URI');
@@ -98,4 +142,8 @@ test('dataObjectUriToHttps should throw a Error when passed an invalid uri', (t)
 
 test('samBaseUrl should come from the config json', (t) => {
     t.is(samBaseUrl(), config.samBaseUrl);
+});
+
+test('jade data repo base url should come from the config json', (t) => {
+    t.is(jadeDataRepoUrl(), config.jadeDataRepoBaseUrl);
 });

--- a/test/common/helpers.test.js
+++ b/test/common/helpers.test.js
@@ -93,29 +93,29 @@ test('should parse "drs://dg." Data Object uri with only a host part with a quer
  */
 test('should parse Data Object uri with jade data repo as host', (t) => {
     t.is(
-        dataObjectUriToHttps(`drs://jade.datarepo-dev.broadinstitute.org/973b5e79-6433-40ce-bf38-686ab7f17820`),
-        `https://jade.datarepo-dev.broadinstitute.org/ga4gh/drs/v1/objects/973b5e79-6433-40ce-bf38-686ab7f17820`
+        dataObjectUriToHttps('drs://jade.datarepo-dev.broadinstitute.org/973b5e79-6433-40ce-bf38-686ab7f17820'),
+        'https://jade.datarepo-dev.broadinstitute.org/ga4gh/drs/v1/objects/973b5e79-6433-40ce-bf38-686ab7f17820'
     );
 });
 
 test('should parse Data Object uri with jade data repo as host and path with snapshot id', (t) => {
     t.is(
-        dataObjectUriToHttps(`drs://jade.datarepo-dev.broadinstitute.org/v1_c78919df-5d71-414b-ad29-7c3c0d810657_973b5e79-6433-40ce-bf38-686ab7f17820`),
-        `https://jade.datarepo-dev.broadinstitute.org/ga4gh/drs/v1/objects/v1_c78919df-5d71-414b-ad29-7c3c0d810657_973b5e79-6433-40ce-bf38-686ab7f17820`
+        dataObjectUriToHttps('drs://jade.datarepo-dev.broadinstitute.org/v1_c78919df-5d71-414b-ad29-7c3c0d810657_973b5e79-6433-40ce-bf38-686ab7f17820'),
+        'https://jade.datarepo-dev.broadinstitute.org/ga4gh/drs/v1/objects/v1_c78919df-5d71-414b-ad29-7c3c0d810657_973b5e79-6433-40ce-bf38-686ab7f17820'
     );
 });
 
 test('should throw error if Data Object uri belongs to jade data repo hosts but not the one mentioned in config', (t) => {
     try {
-        dataObjectUriToHttps(`drs://jade-terra.datarepo-prod.broadinstitute.org/anything`)
+        dataObjectUriToHttps('drs://jade-terra.datarepo-prod.broadinstitute.org/anything');
     } catch(error) {
-        t.is(error.message, 'Data Object URI belongs to a different Jade Data Repo host. This version supports \'jade.datarepo-dev.broadinstitute.org\'. URL passed: \'drs://jade-terra.datarepo-prod.broadinstitute.org/anything\'')
+        t.is(error.message, 'Data Object URI belongs to a different Jade Data Repo host. This version supports \'jade.datarepo-dev.broadinstitute.org\'. URL passed: \'drs://jade-terra.datarepo-prod.broadinstitute.org/anything\'');
     }
 });
 
 test('should throw error when given jade data repo host and no path', (t) => {
     try {
-        dataObjectUriToHttps(`drs://jade.datarepo-dev.broadinstitute.org/`);
+        dataObjectUriToHttps('drs://jade.datarepo-dev.broadinstitute.org/');
     } catch(error) {
         t.is(error.message, 'Data Object URIs with either \'dg.*\' or \'jade.datarepo-dev.broadinstitute.org\' as host are required to have a path: "drs://jade.datarepo-dev.broadinstitute.org"');
     }
@@ -123,8 +123,8 @@ test('should throw error when given jade data repo host and no path', (t) => {
 
 test('should parse Data Object uri with host that looks like jade data repo host and use dos object prefix', (t) => {
     t.is(
-        dataObjectUriToHttps(`drs://jade-data-repo.datarepo-dev.broadinstitute.org/v1_anything`),
-        `https://jade-data-repo.datarepo-dev.broadinstitute.org/ga4gh/dos/v1/dataobjects/v1_anything`
+        dataObjectUriToHttps('drs://jade-data-repo.datarepo-dev.broadinstitute.org/v1_anything'),
+        'https://jade-data-repo.datarepo-dev.broadinstitute.org/ga4gh/dos/v1/dataobjects/v1_anything'
     );
 });
 /**

--- a/test/martha/martha_v3.test.js
+++ b/test/martha/martha_v3.test.js
@@ -1,0 +1,154 @@
+/**
+ * When writing/testing GCF functions, see:
+ * - https://cloud.google.com/functions/docs/monitoring/error-reporting
+ * - https://cloud.google.com/functions/docs/bestpractices/testing
+ *
+ * NOTE: Any tests in this file that rely on the before/after stubs need to be run sequentially, see:
+ * https://github.com/avajs/ava/issues/1066
+ */
+
+const test = require('ava');
+const sinon = require('sinon');
+const marthaV3 = require('../../martha/martha_v3').marthaV3Handler;
+const apiAdapter = require('../../common/api_adapter');
+
+const mockRequest = (req) => {
+    req.method = 'POST';
+    req.headers = { authorization: 'bearer abc123' };
+    return req;
+};
+
+const mockResponse = () => {
+    return {
+        status(s) {
+            this.statusCode = s;
+            return this;
+        },
+        send: sinon.stub(),
+        setHeader: sinon.stub()
+    };
+};
+
+const dataObject = { fake: 'A fake Data Object' };
+const googleSAKeyObject = { key: 'A Google Service Account private key json object' };
+
+const bondRegEx = /^([^/]+)\/api\/link\/v1\/([a-z-]+)\/serviceaccount\/key$/;
+
+let getJsonFromApiStub;
+let getJsonFromApiMethodName = 'getJsonFrom';
+let sandbox = sinon.createSandbox();
+
+test.serial.beforeEach(() => {
+    sandbox.restore(); // If one test fails, the .afterEach() block will not execute, so always clean the slate here
+    getJsonFromApiStub = sandbox.stub(apiAdapter, getJsonFromApiMethodName);
+    getJsonFromApiStub.onFirstCall().resolves(dataObject);
+    getJsonFromApiStub.onSecondCall().resolves(googleSAKeyObject);
+});
+
+test.serial.afterEach(() => {
+    sandbox.restore();
+});
+
+test.serial('martha_v3 resolves a valid url into a Data Object and google service account key', async (t) => {
+    const response = mockResponse();
+    await marthaV3(mockRequest({ body: { 'url': 'dos://abc/123' } }), response);
+    const result = response.send.lastCall.args[0];
+    t.deepEqual(result.dos, dataObject);
+    t.deepEqual(result.googleServiceAccount, googleSAKeyObject);
+    t.is(response.statusCode, 200);
+});
+
+test.serial('martha_v3 resolves successfully and ignores extra data submitted besides a \'url\'', async (t) => {
+    const response = mockResponse();
+    await marthaV3(mockRequest({
+        body: {
+            url: 'dos://abc/123',
+            pattern: 'gs://',
+            foo: 'bar'
+        }
+    }), response);
+    const result = response.send.lastCall.args[0];
+    t.deepEqual(result.dos, dataObject);
+    t.deepEqual(result.googleServiceAccount, googleSAKeyObject);
+    t.is(response.statusCode, 200);
+});
+
+test.serial('martha_v3 resolves a valid url into a Data Object without a service account key if no authorization header is provided', async (t) => {
+    const response = mockResponse();
+    const mockReq = mockRequest({ body: { 'url': 'dos://abc/123' } });
+    delete mockReq.headers.authorization;
+    await marthaV3(mockReq, response);
+    const result = response.send.lastCall.args[0];
+    t.is(response.statusCode, 200);
+    t.deepEqual(result.dos, dataObject);
+});
+
+test.serial('martha_v3 should return 400 if not given a url', async (t) => {
+    const response = mockResponse();
+    await marthaV3(mockRequest({ body: { 'uri': 'dos://abc/123' } }), response);
+    t.is(response.statusCode, 400);
+});
+
+test.serial('martha_v3 should return 400 if no data is posted with the request', async (t) => {
+    const response = mockResponse();
+    await marthaV3(mockRequest({}), response);
+    t.is(response.statusCode, 400);
+});
+
+test.serial('martha_v3 should return 400 if given a \'url\' with an invalid value', async (t) => {
+    const response = mockResponse();
+    await marthaV3(mockRequest({ body: { url: 'Not a valid URI' } }), response);
+    t.is(response.statusCode, 400);
+});
+
+test.serial('martha_v3 should return 502 if Data Object resolution fails', async (t) => {
+    getJsonFromApiStub.restore();
+    sandbox.stub(apiAdapter, getJsonFromApiMethodName).rejects(new Error('Data Object Resolution forced to fail by testing stub'));
+    const response = mockResponse();
+    await marthaV3(mockRequest({ body: { 'url': 'dos://abc/123' } }), response);
+    const result = response.send.lastCall.args[0];
+    t.true(result instanceof Error);
+    t.is(response.statusCode, 502);
+});
+
+test.serial('martha_v3 should return 502 if key retrieval from bond fails', async (t) => {
+    getJsonFromApiStub.restore();
+    sandbox.stub(apiAdapter, getJsonFromApiMethodName).rejects(new Error('Bond key lookup forced to fail by testing stub'));
+    const response = mockResponse();
+    await marthaV3(mockRequest({ body: { 'url': 'dos://abc/123' } }), response);
+    const result = response.send.lastCall.args[0];
+    t.true(result instanceof Error);
+    t.is(response.statusCode, 502);
+});
+
+test.serial('martha_v3 calls bond Bond with the "dcf-fence" provider when the Data Object URL host is not "dg.4503"', async (t) => {
+    const response = mockResponse();
+    await marthaV3(mockRequest({ body: { 'url': 'dos://abc/123' } }), response);
+    const requestedBondUrl = getJsonFromApiStub.secondCall.args[0];
+    const matches = requestedBondUrl.match(bondRegEx);
+    t.truthy(matches, 'Bond URL called does not match Bond URL regular expression');
+    const expectedProvider = 'dcf-fence';
+    const actualProvider = matches[2];
+    t.is(actualProvider, expectedProvider);
+});
+
+test.serial('martha_v3 calls bond Bond with the "fence" provider when the Data Object URL host is "dg.4503"', async (t) => {
+    const response = mockResponse();
+    await marthaV3(mockRequest({ body: { 'url': 'drs://dg.4503/this_part_can_be_anything' } }), response);
+    const requestedBondUrl = getJsonFromApiStub.secondCall.args[0];
+    const matches = requestedBondUrl.match(bondRegEx);
+    t.truthy(matches, 'Bond URL called does not match Bond URL regular expression');
+    const expectedProvider = 'fence';
+    const actualProvider = matches[2];
+    t.is(actualProvider, expectedProvider);
+});
+
+test.serial('martha_v3 does not call Bond or return SA key when the Data Object URL host endswith ".humancellatlas.org', async (t) => {
+    const response = mockResponse();
+    await marthaV3(mockRequest({ body: { 'url': 'drs://someservice.humancellatlas.org/this_part_can_be_anything' } }), response);
+    const result = response.send.lastCall.args[0];
+    t.true(getJsonFromApiStub.calledOnce); // Bond was not called to get SA key
+    t.deepEqual(result.dos, dataObject);
+    t.falsy(result.googleServiceAccount);
+    t.is(response.statusCode, 200);
+});


### PR DESCRIPTION
This PR introduces new version of martha, `martha_v3`. Currently in the codebase, there are 2 functions common across `martha_v2` and `martha_v3` handlers namely `maybeTalkToBond` and `aggregateResponses` which I haven't refactored. Since they both will change in the eventual tickets for JDR support (auth header and standard response), I have left them as it is. Same applies to the tests in `martha_v3.test.js` where mock responses and assertion checks will eventually change.

Closes https://broadworkbench.atlassian.net/browse/WA-178.