### PR TITLE
Support for multiple hashes in /martha_v3 [WA-219]

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,6 @@ It will always return an object with the same properties:
  name:           string,
  gsUri:          string,
  googleServiceAccount: object, [null unless the DOS url belongs to a Bond supported host]
- signedUrl:      string [always the empty string ''],
  hashes:         object [contains the hashes type and their checksum value]
 ```
 
@@ -68,7 +67,6 @@ Example response for /martha_v3:
     "name": "dd3c716a-852f-4d74-9073-9920e835ec8a/f3b148ac-1802-4acc-a0b9-610ea266fb61",
     "gsUri": "gs://my-bucket/dd3c716a-852f-4d74-9073-9920e835ec8a/f3b148ac-1802-4acc-a0b9-610ea266fb61",
     "googleServiceAccount": null,
-    "signedUrl": "",
     "hashes": {
         "md5": "336ea55913bc261b72875bd259753046",
         "sha256": "f76877f8e86ec3932fd2ae04239fbabb8c90199dab0019ae55fa42b31c314c44",

--- a/README.md
+++ b/README.md
@@ -48,12 +48,33 @@ It will always return an object with the same properties:
  size:           int,
  timeCreated:    string [the time created, formatted using ISO 8601],
  updated:        string [the time updated, formatted using ISO 8601, or the empty string '' if unknown],
- md5Hash:        string,
  bucket:         string,
  name:           string,
  gsUri:          string,
- googleServiceAccount: string, [null unless the DOS url belongs to a Bond supported host]
- signedUrl:      string [always the empty string '']
+ googleServiceAccount: object, [null unless the DOS url belongs to a Bond supported host]
+ signedUrl:      string [always the empty string ''],
+ hashes:         object [contains the hashes type and their checksum value]
+```
+
+Example response for /martha_v3:
+
+```
+{
+    "contentType": "application/octet-stream",
+    "size": 156018255,
+    "timeCreated": "2020-04-27T15:56:09.696Z",
+    "updated": "2020-04-27T15:56:09.696Z",
+    "bucket": "my-bucket",
+    "name": "dd3c716a-852f-4d74-9073-9920e835ec8a/f3b148ac-1802-4acc-a0b9-610ea266fb61",
+    "gsUri": "gs://my-bucket/dd3c716a-852f-4d74-9073-9920e835ec8a/f3b148ac-1802-4acc-a0b9-610ea266fb61",
+    "googleServiceAccount": null,
+    "signedUrl": "",
+    "hashes": {
+        "md5": "336ea55913bc261b72875bd259753046",
+        "sha256": "f76877f8e86ec3932fd2ae04239fbabb8c90199dab0019ae55fa42b31c314c44",
+        "crc32c": "8a366443"
+    }
+}
 ```
 
 **NOTE:**

