### PR TITLE
Move build process from Quay to GCR [WA-222]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -95,7 +95,8 @@ jobs:
       - image: google/cloud-sdk
 
     environment:
-      IMAGE_NAME: gcr.io/broad-dsp-gcr-public/martha
+      # Martha will be pushed to GCR as a public image since it was public in Quay as well
+      IMAGE_NAME: us.gcr.io/broad-dsp-gcr-public/martha
 
     steps:
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -129,6 +129,7 @@ jobs:
           name: Push to GCR
           command: |
             apt-get install -y jq
+            apt-get install -y sudo
             # Get the credentials used to push to GCR from CircleCI
             echo ${QUAY_USER} > ${HOME}/gcr_auth_key_file.json
             gcloud auth activate-service-account --key-file ${HOME}/gcr_auth_key_file.json

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -97,7 +97,7 @@ jobs:
     environment:
       GCR_REGISTRY: broad-dsp-gcr-public
       # Martha will be pushed to GCR as a public image since it was public in Quay as well
-      IMAGE_NAME: us.gcr.io/${GCR_REGISTRY}/martha
+      IMAGE_NAME: us.gcr.io/$GCR_REGISTRY/martha
 
     steps:
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -95,9 +95,11 @@ jobs:
       - image: google/cloud-sdk
 
     environment:
+      QUAY_IMAGE_NAME: quay.io/broadinstitute/martha
+      QUAY_USER: broadinstitute+martha_circle_bot
       GCR_REGISTRY_HOST: us.gcr.io
       # Martha will be pushed to GCR as a public image since it was public in Quay as well
-      IMAGE_NAME: us.gcr.io/broad-dsp-gcr-public/martha
+      GCR_IMAGE_NAME: us.gcr.io/broad-dsp-gcr-public/martha
 
     steps:
       - checkout
@@ -108,8 +110,12 @@ jobs:
       - run:
           name: Build image
           command: |
-            docker build -t ${IMAGE_NAME}:${CIRCLE_BRANCH} -f docker/Dockerfile .
-            if [[ ${CIRCLE_BRANCH} == "dev" ]]; then docker tag ${IMAGE_NAME}:${CIRCLE_BRANCH} ${IMAGE_NAME}:latest ; fi
+            docker build -t ${GCR_IMAGE_NAME}:${CIRCLE_BRANCH} -f docker/Dockerfile .
+            docker tag ${GCR_IMAGE_NAME}:${CIRCLE_BRANCH} ${QUAY_IMAGE_NAME}:${CIRCLE_BRANCH}
+            if [[ ${CIRCLE_BRANCH} == "dev" ]]; then
+              docker tag ${GCR_IMAGE_NAME}:${CIRCLE_BRANCH} ${GCR_IMAGE_NAME}:latest
+              docker tag ${QUAY_IMAGE_NAME}:${CIRCLE_BRANCH} ${QUAY_IMAGE_NAME}:latest
+            fi
 
       - run:
           name: Install trivy
@@ -120,9 +126,11 @@ jobs:
           name: Scan the local image with trivy (light)
           command:  |
             if [[ ${CIRCLE_BRANCH} == "dev" ]]; then 
-            trivy --exit-code 1 --severity CRITICAL --no-progress ${IMAGE_NAME}:latest
-            else 
-            trivy --exit-code 1 --severity CRITICAL --no-progress ${IMAGE_NAME}:${CIRCLE_BRANCH} 
+            trivy --exit-code 1 --severity CRITICAL --no-progress ${GCR_IMAGE_NAME}:latest
+            trivy --exit-code 1 --severity CRITICAL --no-progress ${QUAY_IMAGE_NAME}:latest
+            else
+            trivy --exit-code 1 --severity CRITICAL --no-progress ${GCR_IMAGE_NAME}:${CIRCLE_BRANCH}
+            trivy --exit-code 1 --severity CRITICAL --no-progress ${QUAY_IMAGE_NAME}:${CIRCLE_BRANCH}
             fi
 
       - run:
