### PR TITLE
Test then docker push for git tags WA-309

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,6 +7,10 @@ version: 2
 job_defaults: &job_defaults
   working_directory: ~/repo
 
+git_tags: &git_tags
+  tags:
+    only: /^\d+\.\d+\.\d+$/
+
 run_env_setup: &run_env_setup
   run:
     name: Setup Environment Variables
@@ -107,7 +111,7 @@ jobs:
       - run:
           name: Build image
           command: |
-            docker build -t ${GCR_IMAGE_NAME}:${CIRCLE_BRANCH} -f docker/Dockerfile .
+            docker build -t "${GCR_IMAGE_NAME}:${CIRCLE_TAG:-${CIRCLE_BRANCH}}" -f docker/Dockerfile .
             if [[ ${CIRCLE_BRANCH} == "dev" ]]; then
               docker tag ${GCR_IMAGE_NAME}:${CIRCLE_BRANCH} ${GCR_IMAGE_NAME}:latest
             fi
@@ -120,11 +124,7 @@ jobs:
       - run:
           name: Scan the local image with trivy (light)
           command:  |
-            if [[ ${CIRCLE_BRANCH} == "dev" ]]; then 
-            trivy --exit-code 1 --severity CRITICAL --no-progress ${GCR_IMAGE_NAME}:latest
-            else
-            trivy --exit-code 1 --severity CRITICAL --no-progress ${GCR_IMAGE_NAME}:${CIRCLE_BRANCH}
-            fi
+            trivy --exit-code 1 --severity CRITICAL --no-progress "${GCR_IMAGE_NAME}:${CIRCLE_TAG:-${CIRCLE_BRANCH}}"
 
       - run:
           name: Push to GCR
@@ -136,20 +136,32 @@ jobs:
             gcloud auth activate-service-account --key-file ${HOME}/gcr_auth_key_file.json
             # Register `gcloud` as a Docker credential helper. Add `-q` to silence confirmation prompts
             gcloud auth configure-docker ${GCR_REGISTRY_HOST} -q
-            docker push ${GCR_IMAGE_NAME}
+
+            docker push "${GCR_IMAGE_NAME}:${CIRCLE_TAG:-${CIRCLE_BRANCH}}"
+            if [[ ${CIRCLE_BRANCH} == "dev" ]]; then
+              docker push ${GCR_IMAGE_NAME}:latest
+            fi
 
 workflows:
   version: 2
   test-and-tag:
     jobs:
-      - secrets
-      - lint
+      - secrets:
+          filters:
+            <<: *git_tags
+      - lint:
+          filters:
+            <<: *git_tags
       - test:
           requires:
             - secrets
+          filters:
+            <<: *git_tags
       - build-image:
           requires:
             - secrets
+          filters:
+            <<: *git_tags
       - tag:
           requires:
             - lint
@@ -158,3 +170,5 @@ workflows:
           filters:
             branches:
               only: dev
+            <<: *git_tags
+


### PR DESCRIPTION
Examples:
- Correctly built tag: https://app.circleci.com/pipelines/github/broadinstitute/martha/257/workflows/8e10db5b-b291-4af3-8523-34175bab62ad/jobs/1474/parallel-runs/0/steps/0-106
- Correctly ignored tag `dev_tests_passed_1597877970` for build 258: https://app.circleci.com/pipelines/github/broadinstitute/martha (See also: WA-308)

Of note in the PR:
- We tag the same image twice on `dev` by adding a `:latest` to the regular tag. The CI command to run trivy was going out of its way to test `:latest` on `dev`. Using `:latest` [was generating a trivy warning](https://app.circleci.com/pipelines/github/broadinstitute/martha/240/workflows/a664b9d9-74c7-4718-b24f-7ffb2931bf1d/jobs/1414/parallel-runs/0/steps/0-105) and we might as well use the regular tag so that code was simplified. This has been noted in the Jira security impact.
- Implicitly pushing "all the tags" had some weird side effects... why was `:aen_wa_287` available/pushed in [this GCR push](https://app.circleci.com/pipelines/github/broadinstitute/martha/256/workflows/c9eedb1f-7158-4033-b446-a62c1dfd985d/jobs/1469/parallel-runs/0/steps/0-106)?? So now we're only explicitly pushing the tags we expect.
- For the curious: some docs on CircleCI tag builds
  - https://circleci.com/docs/2.0/workflows/#executing-workflows-for-a-git-tag
  - https://circleci.com/docs/2.0/configuration-reference/#tags