### PR TITLE
Smoke tests for martha_v3 [WA-228]

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,8 +6,9 @@
   "scripts": {
     "start": "functions-framework --target=index --port=8010",
     "test": "./minnie-kenny.sh && nyc ava -m !smoketest* -m !live_test* -m !integration*",
-    "smoketest": "ava -m smoketest*",
+    "smoketest": "ava --timeout 10m --match smoketest*",
     "smoketest_v2": "ava -m smoketest_v2*",
+    "smoketest_v3": "ava --timeout 10m --match smoketest_v3*",
     "smoketest_fileSummaryV1": "ava -m smoketest_fileSummaryV1*",
     "integration": "ava --timeout 10m --match integration*",
     "integration_v2": "ava -m integration_v2*",

--- a/test/martha/smoketest_v3.test.js
+++ b/test/martha/smoketest_v3.test.js
@@ -1,0 +1,93 @@
+/** Run smoketests from the command line.  For example:
+ *
+ *    BASE_URL="https://us-central1-broad-dsde-dev.cloudfunctions.net" npm run-script smoketest_v3
+ *
+ * Run smoketests after a deployment to confirm that the functions deployed successfully
+ */
+
+const test = require('ava');
+const supertest = require('supertest')(process.env.BASE_URL);
+const assert = require('assert');
+
+const publicFenceUrl = 'dos://dg.4503/preview_dos.json';
+// Dev Jade Data Repo url. Snapshot id is 93dc1e76-8f1c-4949-8f9b-07a087f3ce7b
+const jdrDevTestUrl = 'drs://jade.datarepo-dev.broadinstitute.org/v1_93dc1e76-8f1c-4949-8f9b-07a087f3ce7b_8b07563a-542f-4b5c-9e00-e8fe6b1861de';
+
+/*
+ * NOTE: We are only testing few variation of martha_v3 tests. Because these smoke tests are executed by a Google
+ * Service Account, we are unable to test martha_v3 without first authenticating that service account with Fence.
+ */
+
+test.cb('smoketest_v3 returns error if url passed is malformed', (t) => {
+    supertest
+        .post('/martha_v3')
+        .set('Content-Type', 'application/json')
+        .send({ url: 'notAValidURL' })
+        .expect((response) => {
+            assert.ok(response.statusCode.toString().match(/4\d\d/), 'Request did not specify the URL of a DRS object');
+        })
+        .end((error, response) => {
+            if (error) { t.log(response.body); }
+            t.end(error);
+        });
+});
+
+test.cb('smoketest_v3 return error if url passed is not good', (t) => {
+    supertest
+        .post('/martha_v3')
+        .set('Content-Type', 'application/json')
+        .send({ url: 'dos://broad-dsp-dos-TYPO.storage.googleapis.com/something-that-does-not-exist' })
+        .expect((response) => {
+            assert.ok(response.statusCode.toString().match(/4\d\d/), 'Incorrect status code');
+        })
+        .end((error, response) => {
+            if (error) { t.log(response.body); }
+            t.end(error);
+        });
+});
+
+test.cb('smoketest_v3 fails when no "authorization" header is provided for public url', (t) => {
+    supertest
+        .post('/martha_v3')
+        .set('Content-Type', 'application/json')
+        .send({ url: publicFenceUrl })
+        .expect((response) => {
+            assert.ok(response.statusCode.toString().match(/4\d\d/), 'Request did not not specify an authorization header');
+        })
+        .end((error, response) => {
+            if (error) { t.log(response.body); }
+            t.end(error);
+        });
+});
+
+test.cb('smoketest_v3 fails when "authorization" header is provided for a public url but the bearer token is invalid', (t) => {
+    supertest
+        .post('/martha_v3')
+        .set('Content-Type', 'application/json')
+        .set('Authorization', 'Bearer badToken')
+        .send({ url: publicFenceUrl })
+        .expect((response) => {
+            assert.ok(response.statusCode.toString().match(/4\d\d/), 'Bond should not have authenticated this token');
+        })
+        .end((error, response) => {
+            if (error) { t.log(response.body); }
+            t.end(error);
+        });
+});
+
+// Even though this test takes few minutes to complete, this test is the only one that talks to Jade Data Repo dev
+test.cb('smoketest_v3 fails when unauthorized user is resolving jade data repo url', (t) => {
+    t.timeout(60*1000);
+    supertest
+        .post('/martha_v3')
+        .set('Content-Type', 'application/json')
+        .set('Authorization', `Bearer y29.abc.123-456`)
+        .send({ url: jdrDevTestUrl })
+        .expect((response) => {
+            assert.strictEqual(response.statusCode, 500, 'This user should be unauthorized in Jade Data Repo');
+        })
+        .end((error, response) => {
+            if (error) { t.log(response.body); }
+            t.end(error);
+        });
+});

--- a/test/martha/smoketest_v3.test.js
+++ b/test/martha/smoketest_v3.test.js
@@ -32,7 +32,7 @@ test.cb('smoketest_v3 returns error if url passed is malformed', (t) => {
         });
 });
 