@@ -131,7 +139,7 @@ jobs:
             # We need to push to Quay as well so that FIAB tests don't fail. Once WA-240 (https://broadworkbench.atlassian.net/browse/WA-240)
             # is done, pushing to Quay should be removed in WA-241 (https://broadworkbench.atlassian.net/browse/WA-241).
             docker login -u="${QUAY_USER}" -p="${QUAY_USER_PW}" quay.io
-            docker push ${IMAGE_NAME}
+            docker push ${QUAY_IMAGE_NAME}
 
       - run:
           name: Push to GCR
@@ -141,7 +149,7 @@ jobs:
             gcloud auth activate-service-account --key-file ${HOME}/gcr_auth_key_file.json
             # Register `gcloud` as a Docker credential helper. Add `-q` to silence confirmation prompts
             gcloud auth configure-docker ${GCR_REGISTRY_HOST} -q
-            docker push ${IMAGE_NAME}
+            docker push ${GCR_IMAGE_NAME}
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -95,7 +95,6 @@ jobs:
       - image: google/cloud-sdk
 
     environment:
-      GCR_REGISTRY: broad-dsp-gcr-public
       # Martha will be pushed to GCR as a public image since it was public in Quay as well
       IMAGE_NAME: us.gcr.io/broad-dsp-gcr-public/martha
 
@@ -139,7 +138,7 @@ jobs:
             jq .data > ${HOME}/gcr_auth_key_file.json
             gcloud auth activate-service-account --key-file ${HOME}/gcr_auth_key_file.json
             # Register `gcloud` as a Docker credential helper. Add `-q` to silence confirmation prompts
-            gcloud auth configure-docker ${GCR_REGISTRY} -q
+            gcloud auth configure-docker ${IMAGE_NAME} -q
             docker push ${IMAGE_NAME}
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -126,18 +126,11 @@ jobs:
             fi 
 
       - run:
-          name: Push to quay
+          name: Push to GCR
           command: |
-            # TODO: SSHAH_TEMP_VAULT_TOKEN should be removed and replaced with actual vault token env variable before merging
             apt-get install -y jq
-            # Get the credentials used to push to GCR out of Vault and put key into file
-            docker run \
-                --rm \
-                --env "VAULT_TOKEN=${SSHAH_TEMP_VAULT_TOKEN}" \
-                broadinstitute/dsde-toolbox \
-                vault read \
-                --format=json "secret/dsde/dsp-techops/common/dspci-wb-gcr-service-account.json" |
-            jq .data > ${HOME}/gcr_auth_key_file.json
+            # Get the credentials used to push to GCR from CircleCI
+            echo ${QUAY_USER} > ${HOME}/gcr_auth_key_file.json
             gcloud auth activate-service-account --key-file ${HOME}/gcr_auth_key_file.json
             # Register `gcloud` as a Docker credential helper. Add `-q` to silence confirmation prompts
             gcloud auth configure-docker ${GCR_REGISTRY_HOST} -q

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -95,7 +95,7 @@ jobs:
       - image: google/cloud-sdk
 
     environment:
-      GCR_REGISTRY: us.gcr.io/broad-dsp-gcr-public
+      GCR_REGISTRY: us.gcr.io
       # Martha will be pushed to GCR as a public image since it was public in Quay as well
       IMAGE_NAME: us.gcr.io/broad-dsp-gcr-public/martha
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -95,8 +95,9 @@ jobs:
       - image: google/cloud-sdk
 
     environment:
+      GCR_REGISTRY: broad-dsp-gcr-public
       # Martha will be pushed to GCR as a public image since it was public in Quay as well
-      IMAGE_NAME: us.gcr.io/broad-dsp-gcr-public/martha
+      IMAGE_NAME: us.gcr.io/${GCR_REGISTRY}/martha
 
     steps:
       - checkout
@@ -138,7 +139,7 @@ jobs:
             jq .data > ${HOME}/gcr_auth_key_file.json
             gcloud auth activate-service-account --key-file ${HOME}/gcr_auth_key_file.json
             # Register `gcloud` as a Docker credential helper. Add `-q` to silence confirmation prompts
-            gcloud auth configure-docker -q
+            gcloud auth configure-docker ${GCR_REGISTRY} -q
             docker push ${IMAGE_NAME}
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -126,6 +126,7 @@ jobs:
       - run:
           name: Push to quay
           command: |
