### PR TITLE
Auth header in request for JDR Integration [WA-179]

### DIFF
--- a/common/bond.js
+++ b/common/bond.js
@@ -1,7 +1,7 @@
 const config = require('../config.json');
 const URL = require('url');
 const {hasJadeDataRepoHost} = require('../common/helpers.js');
-const {getJsonFrom} = require('../common/api_adapter');
+const apiAdapter = require('../common/api_adapter.js');
 
 const BondProviders = Object.freeze({
   FENCE: 'fence',
@@ -46,7 +46,11 @@ async function maybeTalkToBond(req, provider = BondProviders.default) {
       provider !== BondProviders.HCA &&
       provider !== BondProviders.JADE_DATA_REPO) {
     try {
-      return await getJsonFrom(`${bondBaseUrl()}/api/link/v1/${provider}/serviceaccount/key`, req.headers.authorization);
+      /*
+          For some reason, importing just `getJsonFrom` from api_adapter.js (at top) and replacing `apiAdapter.getJsonFrom` with
+          `getJsonFrom(...)` is breaking martha_v2.test.js and martha_v3.test.js(!!)
+       */
+      return await apiAdapter.getJsonFrom(`${bondBaseUrl()}/api/link/v1/${provider}/serviceaccount/key`, req.headers.authorization);
     } catch (error) {
       console.log(`Received error while fetching service account from Bond for provider '${provider}'.`);
       console.error(error);

--- a/common/bond.js
+++ b/common/bond.js
@@ -38,8 +38,8 @@ async function maybeTalkToBond(req, provider = BondProviders.default) {
   /*
       Currently HCA data access does not require additional credentials. HCA checkout buckets allow object
       read access for GROUP_All_Users@firecloud.org. Also for Jade Data Repo (JDR), we don't need to contact Bond to
-      check proper authorization. When a metadata retrieval request is made to JDR, we need to pass authorization
-      which is used to check permissions of that account.
+      check proper authorization. JDR itself checks for the proper authorization when a metadata retrieval request for
+      data object is made.
    */
   if (req && req.headers &&
       req.headers.authorization &&
@@ -47,8 +47,9 @@ async function maybeTalkToBond(req, provider = BondProviders.default) {
       provider !== BondProviders.JADE_DATA_REPO) {
     try {
       /*
-          For some reason, importing just `getJsonFrom` from api_adapter.js (at top) and replacing `apiAdapter.getJsonFrom` with
-          `getJsonFrom(...)` is breaking martha_v2.test.js and martha_v3.test.js(!!)
+          Importing just `getJsonFrom` from api_adapter.js (at top) and replacing `apiAdapter.getJsonFrom` with
+          `getJsonFrom(...)` is breaking martha_v2.test.js and martha_v3.test.js for some reason(!!). It might be the way
+          `getJsonFrom` is mocked in the tests. Please do not change the import at top for this reason.
        */
       return await apiAdapter.getJsonFrom(`${bondBaseUrl()}/api/link/v1/${provider}/serviceaccount/key`, req.headers.authorization);
     } catch (error) {

--- a/common/helpers.js
+++ b/common/helpers.js
@@ -154,4 +154,4 @@ const promiseHandler = (fn) => (req, res) => {
     return fn(req, res).then(handleValue, handleValue);
 };
 
-module.exports = {dataObjectUriToHttps, convertToFileInfoResponse, samBaseUrl, Response, promiseHandler, parseRequest};
+module.exports = {dataObjectUriToHttps, convertToFileInfoResponse, samBaseUrl, Response, promiseHandler, parseRequest, hasJadeDataRepoHost};

--- a/martha/martha_v2.js
+++ b/martha/martha_v2.js
@@ -1,23 +1,7 @@
 const {dataObjectUriToHttps, parseRequest} = require('../common/helpers');
-const {bondBaseUrl, determineBondProvider, BondProviders} = require('../common/bond');
+const {maybeTalkToBond, determineBondProvider} = require('../common/bond');
 const apiAdapter = require('../common/api_adapter');
 
-
-async function maybeTalkToBond(req, provider = BondProviders.default) {
-    // Currently HCA data access does not require additional credentials.
-    // The HCA checkout buckets allow object read access for GROUP_All_Users@firecloud.org.
-    if (req && req.headers && req.headers.authorization && provider !== BondProviders.HCA) {
-        try {
-            return await apiAdapter.getJsonFrom(`${bondBaseUrl()}/api/link/v1/${provider}/serviceaccount/key`, req.headers.authorization);
-        } catch (error) {
-            console.log(`Received error while fetching service account from Bond for provider '${provider}'.`);
-            console.error(error);
-            throw error;
-        }
-    } else {
-        return Promise.resolve();
-    }
-}
 
 function aggregateResponses(responses) {
     // Note: for backwards compatibility, we are returning the DRS object with the key, "dos".  If we want to change this, we can add a new api version for Martha_v2.

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "live_test_fileSummaryV1": "ava test/fileSummaryV1/fileSummaryV1_live.test.js",
     "integration": "ava -m integration*",
     "integration_v2": "ava -m integration_v2*",
+    "integration_v3": "ava -m integration_v3*",
     "integration_fileSummaryV1": "ava -m integration_fileSummaryV1*"
   },
   "dependencies": {

--- a/test/common/bond_test.js
+++ b/test/common/bond_test.js
@@ -15,6 +15,10 @@ test('BondProviders should contain "dcf-fence" and "fence"', (t) => {
   t.truthy(BondProviders.FENCE);
 });
 
+test('BondProviders should contain "jade-data-repo"', (t) => {
+  t.truthy(BondProviders.JADE_DATA_REPO);
+});
+
 test('determineBondProvider should be "fence" if the URL host is "dg.4503"', (t) => {
   t.is(determineBondProvider('drs://dg.4503/anything'), BondProviders.FENCE);
 });
@@ -38,4 +42,8 @@ test('determineBondProvider should return the default BondProvider if the URL ho
 
 test('determineBondProvider should return the default BondProvider if the URL host is NOT "dg.4503" or HCA', (t) => {
   t.is(determineBondProvider('drs://some-host/anything'), BondProviders.default);
+});
+
+test('determineBondProvider should return the "jade-data-repo" as the provider for JDR host"', (t) => {
+  t.is(determineBondProvider('drs://jade.datarepo-dev.broadinstitute.org/identifier'), BondProviders.JADE_DATA_REPO);
 });

--- a/test/martha/integration_v3.test.js
+++ b/test/martha/integration_v3.test.js
@@ -218,7 +218,7 @@ test.cb('integration_v3 responds with Data Object for authorized user for jade d
         .expect((response) => {
             assert.strictEqual(response.statusCode, 200, 'Incorrect status code');
             assert(response.body.dos, 'No Data Object found');
-            assert.strictEqual(response.body.dos.size, 2920608066, 'Incorrect size for url');
+            assert.strictEqual(response.body.dos.size, 15601108255, 'Incorrect size for url');
         })
         .end((error, response) => {
             if (error) { t.log(response.body); }

--- a/test/martha/integration_v3.test.js
+++ b/test/martha/integration_v3.test.js
@@ -218,7 +218,6 @@ test.cb('integration_v3 responds with Data Object for authorized user for jade d
         .expect((response) => {
             assert.strictEqual(response.statusCode, 200, 'Incorrect status code');
             assert(response.body.dos, 'No Data Object found');
-            assert.strictEqual(response.body.dos.size, 15601108255, 'Incorrect size for url');
         })
         .end((error, response) => {
             if (error) { t.log(response.body); }

--- a/test/martha/integration_v3.test.js
+++ b/test/martha/integration_v3.test.js
@@ -35,13 +35,13 @@ const jdrDevTestUrl = 'drs://jade.datarepo-dev.broadinstitute.org/v1_93dc1e76-8f
 
 test.before(async () => {
     unauthorizedToken = await new GoogleToken({
-        keyFile: keyFile,
+        keyFile,
         email: serviceAccountEmail,
         sub: unauthorizedEmail,
         scope: scopes
     }).getToken();
     authorizedToken = await new GoogleToken({
-        keyFile: keyFile,
+        keyFile,
         email: serviceAccountEmail,
         sub: authorizedEmail,
         scope: scopes
@@ -133,7 +133,7 @@ test.cb('integration_v3 fails when "authorization" header is provided for a publ
     supertest
         .post('/martha_v3')
         .set('Content-Type', 'application/json')
-        .set('Authorization', `Bearer badToken`)
+        .set('Authorization', 'Bearer badToken')
         .send({ url: publicFenceUrl })
         .expect((response) => {
             assert.strictEqual(response.statusCode, 502, 'Bond should not have authenticated this token');

--- a/test/martha/integration_v3.test.js
+++ b/test/martha/integration_v3.test.js
@@ -1,0 +1,242 @@
+/** Run integration tests from the command line.  For example:
+ *
+ *    BASE_URL="https://us-central1-broad-dsde-dev.cloudfunctions.net" npm run-script integration_v3
+ *
+ * Run integration tests after a deployment to confirm that the functions deployed successfully
+ * (these tests are currently run in Jenkins job 'martha-fiab-test-runner' inside a FIAB)
+ */
+
+const test = require('ava');
+const supertest = require('supertest')(process.env.BASE_URL);
+const assert = require('assert');
+const { GoogleToken } = require('gtoken');
+const { postJsonTo } = require('../../common/api_adapter');
+
+let unauthorizedToken;
+let authorizedToken;
+
+const myEnv = process.env.ENV ? process.env.ENV : 'dev';
+const emailDomain = (myEnv === 'qa' ? 'quality' : 'test') + '.firecloud.org';
+
+let keyFile = 'automation/firecloud-account.pem';
+const serviceAccountEmail = `firecloud-${myEnv}@broad-dsde-${myEnv}.iam.gserviceaccount.com`;
+let scopes = 'email openid';
+const unauthorizedEmail = `ron.weasley@${emailDomain}`;
+const authorizedEmail = `hermione.owner@${emailDomain}`;
+
+let publicFenceUrl = 'dos://dg.4503/preview_dos.json';
+let protectedFenceUrl = 'dos://dg.4503/65e4cd14-f549-4a7f-ad0c-d29212ff6e46';
+// TODO: remove static link so bond host can be changed depending on env
+const fenceAuthLink = `https://bond-fiab.dsde-${myEnv}.broadinstitute.org:31443/api/link/v1/fence/oauthcode?oauthcode=IgnoredByMockProvider&redirect_uri=http%3A%2F%2Flocal.broadinstitute.org%2F%23fence-callback`;
+
+// Dev Jade Data Repo url. Snapshot id is 93dc1e76-8f1c-4949-8f9b-07a087f3ce7b
+const jdrDevTestUrl = 'drs://jade.datarepo-dev.broadinstitute.org/v1_93dc1e76-8f1c-4949-8f9b-07a087f3ce7b_8b07563a-542f-4b5c-9e00-e8fe6b1861de';
+
+
+test.before(async () => {
+    unauthorizedToken = await new GoogleToken({
+        keyFile: keyFile,
+        email: serviceAccountEmail,
+        sub: unauthorizedEmail,
+        scope: scopes
+    }).getToken();
+    authorizedToken = await new GoogleToken({
+        keyFile: keyFile,
+        email: serviceAccountEmail,
+        sub: authorizedEmail,
+        scope: scopes
+    }).getToken();
+
+    await postJsonTo(fenceAuthLink, 'Bearer ' + authorizedToken);
+});
+
+// Invalid inputs
+
+test.cb('integration_v3 returns error if url passed is malformed', (t) => {
+    supertest
+        .post('/martha_v3')
+        .set('Content-Type', 'application/json')
+        .send({ url: 'notAValidURL' })
+        .expect((response) => {
+            assert.strictEqual(response.statusCode, 400, 'Request did not specify the URL of a DRS object');
+        })
+        .end((error, response) => {
+            if (error) { t.log(response.body); }
+            t.end(error);
+        });
+});
+
+test.cb('integration_v3 return error if url passed is not good', (t) => {
+    supertest
+        .post('/martha_v3')
+        .set('Content-Type', 'application/json')
+        .set('Authorization', `Bearer ${authorizedToken}`)
+        .send({ url: 'dos://broad-dsp-dos-TYPO.storage.googleapis.com/something-that-does-not-exist' })
+        .expect((response) => {
+            assert.strictEqual(response.statusCode, 502, 'Incorrect status code');
+        })
+        .end((error, response) => {
+            if (error) { t.log(response.body); }
+            t.end(error);
+        });
+});
+
+// Public data guid url
+
+test.cb('integration_v3 fails when no "authorization" header is provided for public url', (t) => {
+    supertest
+        .post('/martha_v3')
+        .set('Content-Type', 'application/json')
+        .send({ url: publicFenceUrl })
+        .expect((response) => {
+            assert.strictEqual(response.statusCode, 400, 'Request did not not specify an authorization header');
+        })
+        .end((error, response) => {
+            if (error) { t.log(response.body); }
+            t.end(error);
+        });
+});
+
+test.cb('integration_v3 responds with Data Object and service account for a public url', (t) => {
+    supertest
+        .post('/martha_v3')
+        .set('Content-Type', 'application/json')
+        .set('Authorization', `Bearer ${authorizedToken}`)
+        .send({ url: publicFenceUrl })
+        .expect((response) => {
+            assert.strictEqual(response.statusCode, 200, 'Incorrect status code');
+            assert(response.body.dos, 'No Data Object found');
+            assert(response.body.googleServiceAccount, 'No Google Service Account found');
+        })
+        .end((error, response) => {
+            if (error) { t.log(response.body); }
+            t.end(error);
+        });
+});
+
+test.cb('integration_v3 fails when "authorization" header is provided for a public url but user is not authed with provider', (t) => {
+    supertest
+        .post('/martha_v3')
+        .set('Content-Type', 'application/json')
+        .set('Authorization', `Bearer ${unauthorizedToken}`)
+        .send({ url: publicFenceUrl })
+        .expect((response) => {
+            assert.strictEqual(response.statusCode, 502, 'User should not be authorized with provider');
+        })
+        .end((error, response) => {
+            if (error) { t.log(response.body); }
+            t.end(error);
+        });
+});
+
+test.cb('integration_v3 fails when "authorization" header is provided for a public url but the bearer token is invalid', (t) => {
+    supertest
+        .post('/martha_v3')
+        .set('Content-Type', 'application/json')
+        .set('Authorization', `Bearer badToken`)
+        .send({ url: publicFenceUrl })
+        .expect((response) => {
+            assert.strictEqual(response.statusCode, 502, 'Bond should not have authenticated this token');
+        })
+        .end((error, response) => {
+            if (error) { t.log(response.body); }
+            t.end(error);
+        });
+});
+
+// Protected data guid url
+
+test.cb('integration_v3 fails when no "authorization" header is provided for a protected url', (t) => {
+    supertest
+        .post('/martha_v3')
+        .set('Content-Type', 'application/json')
+        .send({ url: protectedFenceUrl })
+        .expect((response) => {
+            assert.strictEqual(response.statusCode, 400, 'Request did not not specify an authorization header');
+        })
+        .end((error, response) => {
+            if (error) { t.log(response.body); }
+            t.end(error);
+        });
+});
+
+test.cb('integration_v3 responds with Data Object and service account when "authorization" header is provided for a protected url', (t) => {
+    supertest
+        .post('/martha_v3')
+        .set('Content-Type', 'application/json')
+        .set('Authorization', `Bearer ${authorizedToken}`)
+        .send({ url: protectedFenceUrl })
+        .expect((response) => {
+            assert.strictEqual(response.statusCode, 200, 'Incorrect status code');
+            assert(response.body.dos, 'No Data Object found');
+            assert(response.body.googleServiceAccount, 'No Google Service Account found');
+        })
+        .end((error, response) => {
+            if (error) { t.log(response.body); }
+            t.end(error);
+        });
+});
+
+test.cb('integration_v3 fails when "authorization" header is provided for a protected url but user is not authed with provider', (t) => {
+    supertest
+        .post('/martha_v3')
+        .set('Content-Type', 'application/json')
+        .set('Authorization', `Bearer ${unauthorizedToken}`)
+        .send({ url: protectedFenceUrl })
+        .expect((response) => {
+            assert.strictEqual(response.statusCode, 502, 'User should not be authorized with provider');
+        })
+        .end((error, response) => {
+            if (error) { t.log(response.body); }
+            t.end(error);
+        });
+});
+
+test.cb('integration_v3 fails when "authorization" header is provided for a protected url but the bearer token is invalid', (t) => {
+    supertest
+        .post('/martha_v3')
+        .set('Content-Type', 'application/json')
+        .set('Authorization', 'Bearer badToken')
+        .send({ url: protectedFenceUrl })
+        .expect((response) => {
+            assert.strictEqual(response.statusCode, 502, 'Bond should not have authenticated this token');
+        })
+        .end((error, response) => {
+            if (error) { t.log(response.body); }
+            t.end(error);
+        });
+});
+
+// Jade Data Repo url
+
+test.cb('integration_v3 responds with Data Object for authorized user for jade data repo url', (t) => {
+    supertest
+        .post('/martha_v3')
+        .set('Content-Type', 'application/json')
+        .set('Authorization', `Bearer ${authorizedToken}`)
+        .send({ url: jdrDevTestUrl })
+        .expect((response) => {
+            assert.strictEqual(response.statusCode, 200, 'Incorrect status code');
+            assert(response.body.dos, 'No Data Object found');
+            assert.strictEqual(response.body.dos.size, 2920608066, 'Incorrect size for url');
+        })
+        .end((error, response) => {
+            if (error) { t.log(response.body); }
+            t.end(error);
+        });
+});
+
+test.cb('integration_v3 fails when unauthorized user is resolving jade data repo url', (t) => {
+    supertest
+        .post('/martha_v3')
+        .set('Content-Type', 'application/json')
+        .set('Authorization', `Bearer ${unauthorizedToken}`)
+        .send({ url: jdrDevTestUrl })
+        .expect((response) => {
+            assert.strictEqual(response.statusCode, 502, 'This user should be unauthorized in Jade Data Repo');
+        })
+        .end((error, response) => {
+            if (error) { t.log(response.body); }
+            t.end(error);
+        });
+});


### PR DESCRIPTION
This PR makes auth header being passed to `martha_v3` mandatory. `maybeTalkToBond` has now been refactored into `bond.js`. I initially thought there would be more logic for not talking to Bond in v3 that would keep martha_v3 and martha_v2 code diverged for this function. But it turns out adding 1 additional condition works for both v3 and v2. Integration tests have been added for v3 as part of this PR.

Closes https://broadworkbench.atlassian.net/browse/WA-179.