-test.cb('smoketest_v3 return error if url passed is not good', (t) => {
+test.cb('smoketest_v3 return error if url passed is not valid', (t) => {
     supertest
         .post('/martha_v3')
         .set('Content-Type', 'application/json')

--- a/test/martha/smoketest_v3.test.js
+++ b/test/martha/smoketest_v3.test.js
@@ -14,7 +14,7 @@ const publicFenceUrl = 'dos://dg.4503/preview_dos.json';
 const jdrDevTestUrl = 'drs://jade.datarepo-dev.broadinstitute.org/v1_93dc1e76-8f1c-4949-8f9b-07a087f3ce7b_8b07563a-542f-4b5c-9e00-e8fe6b1861de';
 
 /*
- * NOTE: We are only testing few variation of martha_v3 tests. Because these smoke tests are executed by a Google
+ * NOTE: We are only testing few variations of martha_v3 requests. Because these smoke tests are executed by a Google
  * Service Account, we are unable to test martha_v3 without first authenticating that service account with Fence.
  */
 


### PR DESCRIPTION
I also confirmed these changes by running `./deploy-cromwell-dev.sh`:

![image](https://user-images.githubusercontent.com/16748522/89426685-6c01f800-d708-11ea-9900-d7228a4ba935.png)

```
++ git rev-parse --abbrev-ref HEAD
+ GIT_BRANCH=ss_martha_v3_smoketest
+ MARTHA_IMAGE=us.gcr.io/broad-dsp-gcr-public/martha:ss_martha_v3_smoketest
+ docker build --tag us.gcr.io/broad-dsp-gcr-public/martha:ss_martha_v3_smoketest --file docker/Dockerfile .
Sending build context to Docker daemon  53.35MB
Step 1/16 : FROM node:12.16.1
.............
.............
> martha@0.0.0 smoketest /martha
> ava --timeout 10m --match smoketest*


  ✔ fileSummaryV1 › smoketest_fileSummaryV1 › smoketest_fileSummaryV1 responds with 400 if uri passed is malformed (731ms)
  ✔ fileSummaryV1 › smoketest_fileSummaryV1 › smoketest_fileSummaryV1 responds with 400 if a uri is not provided (2.9s)
  ✔ fileSummaryV1 › smoketest_fileSummaryV1 › smoketest_fileSummaryV1 responds with 400 if uri is valid but not authorization is provided (2.9s)
  ✔ martha › smoketest_v2 › smoketest_v2 return error if url passed is malformed (370ms)
  ✔ martha › smoketest_v3 › smoketest_v3 returns error if url passed is malformed (845ms)
  ✔ martha › smoketest_v2 › smoketest_v2 return error if url passed is not good (2.3s)
  ✔ martha › smoketest_v3 › smoketest_v3 return error if url passed is not good (2.7s)
  ✔ martha › smoketest_v3 › smoketest_v3 fails when "authorization" header is provided for a public url but the bearer token is invalid (3.3s)
  ✔ martha › smoketest_v3 › smoketest_v3 fails when no "authorization" header is provided for public url (4s)
  ✔ martha › smoketest_v3 › smoketest_v3 fails when unauthorized user is resolving jade data repo url (19.4s)

  10 tests passed
```

Closes https://broadworkbench.atlassian.net/browse/WA-228