+            apt-get install jq
             # Get the credentials used to push to GCR out of Vault and put key into file
             docker run \
                 --rm \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -114,8 +114,7 @@ jobs:
       - run:
           name: Install trivy
           command: |
-            apt-get install -y sudo
-            curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/master/contrib/install.sh | sudo sh -s -- -b /usr/local/bin
+            curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/master/contrib/install.sh | sh -s -- -b /usr/local/bin
   
       - run:
           name: Scan the local image with trivy (light)
@@ -124,7 +123,15 @@ jobs:
             trivy --exit-code 1 --severity CRITICAL --no-progress ${IMAGE_NAME}:latest
             else 
             trivy --exit-code 1 --severity CRITICAL --no-progress ${IMAGE_NAME}:${CIRCLE_BRANCH} 
-            fi 
+            fi
+
+      - run:
+          name: Push to Quay
+          command: |
+            # We need to push to Quay as well so that FIAB tests don't fail. Once WA-240 (https://broadworkbench.atlassian.net/browse/WA-240)
+            # is done, pushing to Quay should be removed in WA-241 (https://broadworkbench.atlassian.net/browse/WA-241).
+            docker login -u="${QUAY_USER}" -p="${QUAY_USER_PW}" quay.io
+            docker push ${IMAGE_NAME}
 
       - run:
           name: Push to GCR

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -95,7 +95,7 @@ jobs:
       - image: google/cloud-sdk
 
     environment:
-      GCR_REGISTRY: us.gcr.io
+      GCR_REGISTRY_HOST: us.gcr.io
       # Martha will be pushed to GCR as a public image since it was public in Quay as well
       IMAGE_NAME: us.gcr.io/broad-dsp-gcr-public/martha
 
@@ -128,6 +128,7 @@ jobs:
       - run:
           name: Push to quay
           command: |
+            # TODO: SSHAH_TEMP_VAULT_TOKEN should be removed and replaced with actual vault token env variable before merging
             apt-get install -y jq
             # Get the credentials used to push to GCR out of Vault and put key into file
             docker run \
@@ -139,7 +140,7 @@ jobs:
             jq .data > ${HOME}/gcr_auth_key_file.json
             gcloud auth activate-service-account --key-file ${HOME}/gcr_auth_key_file.json
             # Register `gcloud` as a Docker credential helper. Add `-q` to silence confirmation prompts
-            gcloud auth configure-docker ${GCR_REGISTRY} -q
+            gcloud auth configure-docker ${GCR_REGISTRY_HOST} -q
             docker push ${IMAGE_NAME}
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -95,6 +95,7 @@ jobs:
       - image: google/cloud-sdk
 
     environment:
+      GCR_REGISTRY: us.gcr.io/broad-dsp-gcr-public
       # Martha will be pushed to GCR as a public image since it was public in Quay as well
       IMAGE_NAME: us.gcr.io/broad-dsp-gcr-public/martha
 
@@ -138,7 +139,7 @@ jobs:
             jq .data > ${HOME}/gcr_auth_key_file.json
             gcloud auth activate-service-account --key-file ${HOME}/gcr_auth_key_file.json
             # Register `gcloud` as a Docker credential helper. Add `-q` to silence confirmation prompts
-            gcloud auth configure-docker ${IMAGE_NAME} -q
+            gcloud auth configure-docker ${GCR_REGISTRY} -q
             docker push ${IMAGE_NAME}
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -137,7 +137,9 @@ jobs:
                 --format=json "secret/dsde/dsp-techops/common/dspci-wb-gcr-service-account.json" |
             jq .data > ${HOME}/gcr_auth_key_file.json
             gcloud auth activate-service-account --key-file ${HOME}/gcr_auth_key_file.json
-            gcloud docker -- push ${IMAGE_NAME}
+            # Register `gcloud` as a Docker credential helper. Add `-q` to silence confirmation prompts
+            gcloud auth configure-docker -q
+            docker push ${IMAGE_NAME}
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -114,6 +114,7 @@ jobs:
       - run:
           name: Install trivy
           command: |