--- a/common/helpers.js
+++ b/common/helpers.js
@@ -247,7 +247,7 @@ function getMd5Checksum(checksums) {
  */
 function getHashesMap(checksumArray) {
     /*
-        if there are more than 1 entry for same type of hash, the last hash value in the checksums array for that
+        if there are more than 1 checksum for same type of hash, the last hash value in the checksums array for that
         type will be taken
      */
     return checksumArray.reduce(function(map, obj){

--- a/common/helpers.js
+++ b/common/helpers.js
@@ -118,8 +118,7 @@ class CommonFileInfoResponse {
         bucket,
         name,
         gsUri,
-        googleServiceAccount,
-        signedUrl,
+        googleServiceAccount
     ) {
         this.contentType = contentType || '';
         this.size = size || 0;
@@ -129,7 +128,6 @@ class CommonFileInfoResponse {
         this.name = name || '';
         this.gsUri = gsUri || '';
         this.googleServiceAccount = googleServiceAccount || null;
-        this.signedUrl = signedUrl || '';
     }
 }
 
@@ -146,7 +144,6 @@ class MarthaV3Response extends CommonFileInfoResponse {
         name,
         gsUri,
         googleServiceAccount,
-        signedUrl,
         hashesMap
     ) {
         super(
@@ -157,8 +154,7 @@ class MarthaV3Response extends CommonFileInfoResponse {
             bucket,
             name,
             gsUri,
-            googleServiceAccount,
-            signedUrl
+            googleServiceAccount
         );
         this.hashes = hashesMap || {};
     }
@@ -188,10 +184,10 @@ class FileSummaryV1Response extends CommonFileInfoResponse {
             bucket,
             name,
             gsUri,
-            googleServiceAccount,
-            signedUrl
+            googleServiceAccount
         );
         this.md5Hash = hash || '';
+        this.signedUrl = signedUrl || '';
     }
 }
 
@@ -317,7 +313,6 @@ function convertToMarthaV3Response(drsResponse, googleServiceAccount) {
     const gsUrl = getGsUrlFromDrsObject(drsResponse);
     const [bucket, name] = parseGsUri(gsUrl);
     const hashesMap = getHashesMap(checksums);
-    const signedUrl = null; // Not included currently when returning only the drs metadata
 
     return new MarthaV3Response(
         mimeType,
@@ -328,7 +323,6 @@ function convertToMarthaV3Response(drsResponse, googleServiceAccount) {
         name,
         gsUrl,
         googleServiceAccount,
-        signedUrl,
         hashesMap
     );
 }

--- a/common/helpers.js
+++ b/common/helpers.js
@@ -247,7 +247,7 @@ function getHashesMap(checksumArray) {
         if (!hashMapAsObj.hasOwnProperty(checksumObj.type)) {
             hashMapAsObj[checksumObj.type] = checksumObj.checksum;
             return hashMapAsObj;
-        } else throw new Error("Response from DRS Resolution server contained duplicate checksum values for" +
+        } else throw new Error('Response from DRS Resolution server contained duplicate checksum values for' +
             ` hash type '${checksumObj.type}' in checksums array!`);
     }, {});
 }

--- a/common/helpers.js
+++ b/common/helpers.js
@@ -68,7 +68,7 @@ function determinePathname(someUrl) {
  */
 function preserveHostnameCase(parsedUrl, rawUrl) {
     const hostnameRegExp = new RegExp(parsedUrl.hostname, 'i');
-    parsedUrl.hostname = hostnameRegExp.exec(rawUrl)[0]
+    parsedUrl.hostname = hostnameRegExp.exec(rawUrl)[0];
 }
 
 // 3 Scenarios we need to account for:

--- a/common/helpers.js
+++ b/common/helpers.js
@@ -240,15 +240,15 @@ function getMd5Checksum(checksums) {
  * @param {string} checksums[].checksum The hex-string encoded checksum for the data
  * @param {string} checksums[].type The digest method used to create the checksum
  * @returns {Object} The checksum map as an object
+ * @throws {Error} throws an error if the checksums[] contains multiple checksum values for same hash type
  */
 function getHashesMap(checksumArray) {
-    /*
-        if there are more than 1 checksum for same type of hash, the last hash value in the checksums array for that
-        type will be taken
-     */
-    return checksumArray.reduce(function(map, obj){
-        map[obj.type] = obj.checksum;
-        return map;
+    return checksumArray.reduce(function(hashMapAsObj, checksumObj){
+        if (!hashMapAsObj.hasOwnProperty(checksumObj.type)) {
+            hashMapAsObj[checksumObj.type] = checksumObj.checksum;
+            return hashMapAsObj;
+        } else throw new Error("Response from DRS Resolution server contained duplicate checksum values for" +
+            ` hash type '${checksumObj.type}' in checksums array!`);
     }, {});
 }
 

--- a/common/helpers.js
+++ b/common/helpers.js
@@ -247,8 +247,10 @@ function getHashesMap(checksumArray) {
         if (!hashMapAsObj.hasOwnProperty(checksumObj.type)) {
             hashMapAsObj[checksumObj.type] = checksumObj.checksum;
             return hashMapAsObj;
-        } else throw new Error('Response from DRS Resolution server contained duplicate checksum values for' +
-            ` hash type '${checksumObj.type}' in checksums array!`);
+        } else {
+            throw new Error('Response from DRS Resolution server contained duplicate checksum values for' +
+                ` hash type '${checksumObj.type}' in checksums array!`);
+        }
     }, {});
 }
 

--- a/fileSummaryV1/metadata_api.js
+++ b/fileSummaryV1/metadata_api.js
@@ -1,4 +1,4 @@
-const { dataObjectUriToHttps, convertToFileInfoResponse, samBaseUrl, getMd5Checksum, parseGsUri } = require('../common/helpers');
+const { dataObjectUriToHttps, FileSummaryV1Response, samBaseUrl, getMd5Checksum, parseGsUri } = require('../common/helpers');
 const apiAdapter = require('../common/api_adapter');
 
 function getRawMetadata(token, bucket, name) {
@@ -36,18 +36,18 @@ function getGsObjectMetadata(gsUri, auth) {
                 'last-modified': lastModified, 'x-goog-hash': xGoogHash
             } = response;
 
-            return convertToFileInfoResponse (
+            return new FileSummaryV1Response(
                 contentType,
                 parseInt(contentLength),
                 new Date(lastModified).toString(),
                 null,
-                xGoogHash.substring(xGoogHash.indexOf('md5=') + 4),
                 bucket,
                 name,
                 gsUri,
                 null,
-                null
-          );
+                null,
+                xGoogHash.substring(xGoogHash.indexOf('md5=') + 4)
+            );
         })
         .catch((e) => {
             console.error(new Error(`Failed to get metadata for: ${gsUri}`));
@@ -69,17 +69,17 @@ function getDataObjectMetadata(dataObjectUri) {
             const gsUri = getGsUriFromDataObject(metadata);
             const [bucket, name] = parseGsUri(gsUri);
 
-            return convertToFileInfoResponse(
+            return new FileSummaryV1Response(
                 mimeType || 'application/octet-stream',
                 size,
                 created ? new Date(created).toString() : null,
                 updated ? new Date(updated).toString() : null,
-                getMd5Checksum(checksums),
                 bucket,
                 name,
                 gsUri,
                 null,
-                null
+                null,
+                getMd5Checksum(checksums)
             );
         })
         .catch((e) => {

--- a/martha/martha_v3.js
+++ b/martha/martha_v3.js
@@ -1,4 +1,4 @@
-const { dataObjectUriToHttps, parseRequest, getFileInfoFromDrsResponse } = require('../common/helpers');
+const { dataObjectUriToHttps, parseRequest, convertToMarthaV3Response } = require('../common/helpers');
 const { maybeTalkToBond, determineBondProvider, BondProviders } = require('../common/bond');
 const apiAdapter = require('../common/api_adapter');
 
@@ -22,7 +22,7 @@ function getDataObjectMetadata(dataObjectResolutionUrl, auth, bondProvider) {
 function aggregateResponses(responses) {
     const drsResponse = responses[0];
     const googleServiceAccount = responses[1];
-    return getFileInfoFromDrsResponse(drsResponse, googleServiceAccount);
+    return convertToMarthaV3Response(drsResponse, googleServiceAccount);
 }
 
 function marthaV3Handler(req, res) {

--- a/test/common/helpers.test.js
+++ b/test/common/helpers.test.js
@@ -1,5 +1,5 @@
 const test = require('ava');
-const { dataObjectUriToHttps, samBaseUrl } = require('../../common/helpers');
+const { dataObjectUriToHttps, samBaseUrl, getHashesMap } = require('../../common/helpers');
 const config = require('../../config.json');
 
 /**
@@ -149,4 +149,73 @@ test('dataObjectUriToHttps should throw a Error when passed an invalid uri', (t)
 
 test('samBaseUrl should come from the config json', (t) => {
     t.is(samBaseUrl(), config.samBaseUrl);
+});
+
+/**
+ * Test the getHashesMap() function
+ */
+
+test('getHashesMap should return empty object for empty checksums array', (t) => {
+    t.deepEqual(getHashesMap([]), {})
+});
+
+test('getHashesMap should return map with 1 entry for checksums array with 1 element', (t) => {
+    const checksumArray = [
+        {
+            type: 'md5',
+            checksum: '336ea55913bc261b72875bd259753046'
+        }
+    ];
+    const expectedChecksumMap = {
+        md5: '336ea55913bc261b72875bd259753046'
+    };
+
+    t.deepEqual(getHashesMap(checksumArray), expectedChecksumMap)
+});
+
+test('getHashesMap should return map with multiple hashes for checksums array', (t) => {
+    const checksumArray = [
+        {
+            type: 'md5',
+            checksum: '336ea55913bc261b72875bd259753046'
+        },
+        {
+            type: 'sha256',
+            checksum: 'f76877f8e86ec3932fd2ae04239fbabb8c90199dab0019ae55fa42b31c314c44'
+        },
+        {
+            type: 'crc32c',
+            checksum: '8a366443'
+        },
+    ];
+    const expectedChecksumMap = {
+        md5: '336ea55913bc261b72875bd259753046',
+        sha256: 'f76877f8e86ec3932fd2ae04239fbabb8c90199dab0019ae55fa42b31c314c44',
+        crc32c: '8a366443'
+    };
+
+    t.deepEqual(getHashesMap(checksumArray), expectedChecksumMap)
+});
+
+test('getHashesMap should return map for checksums array containing multiple `checksum` for same `type`', (t) => {
+    const checksumArray = [
+        {
+            type: 'md5',
+            checksum: '336ea55913bc261b72875bd259753046'
+        },
+        {
+            type: 'sha256',
+            checksum: 'f76877f8e86ec3932fd2ae04239fbabb8c90199dab0019ae55fa42b31c314c44'
+        },
+        {
+            type: 'md5',
+            checksum: 'a06d435b61a55eb5c0f712c1d88ac782'
+        },
+    ];
+    const expectedChecksumMap = {
+        md5: 'a06d435b61a55eb5c0f712c1d88ac782',
+        sha256: 'f76877f8e86ec3932fd2ae04239fbabb8c90199dab0019ae55fa42b31c314c44'
+    };
+
+    t.deepEqual(getHashesMap(checksumArray), expectedChecksumMap)
 });

--- a/test/common/helpers.test.js
+++ b/test/common/helpers.test.js
@@ -197,7 +197,7 @@ test('getHashesMap should return map with multiple hashes for checksums array', 
     t.deepEqual(getHashesMap(checksumArray), expectedChecksumMap);
 });
 
-test('getHashesMap should return map for checksums array containing multiple `checksum` for same `type`', (t) => {
+test('getHashesMap should throw error if the checksums array contains duplicate `checksum` values for same `type`', (t) => {
     const checksumArray = [
         {
             type: 'md5',
@@ -212,10 +212,13 @@ test('getHashesMap should return map for checksums array containing multiple `ch
             checksum: 'a06d435b61a55eb5c0f712c1d88ac782'
         },
     ];
-    const expectedChecksumMap = {
-        md5: 'a06d435b61a55eb5c0f712c1d88ac782',
-        sha256: 'f76877f8e86ec3932fd2ae04239fbabb8c90199dab0019ae55fa42b31c314c44'
-    };
 
-    t.deepEqual(getHashesMap(checksumArray), expectedChecksumMap);
+    t.throws(
+        () => getHashesMap(checksumArray),
+        {
+            instanceOf: Error,
+            message: 'Response from DRS Resolution server contained duplicate checksum values for hash type \'md5\' in checksums array!'
+        },
+        'Should have throw error but didnt!'
+    );
 });

--- a/test/common/helpers.test.js
+++ b/test/common/helpers.test.js
@@ -156,7 +156,7 @@ test('samBaseUrl should come from the config json', (t) => {
  */
 
 test('getHashesMap should return empty object for empty checksums array', (t) => {
-    t.deepEqual(getHashesMap([]), {})
+    t.deepEqual(getHashesMap([]), {});
 });
 
 test('getHashesMap should return map with 1 entry for checksums array with 1 element', (t) => {
@@ -170,7 +170,7 @@ test('getHashesMap should return map with 1 entry for checksums array with 1 ele
         md5: '336ea55913bc261b72875bd259753046'
     };
 
-    t.deepEqual(getHashesMap(checksumArray), expectedChecksumMap)
+    t.deepEqual(getHashesMap(checksumArray), expectedChecksumMap);
 });
 
 test('getHashesMap should return map with multiple hashes for checksums array', (t) => {
@@ -194,7 +194,7 @@ test('getHashesMap should return map with multiple hashes for checksums array', 
         crc32c: '8a366443'
     };
 
-    t.deepEqual(getHashesMap(checksumArray), expectedChecksumMap)
+    t.deepEqual(getHashesMap(checksumArray), expectedChecksumMap);
 });
 
 test('getHashesMap should return map for checksums array containing multiple `checksum` for same `type`', (t) => {
@@ -217,5 +217,5 @@ test('getHashesMap should return map for checksums array containing multiple `ch
         sha256: 'f76877f8e86ec3932fd2ae04239fbabb8c90199dab0019ae55fa42b31c314c44'
     };
 
-    t.deepEqual(getHashesMap(checksumArray), expectedChecksumMap)
+    t.deepEqual(getHashesMap(checksumArray), expectedChecksumMap);
 });

--- a/test/fileSummaryV1/fileSummaryV1.test.js
+++ b/test/fileSummaryV1/fileSummaryV1.test.js
@@ -14,7 +14,7 @@ const saKeys = require('../../fileSummaryV1/service_account_keys');
 const metadataApi = require('../../fileSummaryV1/metadata_api');
 const createSignedGsUrl = require('../../common/createSignedGsUrl');
 const apiAdapter = require('../../common/api_adapter');
-const { convertToFileInfoResponse } = require('../../common/helpers');
+const { FileSummaryV1Response } = require('../../common/helpers');
 
 const mockRequest = (req) => {
     req.method = 'POST';
@@ -34,17 +34,17 @@ const mockResponse = () => {
 };
 
 const gsObjectMetadata = () => {
-    return convertToFileInfoResponse(
+    return new FileSummaryV1Response(
         'application/json',
         1234,
         null,
         'Mon, 16 Jul 2018 21:36:14 GMT',
-        'abcdefg',
         'some.fake-location',
         'file.txt',
         'gs://some.fake-location/file.txt',
         null,
-        null
+        null,
+        'abcdefg'
     );
 };
 
@@ -52,17 +52,17 @@ const fakeSignedUrl = 'http://i.am.a.signed.url.com/totallyMadeUp';
 const fakeSAKey = {key: 'I am not real'};
 
 const fullExpectedResult = () => {
-    return convertToFileInfoResponse(
+    return new FileSummaryV1Response(
       'application/json',
       1234,
       null,
       'Mon, 16 Jul 2018 21:36:14 GMT',
-      'abcdefg',
       'some.fake-location',
       'file.txt',
       'gs://some.fake-location/file.txt',
       null,
-      fakeSignedUrl
+      fakeSignedUrl,
+      'abcdefg'
     );
 };
 

--- a/test/martha/integration_v3.test.js
+++ b/test/martha/integration_v3.test.js
@@ -237,7 +237,6 @@ test.cb('integration_v3 responds with Data Object for authorized user for jade d
                         'gs://broad-jade-dev-data-bucket/fd8d8492-ad02-447d-b54e-35a7ffd0e7a5/' +
                         '8b07563a-542f-4b5c-9e00-e8fe6b1861de',
                     googleServiceAccount: null,
-                    signedUrl: '',
                     hashes: {
                         md5: '336ea55913bc261b72875bd259753046',
                         crc32c: 'ecb19226'

--- a/test/martha/integration_v3.test.js
+++ b/test/martha/integration_v3.test.js
@@ -231,7 +231,6 @@ test.cb('integration_v3 responds with Data Object for authorized user for jade d
                     size: 15601108255,
                     timeCreated: '2020-04-27T15:56:09.696Z',
                     updated: '2020-04-27T15:56:09.696Z',
-                    md5Hash: '336ea55913bc261b72875bd259753046',
                     bucket: 'broad-jade-dev-data-bucket',
                     name: 'fd8d8492-ad02-447d-b54e-35a7ffd0e7a5/8b07563a-542f-4b5c-9e00-e8fe6b1861de',
                     gsUri:
@@ -239,6 +238,10 @@ test.cb('integration_v3 responds with Data Object for authorized user for jade d
                         '8b07563a-542f-4b5c-9e00-e8fe6b1861de',
                     googleServiceAccount: null,
                     signedUrl: '',
+                    hashes: {
+                        md5: '336ea55913bc261b72875bd259753046',
+                        crc32c: 'ecb19226'
+                    }
                 }
             );
         })

--- a/test/martha/martha_v3.test.js
+++ b/test/martha/martha_v3.test.js
@@ -75,7 +75,6 @@ const fullExpectedResult = (expectedGoogleServiceAccount) => {
         gsUri:
             'gs://broad-jade-dev-data-bucket/fd8d8492-ad02-447d-b54e-35a7ffd0e7a5/8b07563a-542f-4b5c-9e00-e8fe6b1861de',
         googleServiceAccount: expectedGoogleServiceAccount,
-        signedUrl: '',
         hashes: {
             md5: '336ea55913bc261b72875bd259753046',
             sha256: 'f76877f8e86ec3932fd2ae04239fbabb8c90199dab0019ae55fa42b31c314c44',

--- a/test/martha/martha_v3.test.js
+++ b/test/martha/martha_v3.test.js
@@ -42,6 +42,14 @@ const dataRepositoryServiceObject = {
         {
             checksum: '336ea55913bc261b72875bd259753046',
             type: 'md5'
+        },
+        {
+            checksum: 'f76877f8e86ec3932fd2ae04239fbabb8c90199dab0019ae55fa42b31c314c44',
+            type: 'sha256'
+        },
+        {
+            checksum: '8a366443',
+            type: 'crc32c'
         }
     ],
     access_methods: [ // eslint-disable-line camelcase
@@ -62,13 +70,17 @@ const fullExpectedResult = (expectedGoogleServiceAccount) => {
         size: 15601108255,
         timeCreated: '2020-04-27T15:56:09.696Z',
         updated: '2020-04-27T15:56:09.696Z',
-        md5Hash: '336ea55913bc261b72875bd259753046',
         bucket: 'broad-jade-dev-data-bucket',
         name: 'fd8d8492-ad02-447d-b54e-35a7ffd0e7a5/8b07563a-542f-4b5c-9e00-e8fe6b1861de',
         gsUri:
             'gs://broad-jade-dev-data-bucket/fd8d8492-ad02-447d-b54e-35a7ffd0e7a5/8b07563a-542f-4b5c-9e00-e8fe6b1861de',
         googleServiceAccount: expectedGoogleServiceAccount,
         signedUrl: '',
+        hashes: {
+            md5: '336ea55913bc261b72875bd259753046',
+            sha256: 'f76877f8e86ec3932fd2ae04239fbabb8c90199dab0019ae55fa42b31c314c44',
+            crc32c: '8a366443'
+        }
     };
 };
 


### PR DESCRIPTION
This PR adds support for new JSON object, “hashes” that contains the keys: hash type, and the corresponding hash in `/martha_v3` response.

Closes https://broadworkbench.atlassian.net/browse/WA-219