+            apt-get install -y sudo
             curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/master/contrib/install.sh | sudo sh -s -- -b /usr/local/bin
   
       - run:
@@ -129,7 +130,6 @@ jobs:
           name: Push to GCR
           command: |
             apt-get install -y jq
-            apt-get install -y sudo
             # Get the credentials used to push to GCR from CircleCI
             echo ${QUAY_USER} > ${HOME}/gcr_auth_key_file.json
             gcloud auth activate-service-account --key-file ${HOME}/gcr_auth_key_file.json

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -97,7 +97,7 @@ jobs:
     environment:
       GCR_REGISTRY: broad-dsp-gcr-public
       # Martha will be pushed to GCR as a public image since it was public in Quay as well
-      IMAGE_NAME: us.gcr.io/$GCR_REGISTRY/martha
+      IMAGE_NAME: us.gcr.io/${{GCR_REGISTRY}}/martha
 
     steps:
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -126,7 +126,7 @@ jobs:
       - run:
           name: Push to quay
           command: |
-            apt-get install jq
+            apt-get install -y jq
             # Get the credentials used to push to GCR out of Vault and put key into file
             docker run \
                 --rm \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -92,7 +92,7 @@ jobs:
   build-image:
     <<: *job_defaults
     docker:
-      - image: circleci/node:12.16.1
+      - image: google/cloud-sdk
 
     environment:
       IMAGE_NAME: gcr.io/broad-dsp-gcr-public/martha

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -129,9 +129,8 @@ jobs:
       - run:
           name: Push to GCR
           command: |
-            apt-get install -y jq
             # Get the credentials used to push to GCR from CircleCI
-            echo ${QUAY_USER} > ${HOME}/gcr_auth_key_file.json
+            echo ${GCR_SA} > ${HOME}/gcr_auth_key_file.json
             gcloud auth activate-service-account --key-file ${HOME}/gcr_auth_key_file.json
             # Register `gcloud` as a Docker credential helper. Add `-q` to silence confirmation prompts
             gcloud auth configure-docker ${GCR_REGISTRY_HOST} -q

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -95,8 +95,7 @@ jobs:
       - image: circleci/node:12.16.1
 
     environment:
-      IMAGE_NAME: quay.io/broadinstitute/martha
-      QUAY_USER: broadinstitute+martha_circle_bot
+      IMAGE_NAME: gcr.io/broad-dsp-gcr-public/martha
 
     steps:
       - checkout
@@ -127,8 +126,16 @@ jobs:
       - run:
           name: Push to quay
           command: |
-            docker login -u="${QUAY_USER}" -p="${QUAY_USER_PW}" quay.io
-            docker push ${IMAGE_NAME}
+            # Get the credentials used to push to GCR out of Vault and put key into file
+            docker run \
+                --rm \
+                --env "VAULT_TOKEN=${SSHAH_TEMP_VAULT_TOKEN}" \
+                broadinstitute/dsde-toolbox \
+                vault read \
+                --format=json "secret/dsde/dsp-techops/common/dspci-wb-gcr-service-account.json" |
+            jq .data > ${HOME}/gcr_auth_key_file.json
+            gcloud auth activate-service-account --key-file ${HOME}/gcr_auth_key_file.json
+            gcloud docker -- push ${IMAGE_NAME}
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -97,7 +97,7 @@ jobs:
     environment:
       GCR_REGISTRY: broad-dsp-gcr-public
       # Martha will be pushed to GCR as a public image since it was public in Quay as well
-      IMAGE_NAME: us.gcr.io/${{GCR_REGISTRY}}/martha
+      IMAGE_NAME: us.gcr.io/broad-dsp-gcr-public/martha
 
     steps:
       - checkout

--- a/deploy-cromwell-dev.sh
+++ b/deploy-cromwell-dev.sh
@@ -2,7 +2,7 @@
 set -eoux pipefail
 
 GIT_BRANCH="$(git rev-parse --abbrev-ref HEAD)"
-MARTHA_IMAGE="quay.io/broadinstitute/martha:${GIT_BRANCH}"
+MARTHA_IMAGE="gcr.io/broad-dsp-gcr-public/martha:${GIT_BRANCH}"
 
 docker build \
     --tag "${MARTHA_IMAGE}" \

--- a/deploy-cromwell-dev.sh
+++ b/deploy-cromwell-dev.sh
@@ -2,7 +2,7 @@
 set -eoux pipefail
 
 GIT_BRANCH="$(git rev-parse --abbrev-ref HEAD)"
-MARTHA_IMAGE="gcr.io/broad-dsp-gcr-public/martha:${GIT_BRANCH}"
+MARTHA_IMAGE="us.gcr.io/broad-dsp-gcr-public/martha:${GIT_BRANCH}"
 
 docker build \
     --tag "${MARTHA_IMAGE}" \

--- a/deploy.sh
+++ b/deploy.sh
@@ -102,13 +102,13 @@ docker run \
     "gcloud config set project ${DEPLOY_PROJECT_NAME} &&
       gcloud auth activate-service-account --key-file ${MARTHA_PATH}/${SERVICE_ACCT_KEY_FILE} &&
       cd ${MARTHA_PATH} &&
-      gcloud beta functions deploy martha_v2 --trigger-http --source=. --runtime nodejs8 \\
+      gcloud beta functions deploy martha_v2 --trigger-http --source=. --runtime nodejs10 \\
         --allow-unauthenticated --project ${DEPLOY_PROJECT_NAME} &&
-      gcloud beta functions deploy martha_v3 --trigger-http --source=. --runtime nodejs8 \\
+      gcloud beta functions deploy martha_v3 --trigger-http --source=. --runtime nodejs10 \\
         --allow-unauthenticated --project ${DEPLOY_PROJECT_NAME} &&
-      gcloud beta functions deploy fileSummaryV1 --trigger-http --source=. --runtime nodejs8 \\
+      gcloud beta functions deploy fileSummaryV1 --trigger-http --source=. --runtime nodejs10 \\
         --allow-unauthenticated --project ${DEPLOY_PROJECT_NAME} &&
-      gcloud beta functions deploy getSignedUrlV1 --trigger-http --source=. --runtime nodejs8 \\
+      gcloud beta functions deploy getSignedUrlV1 --trigger-http --source=. --runtime nodejs10 \\
         --allow-unauthenticated --project ${DEPLOY_PROJECT_NAME} &&
       npm ci &&
       npm run-script smoketest"

--- a/deploy.sh
+++ b/deploy.sh
@@ -31,7 +31,7 @@ set -u
 
 MARTHA_PATH=/martha
 SERVICE_ACCT_KEY_FILE="deploy_account.json"
-MARTHA_IMAGE="quay.io/broadinstitute/martha:${GIT_BRANCH}"
+MARTHA_IMAGE="gcr.io/broad-dsp-gcr-public/martha:${GIT_BRANCH}"
 DEPLOY_PROJECT_NAME="broad-dsde-${DEPLOY_ENV}"
 
 if [[ "${DEPLOY_ENV}" =~ ^(cromwell-dev)$ ]]; then

--- a/deploy.sh
+++ b/deploy.sh
@@ -31,7 +31,7 @@ set -u
 
 MARTHA_PATH=/martha
 SERVICE_ACCT_KEY_FILE="deploy_account.json"
-MARTHA_IMAGE="gcr.io/broad-dsp-gcr-public/martha:${GIT_BRANCH}"
+MARTHA_IMAGE="us.gcr.io/broad-dsp-gcr-public/martha:${GIT_BRANCH}"
 DEPLOY_PROJECT_NAME="broad-dsde-${DEPLOY_ENV}"
 
 if [[ "${DEPLOY_ENV}" =~ ^(cromwell-dev)$ ]]; then


### PR DESCRIPTION
This PR pushes Martha to `us.gcr.io/broad-dsp-gcr-public` registry. It reads the SA needed to push to GCR from CircleCI's environment variable settings. 

It also updates the runtime to `nodejs10` since the new version of GCS APIs were not liking `nodejs8`.

Snapshot of successful deploy in `broad-cromwell-dsde-dev`:
![image](https://user-images.githubusercontent.com/16748522/89234445-00117980-d5ba-11ea-81a6-b001ccfd3d16.png)
