### PR TITLE
The AnVIL updates and test updates GAWB-4053 WA-319

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,7 +50,7 @@ jobs:
           name: Run ESLint
           command: |
             npm install
-            npm run lint
+            npx eslint .
 
   test:
     <<: *job_defaults
@@ -120,7 +120,7 @@ jobs:
           name: Install trivy
           command: |
             curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/master/contrib/install.sh | sh -s -- -b /usr/local/bin
-  
+
       - run:
           name: Scan the local image with trivy (light)
           command:  |

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -263,7 +263,7 @@ module.exports = {
         "prefer-exponentiation-operator": "error",   // disallow calls to Math.pow() and suggests using the '**' operator instead
         "prefer-named-capture-group": "off",         // aimed at using named capture groups instead of numbered capture groups in regular expressions
         "prefer-numeric-literals": "error",          // disallow parseInt() and Number.parseInt() in favor of binary, octal, and hexadecimal literals
-        "prefer-object-spread": "off",               // prefer use of an object spread over Object.assign
+        "prefer-object-spread": "error",             // prefer use of an object spread over Object.assign
         "prefer-promise-reject-errors": "error",     // require using Error objects as Promise rejection reasons
         "prefer-regex-literals": "error",            // disallow the use of the RegExp constructor function with string literals as its arguments
         "prefer-rest-params": "error",               // disallow usage of arguments[] variables passed to functions and use variadic functions instead

--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ It will always return an object with the same properties:
  name:                  string [resolver sometimes returns null],
  gsUri:                 string [resolver sometimes returns null],
  googleServiceAccount:  object [null unless the DOS url belongs to a Bond supported host],
+ fileName:              string [resolver sometimes returns null],
  hashes:                object [contains the hashes type and their checksum value; if unknown, it returns null]
 ```
 
@@ -65,6 +66,7 @@ Example response for /martha_v3:
     "name": "dd3c716a-852f-4d74-9073-9920e835ec8a/f3b148ac-1802-4acc-a0b9-610ea266fb61",
     "gsUri": "gs://my-bucket/dd3c716a-852f-4d74-9073-9920e835ec8a/f3b148ac-1802-4acc-a0b9-610ea266fb61",
     "googleServiceAccount": null,
+    "fileName": "hello.txt",
     "hashes": {
         "md5": "336ea55913bc261b72875bd259753046",
         "sha256": "f76877f8e86ec3932fd2ae04239fbabb8c90199dab0019ae55fa42b31c314c44",
@@ -72,6 +74,18 @@ Example response for /martha_v3:
     }
 }
 ```
+
+The fields are:
+- `gsUri`: The full Google Cloud Storage URI/URL/path to the blob storing the data
+- `bucket`: The [bucket name](https://cloud.google.com/storage/docs/key-terms#bucket-names) part of the `gsUri`
+- `name`: The [object name](https://cloud.google.com/storage/docs/key-terms#object-names) part of the `gsUri`
+- `fileName`: The file name for the blob found at `gsUri`
+- `contentType`: The type of data stored in the blob found at `gsUri`
+- `size`: The size of the blob found at `gsUri`
+- `hashes`: The various hash types and values for the blob found at `gsUri`
+- `timeCreated`: The time of creation for the data found at `gsUri`
+- `timeUpdated`: The time of last update for the data found at `gsUri`
+- `googleServiceAccount`: An optional service account that should be used to access the `gsUri`
 
 **NOTE:**
 
@@ -92,48 +106,60 @@ Martha's `martha_v3` implementation translates requests-to and responses-from th
     - Martha Testing: 🤖 Continuous Automated
     - Returns Bond SA: No
     - Requires OAuth for metadata: 🔐 Yes
-- ❌ [DataGuids.org](https://dataguids.org/) (ex: any drs://dg.* other than drs://dg.4503, and not drs://dataguids.org)
+    - Example: `drs://jade.datarepo-dev.broadinstitute.org/v1_0c86170e-312d-4b39-a0a4-2a2bfaa24c7a_c0e40912-8b14-43f6-9a2f-b278144d0060`
+- ❌ [DataGuids.org](https://dataguids.org/)
+    (ex: any drs://dg.* other than drs://dg.4503, drs://dg.712C, drs://dg.ANV0, and not drs://dataguids.org)
     - Prod host: `gen3.biodatacatalyst.nhlbi.nih.gov`
     - Dev host: `staging.gen3.biodatacatalyst.nhlbi.nih.gov`
     - Martha testing: 🖐 Manual (in production)
     - Returns Bond SA: Yes, via the [Data Coordination Platform](https://data.humancellatlas.org/about) (DCP)
     - Requires OAuth for metadata: 🔓 No
-- ❌ [DataGuids.org](https://dataguids.org/) (ex: drs://dg.4503)
+    - Example: _unknown_
+- ❌ [DataGuids.org](https://dataguids.org/) (ex: drs://dg.4503 in prod and drs://dg.712C in non-prod)
     - Prod host: `gen3.biodatacatalyst.nhlbi.nih.gov`
     - Dev host: `staging.gen3.biodatacatalyst.nhlbi.nih.gov`
     - Martha testing: 🖐 Manual
     - Returns Bond SA: Yes, via the [Data Commons Framework](https://datascience.cancer.gov/data-commons/data-commons-framework) (DCF)
     - Requires OAuth for metadata: 🔓 No
+    - Example: `drs://dg.712C/fa640b0e-9779-452f-99a6-16d833d15bd0`
+- ❌ [Analysis, Visualization and Informatics Lab-space](https://www.genome.gov/Funded-Programs-Projects/Computational-Genomics-and-Data-Science-Program/Genomic-Analysis-Visualization-Informatics-Lab-space-AnVIL)
+    (AnVIL, ex: dg.ANV0)
+    - Prod host: `gen3.theanvil.io`
+    - Dev host: _unknown_
+    - Martha testing: 🚫 No testing
+    - Returns Bond SA: Yes, via the AnVIL
+    - Requires OAuth for metadata: 🔓 No
+    - Example: `drs://dg.ANV0/00008531-03d7-418c-b3d3-b7b22b5381a0`
 - ❌ [DataGuids.org](https://dataguids.org/) (ex: drs://dataguids.org, but not drs://dg.*)
     - Prod host: `dataguids.org`
     - Dev host: _unknown_
     - Martha testing: 🚫 No testing
-    - Returns Bond SA: No
+    - Returns Bond SA: Yes
     - Requires OAuth for metadata: 🔓 No
+    - Example: `dos://dataguids.org/a41b0c4f-ebfb-4277-a941-507340dea85d`
 - ❌ [Human Cell Atlas](https://github.com/HumanCellAtlas/data-store) (HCA)
     - Prod host: `drs.data.humancellatlas.org`
     - Dev host: _unknown_
     - Martha testing: 🖐 Manual (in production)
     - Returns Bond SA: No
     - Requires OAuth for metadata: 🔓 No
+    - Example:
+    `drs://drs.data.humancellatlas.org/4cf48dbf-cf09-452e-bb5b-fd016af0c747?version=2019-09-14T024754.281908Z`
 - ❌ [UCSC Single Cell Dev Server](https://drs.dev.singlecell.gi.ucsc.edu/)
     - Prod host: _unknown_
     - Dev host: `drs.dev.singlecell.gi.ucsc.edu`
     - Martha testing: 🚫 No testing
     - Returns Bond SA: No
     - Requires OAuth for metadata: 🔐 Yes
-- ❌ [Analysis, Visualization and Informatics Lab-space](https://www.genome.gov/Funded-Programs-Projects/Computational-Genomics-and-Data-Science-Program/Genomic-Analysis-Visualization-Informatics-Lab-space-AnVIL) (AnVIL)
-    - Prod host: _unknown_
-    - Dev host: _unknown_
-    - Martha testing: 🚫 No testing
-    - Returns Bond SA: No
-    - Requires OAuth for metadata: 🔓 No
+    - Example:
+    `drs://drs.dev.singlecell.gi.ucsc.edu/bee7a822-ea28-4374-8e18-8b9941392723?version=2019-05-15T205839.080730Z`
 - ❌ [Gabriella Miller Kids First Pediatric Data Resource](https://commonfund.nih.gov/kidsfirst/overview)
-    - Prod host: _unknown_
+    - Prod host: `data.kidsfirstdrc.org`
     - Dev host: _unknown_
     - Martha testing: 🚫 No testing
-    - Returns Bond SA: No
-    - Requires OAuth for metadata: _unknown_
+    - Returns Bond SA: Yes, via the [Data Coordination Platform](https://data.humancellatlas.org/about) (DCP)
+    - Requires OAuth for metadata: no
+    - Example: `drs://data.kidsfirstdrc.org/ed6be7ab-068e-46c8-824a-f39cfbb885cc`
 
 <sup>
 ✅ = DRS v1.0 hosts tested with Martha's `martha_v3` endpoint<br/>

--- a/README.md
+++ b/README.md
@@ -105,29 +105,29 @@ Martha's `martha_v3` implementation translates requests-to and responses-from th
     - Requires OAuth for metadata: 🔐 Yes
     - Example: `drs://jade.datarepo-dev.broadinstitute.org/v1_0c86170e-312d-4b39-a0a4-2a2bfaa24c7a_c0e40912-8b14-43f6-9a2f-b278144d0060`
 - ❌ [DataGuids.org](https://dataguids.org/)
-    (ex: any drs://dg.* other than drs://dg.4503, drs://dg.712C, drs://dg.ANV0, and not drs://dataguids.org)
+    (any drs://dg.* other than drs://dg.4503, drs://dg.712C, drs://dg.ANV0, and not drs://dataguids.org)
     - Prod host: `gen3.biodatacatalyst.nhlbi.nih.gov`
     - Dev host: `staging.gen3.biodatacatalyst.nhlbi.nih.gov`
     - Martha testing: 🖐 Manual (in production)
     - Returns Bond SA: Yes, via the [Data Coordination Platform](https://data.humancellatlas.org/about) (DCP)
     - Requires OAuth for metadata: 🔓 No
     - Example: _unknown_
-- ❌ [DataGuids.org](https://dataguids.org/) (ex: drs://dg.4503 in prod and drs://dg.712C in non-prod)
+- ❌ [DataGuids.org](https://dataguids.org/) (drs://dg.4503 in prod and drs://dg.712C in non-prod)
     - Prod host: `gen3.biodatacatalyst.nhlbi.nih.gov`
     - Dev host: `staging.gen3.biodatacatalyst.nhlbi.nih.gov`
     - Martha testing: 🖐 Manual
     - Returns Bond SA: Yes, via the [Data Commons Framework](https://datascience.cancer.gov/data-commons/data-commons-framework) (DCF)
     - Requires OAuth for metadata: 🔓 No
     - Example: `drs://dg.712C/fa640b0e-9779-452f-99a6-16d833d15bd0`
-- ❌ [Analysis, Visualization and Informatics Lab-space](https://www.genome.gov/Funded-Programs-Projects/Computational-Genomics-and-Data-Science-Program/Genomic-Analysis-Visualization-Informatics-Lab-space-AnVIL)
-    (AnVIL, ex: dg.ANV0)
+- ❌ The [Analysis, Visualization and Informatics Lab-space](https://www.genome.gov/Funded-Programs-Projects/Computational-Genomics-and-Data-Science-Program/Genomic-Analysis-Visualization-Informatics-Lab-space-AnVIL)
+    (The AnVIL, dg.ANV0)
     - Prod host: `gen3.theanvil.io`
     - Dev host: _unknown_
     - Martha testing: 🚫 Mock only
     - Returns Bond SA: Yes, via the AnVIL
     - Requires OAuth for metadata: 🔓 No
     - Example: `drs://dg.ANV0/00008531-03d7-418c-b3d3-b7b22b5381a0`
-- ❌ [DataGuids.org](https://dataguids.org/) (ex: drs://dataguids.org, but not drs://dg.*)
+- ❌ [DataGuids.org](https://dataguids.org/) (drs://dataguids.org, but not drs://dg.*)
     - Prod host: `dataguids.org`
     - Dev host: _unknown_
     - Martha testing: 🚫 Mock only

--- a/README.md
+++ b/README.md
@@ -50,7 +50,6 @@ It will always return an object with the same properties:
  name:                  string [resolver sometimes returns null],
  gsUri:                 string [resolver sometimes returns null],
  googleServiceAccount:  object [null unless the DOS url belongs to a Bond supported host],
- fileName:              string [resolver sometimes returns null],
  hashes:                object [contains the hashes type and their checksum value; if unknown, it returns null]
 ```
 
@@ -66,7 +65,6 @@ Example response for /martha_v3:
     "name": "dd3c716a-852f-4d74-9073-9920e835ec8a/f3b148ac-1802-4acc-a0b9-610ea266fb61",
     "gsUri": "gs://my-bucket/dd3c716a-852f-4d74-9073-9920e835ec8a/f3b148ac-1802-4acc-a0b9-610ea266fb61",
     "googleServiceAccount": null,
-    "fileName": "hello.txt",
     "hashes": {
         "md5": "336ea55913bc261b72875bd259753046",
         "sha256": "f76877f8e86ec3932fd2ae04239fbabb8c90199dab0019ae55fa42b31c314c44",
@@ -79,7 +77,6 @@ The fields are:
 - `gsUri`: The full Google Cloud Storage URI/URL/path to the blob storing the data
 - `bucket`: The [bucket name](https://cloud.google.com/storage/docs/key-terms#bucket-names) part of the `gsUri`
 - `name`: The [object name](https://cloud.google.com/storage/docs/key-terms#object-names) part of the `gsUri`
-- `fileName`: The file name for the blob found at `gsUri`
 - `contentType`: The type of data stored in the blob found at `gsUri`
 - `size`: The size of the blob found at `gsUri`
 - `hashes`: The various hash types and values for the blob found at `gsUri`

--- a/README.md
+++ b/README.md
@@ -123,14 +123,14 @@ Martha's `martha_v3` implementation translates requests-to and responses-from th
     (AnVIL, ex: dg.ANV0)
     - Prod host: `gen3.theanvil.io`
     - Dev host: _unknown_
-    - Martha testing: 🚫 No testing
+    - Martha testing: 🚫 Mock only
     - Returns Bond SA: Yes, via the AnVIL
     - Requires OAuth for metadata: 🔓 No
     - Example: `drs://dg.ANV0/00008531-03d7-418c-b3d3-b7b22b5381a0`
 - ❌ [DataGuids.org](https://dataguids.org/) (ex: drs://dataguids.org, but not drs://dg.*)
     - Prod host: `dataguids.org`
     - Dev host: _unknown_
-    - Martha testing: 🚫 No testing
+    - Martha testing: 🚫 Mock only
     - Returns Bond SA: Yes
     - Requires OAuth for metadata: 🔓 No
     - Example: `dos://dataguids.org/a41b0c4f-ebfb-4277-a941-507340dea85d`
@@ -145,18 +145,25 @@ Martha's `martha_v3` implementation translates requests-to and responses-from th
 - ❌ [UCSC Single Cell Dev Server](https://drs.dev.singlecell.gi.ucsc.edu/)
     - Prod host: _unknown_
     - Dev host: `drs.dev.singlecell.gi.ucsc.edu`
-    - Martha testing: 🚫 No testing
-    - Returns Bond SA: No
+    - Martha testing: 🚫 Mock only
+    - Returns Bond SA: Yes, via the [Data Coordination Platform](https://data.humancellatlas.org/about) (DCP)
     - Requires OAuth for metadata: 🔐 Yes
     - Example:
     `drs://drs.dev.singlecell.gi.ucsc.edu/bee7a822-ea28-4374-8e18-8b9941392723?version=2019-05-15T205839.080730Z`
 - ❌ [Gabriella Miller Kids First Pediatric Data Resource](https://commonfund.nih.gov/kidsfirst/overview)
     - Prod host: `data.kidsfirstdrc.org`
     - Dev host: _unknown_
-    - Martha testing: 🚫 No testing
+    - Martha testing: 🚫 Mock only
     - Returns Bond SA: Yes, via the [Data Coordination Platform](https://data.humancellatlas.org/about) (DCP)
     - Requires OAuth for metadata: no
     - Example: `drs://data.kidsfirstdrc.org/ed6be7ab-068e-46c8-824a-f39cfbb885cc`
+- ❌ [Cancer Research Data Commons](https://datacommons.cancer.gov/) (CRDC)
+    - Prod host: `nci-crdc.datacommons.io`
+    - Dev host: `nci-crdc-staging.datacommons.io`
+    - Martha testing: 🚫 Mock only
+    - Returns Bond SA: Yes, via the [Data Coordination Platform](https://data.humancellatlas.org/about) (DCP)
+    - Requires OAuth for metadata: 🔓 No
+    - Example: `drs://nci-crdc.datacommons.io/0027045b-9ed6-45af-a68e-f55037b5184c`
 
 <sup>
 ✅ = DRS v1.0 hosts tested with Martha's `martha_v3` endpoint<br/>

--- a/common/bond.js
+++ b/common/bond.js
@@ -17,10 +17,13 @@ const STAGING_DATASTAGE_NAMESPACE = 'dg.712c';
 const ANVIL_NAMESPACE = 'dg.anv0';
 const DATASTAGE_NAMESPACES = [PROD_DATASTAGE_NAMESPACE, STAGING_DATASTAGE_NAMESPACE];
 
+const ANVIL_HOSTNAME = 'gen3.theanvil.io';
+
 const bondBaseUrl = () => config.bondBaseUrl;
 
 // We are explicitly listing the DOS/DRS host/namespaces here for both production and staging environments.
 // At some point we expect to have a more sophisticated way to do this, but for now, we have to do it this way.
+// If you update this function update the README too!
 function determineBondProvider(urlString) {
     const url = URL.parse(urlString);
 
@@ -28,11 +31,11 @@ function determineBondProvider(urlString) {
         return BondProviders.FENCE;
     }
 
-    if (ANVIL_NAMESPACE === url.hostname.toLowerCase()) {
+    if ([ANVIL_NAMESPACE, ANVIL_HOSTNAME].includes(url.hostname.toLowerCase())) {
         return BondProviders.ANVIL;
     }
 
-    if (url.host.endsWith('.humancellatlas.org')) {
+    if (url.hostname.endsWith('.humancellatlas.org')) {
         return;
     }
 

--- a/common/bond.js
+++ b/common/bond.js
@@ -6,8 +6,7 @@ const apiAdapter = require('../common/api_adapter.js');
 const BondProviders = Object.freeze({
     FENCE: 'fence',
     DCF_FENCE: 'dcf-fence',
-    HCA: 'hca', // Human Cell Atlas,
-    JADE_DATA_REPO: 'jade-data-repo',
+    ANVIL: 'anvil',
     get default() {
         return this.DCF_FENCE;
     }
@@ -15,6 +14,7 @@ const BondProviders = Object.freeze({
 
 const PROD_DATASTAGE_NAMESPACE = 'dg.4503';
 const STAGING_DATASTAGE_NAMESPACE = 'dg.712c';
+const ANVIL_NAMESPACE = 'dg.anv0';
 const DATASTAGE_NAMESPACES = [PROD_DATASTAGE_NAMESPACE, STAGING_DATASTAGE_NAMESPACE];
 
 const bondBaseUrl = () => config.bondBaseUrl;
@@ -23,35 +23,41 @@ const bondBaseUrl = () => config.bondBaseUrl;
 // At some point we expect to have a more sophisticated way to do this, but for now, we have to do it this way.
 function determineBondProvider(urlString) {
     const url = URL.parse(urlString);
+
     if (DATASTAGE_NAMESPACES.includes(url.hostname.toLowerCase())) {
         return BondProviders.FENCE;
-    } else if (url.host.endsWith('.humancellatlas.org')) {
-        return BondProviders.HCA;
-    } else if (hasJadeDataRepoHost(url)) {
-        return BondProviders.JADE_DATA_REPO;
-    } else {
-        return BondProviders.default;
     }
+
+    if (ANVIL_NAMESPACE === url.hostname.toLowerCase()) {
+        return BondProviders.ANVIL;
+    }
+
+    if (url.host.endsWith('.humancellatlas.org')) {
+        return;
+    }
+
+    if (hasJadeDataRepoHost(url)) {
+        return;
+    }
+
+    return BondProviders.default;
 }
 
-async function maybeTalkToBond(req, provider = BondProviders.default) {
+async function maybeTalkToBond(auth, provider) {
     /*
        Currently HCA data access does not require additional credentials. HCA checkout buckets allow object
        read access for GROUP_All_Users@firecloud.org. Also for Jade Data Repo (JDR), we don't need to contact Bond to
        check proper authorization. JDR itself checks for the proper authorization when a metadata retrieval request for
        data object is made.
    */
-    if (req && req.headers &&
-      req.headers.authorization &&
-      provider !== BondProviders.HCA &&
-      provider !== BondProviders.JADE_DATA_REPO) {
+    if (auth && provider) {
         try {
             /*
                Importing just `getJsonFrom` from api_adapter.js (at top) and replacing `apiAdapter.getJsonFrom` with
                `getJsonFrom(...)` is breaking martha_v2.test.js and martha_v3.test.js for some reason(!!). It might be the way
                `getJsonFrom` is mocked in the tests. Please do not change the import at top for this reason.
             */
-            return await apiAdapter.getJsonFrom(`${bondBaseUrl()}/api/link/v1/${provider}/serviceaccount/key`, req.headers.authorization);
+            return await apiAdapter.getJsonFrom(`${bondBaseUrl()}/api/link/v1/${provider}/serviceaccount/key`, auth);
         } catch (error) {
             console.log(`Received error while fetching service account from Bond for provider '${provider}'.`);
             console.error(error);

--- a/common/helpers.js
+++ b/common/helpers.js
@@ -55,7 +55,15 @@ function constructPath(pathParts) {
 }
 
 function determineHostname(someUrl) {
-    return isDataGuidsUrl(someUrl) ? config.dataObjectResolutionHost : someUrl.hostname;
+    if (!isDataGuidsUrl(someUrl)) {
+        return someUrl.hostname;
+    }
+
+    if (someUrl.hostname.toLowerCase() === 'dg.anv0') {
+        return 'gen3.theanvil.io';
+    }
+
+    return config.dataObjectResolutionHost;
 }
 
 function determinePathname(someUrl) {
@@ -84,6 +92,7 @@ function preserveHostnameCase(parsedUrl, rawUrl) {
 //      1. host part starts with "dg."
 //      2. host part DOES NOT start with "dg." AND path part is FALSY
 //      3. host part DOES NOT start with "dg." AND path part is TRUTHY
+// If you update this function update the README too!
 function dataObjectUriToHttps(dataObjectUri) {
     const parsedUrl = url.parse(dataObjectUri);
     if (parsedUrl.pathname === '/') {

--- a/common/helpers.js
+++ b/common/helpers.js
@@ -151,7 +151,6 @@ class CommonFileInfoResponse {
  *         - but `martha_v2` passed-thru whatever unstable response from the `dos` server while the specs keep evolving
  *     - ...which was then coalesced to what you see below for the `martha_v3` endpoint
  *         - `updated` was renamed to `timeUpdated`
- *         - The DOS/DRS optional `name` was added as `fileName`
  *         - etc.
  */
 class MarthaV3Response extends CommonFileInfoResponse {
@@ -164,7 +163,6 @@ class MarthaV3Response extends CommonFileInfoResponse {
         name,
         gsUri,
         googleServiceAccount,
-        fileName,
         hashesMap
     ) {
         super(
@@ -179,7 +177,6 @@ class MarthaV3Response extends CommonFileInfoResponse {
         );
         this.hashes = hashesMap || null;
         this.timeUpdated = updated || null;
-        this.fileName = fileName || null;
         delete this.updated;
     }
 }
@@ -354,7 +351,6 @@ function convertToMarthaV3Response(drsResponse, googleSA) {
         mime_type: mimeType = 'application/octet-stream',
         size: maybeNumberSize,
         updated_time: updatedTime,
-        name: maybeFileName,
     } = drsResponse;
 
     // Some (but not all!) DRS servers return time without a timezone (see example responses in `_martha_v3_resources.js`)
@@ -386,9 +382,6 @@ function convertToMarthaV3Response(drsResponse, googleSA) {
      */
     const size = Number(maybeNumberSize);
 
-    // Use the filename of the server, or get the name from the GCS object name we generated above
-    const fileName = maybeFileName || (name && name.replace(/^.*[\\/]/, ''));
-
     return new MarthaV3Response(
         mimeType,
         size,
@@ -398,7 +391,6 @@ function convertToMarthaV3Response(drsResponse, googleSA) {
         name,
         gsUrl,
         googleServiceAccount,
-        fileName,
         hashesMap
     );
 }

--- a/config.json
+++ b/config.json
@@ -4,6 +4,6 @@
 
 {
     "dataObjectResolutionHost": "staging.gen3.biodatacatalyst.nhlbi.nih.gov",
-    "bondBaseUrl": "broad-bond-dev.appspot.com",
+    "bondBaseUrl": "https://broad-bond-dev.appspot.com",
     "samBaseUrl": "https://sam.dsde-dev.broadinstitute.org"
 }

--- a/config.json.ctmpl
+++ b/config.json.ctmpl
@@ -4,7 +4,7 @@
 
 {
     "dataObjectResolutionHost": {{if eq $runContext "fiab"}}"wb-mock-drs-dev.storage.googleapis.com"{{else if eq $environment "prod"}}"gen3.biodatacatalyst.nhlbi.nih.gov"{{else}}"staging.gen3.biodatacatalyst.nhlbi.nih.gov"{{end}},
-    "bondBaseUrl": {{if eq $runContext "fiab"}}"bond-fiab.{{$dnsDomain}}"{{else}}"https://broad-bond-{{$environment}}.appspot.com"{{end}},
+    "bondBaseUrl": {{if eq $runContext "fiab"}}"https://bond-fiab.{{$dnsDomain}}"{{else}}"https://broad-bond-{{$environment}}.appspot.com"{{end}},
     "samBaseUrl": {{if eq $runContext "fiab"}}"https://sam-fiab.{{$dnsDomain}}"{{else}}"https://sam.dsde-{{$environment}}.broadinstitute.org"{{end}}
 }
 {{end}}{{end}}{{end}}

--- a/config.local.json
+++ b/config.local.json
@@ -1,0 +1,5 @@
+{
+    "dataObjectResolutionHost": "wb-mock-drs-dev.storage.googleapis.com",
+    "bondBaseUrl": "http://127.0.0.1:8080",
+    "samBaseUrl": "https://sam.dsde-dev.broadinstitute.org"
+}

--- a/fileSummaryV1/service_account_keys.js
+++ b/fileSummaryV1/service_account_keys.js
@@ -1,11 +1,11 @@
 const { samBaseUrl } = require('../common/helpers');
-const { determineBondProvider, bondBaseUrl, BondProviders } = require('../common/bond');
+const { determineBondProvider, bondBaseUrl } = require('../common/bond');
 const { getJsonFrom } = require('../common/api_adapter');
 
 function maybeTalkToBond(auth, url) {
     const provider = determineBondProvider(url);
 
-    if (provider === BondProviders.HCA) {
+    if (!provider) {
         return Promise.resolve();
     }
 

--- a/handlers/getSignedUrlV1.js
+++ b/handlers/getSignedUrlV1.js
@@ -1,6 +1,6 @@
 const apiAdapter = require('../common/api_adapter');
 const { promiseHandler, Response, samBaseUrl } = require('../common/helpers');
-const { bondBaseUrl, BondProviders, determineBondProvider } = require('../common/bond');
+const { bondBaseUrl, determineBondProvider } = require('../common/bond');
 const createSignedGsUrl = require('../common/createSignedGsUrl');
 
 const getSignedUrlV1 = promiseHandler(async (req) => {
@@ -8,7 +8,7 @@ const getSignedUrlV1 = promiseHandler(async (req) => {
     const auth = req.headers.authorization;
     const provider = dataObjectUri && determineBondProvider(dataObjectUri);
     try {
-        const credentials = (provider && provider !== BondProviders.HCA) ?
+        const credentials = provider ?
             (await apiAdapter.getJsonFrom(`${bondBaseUrl()}/api/link/v1/${provider}/serviceaccount/key`, auth)).data :
             await apiAdapter.getJsonFrom(`${samBaseUrl()}/api/google/v1/user/petServiceAccount/key`, auth);
         const url = await createSignedGsUrl.createSignedGsUrl(credentials, {bucket, name});

--- a/martha/martha_v2.js
+++ b/martha/martha_v2.js
@@ -34,7 +34,8 @@ function marthaV2Handler(req, res) {
     const bondProvider = determineBondProvider(dataObjectUri);
 
     const dataObjectPromise = apiAdapter.getJsonFrom(dataObjectResolutionUrl);
-    const bondPromise = maybeTalkToBond(req, bondProvider);
+    const auth = req && req.headers && req.headers.authorization;
+    const bondPromise = maybeTalkToBond(auth, bondProvider);
 
     return Promise.all([dataObjectPromise, bondPromise])
         .then((rawResults) => {

--- a/martha/martha_v3.js
+++ b/martha/martha_v3.js
@@ -121,7 +121,7 @@ function determineDrsType (parsedUrl) {
         );
     }
 
-    // Compact the AnVIL
+    // Compact The AnVIL
     if (host === 'dg.anv0') {
         return new DrsType(
             DG_EXPANSION_THE_ANVIL,
@@ -131,7 +131,7 @@ function determineDrsType (parsedUrl) {
         );
     }
 
-    // Full the AnVIL
+    // Full The AnVIL
     if (host === DG_EXPANSION_THE_ANVIL) {
         return new DrsType(
             DG_EXPANSION_NONE,
@@ -171,9 +171,9 @@ function determineDrsType (parsedUrl) {
         );
     }
 
-    // Assume BDC compact but with dcf-fence
+    // Assume this is a BDC compact URI but using dcf-fence Bond provider.
     // If we don't recognize the dg.* assume like martha_v2 that everyone else
-    // speaks DOS, doesn't require auth, and uses dcf-fence
+    // speaks DOS, doesn't require auth, and uses dcf-fence.
     if (host.startsWith("dg.")) {
         return new DrsType(
             DG_EXPANSION_BIO_DATA_CATALYST,
@@ -185,7 +185,7 @@ function determineDrsType (parsedUrl) {
 
 
     // If we don't recognize the server assume like martha_v2 that everyone else
-    // speaks DOS, doesn't require auth, and uses dcf-fence
+    // speaks DOS, doesn't require auth, and uses dcf-fence.
     return new DrsType(
         DG_EXPANSION_NONE,
         PROTOCOL_PREFIX_DOS,

--- a/martha/martha_v3.js
+++ b/martha/martha_v3.js
@@ -70,20 +70,21 @@ function responseParser (response) {
     if (!response.data_object) { return response; }
 
     // Otherwise, find the DOS fields and convert them to DRS.
-    const accessMethods =
-        response.data_object.urls &&
-        response.data_object.urls
+    const {
+        urls,
+        checksums,
+        created: created_time,
+        mimeType: mime_type,
+        name,
+        size,
+        updated: updated_time,
+    } = response.data_object;
+    const access_methods =
+        urls &&
+        urls
             .filter((e) => e.url.startsWith('gs://'))
             .map((gsUrl) => { return { type: 'gs', access_url: { url: gsUrl.url } }; });
-    return {
-        access_methods: accessMethods,
-        checksums: response.data_object.checksums,
-        created_time: response.data_object.created,
-        mime_type: response.data_object.mimeType,
-        name: response.data_object.name,
-        size: response.data_object.size,
-        updated_time: response.data_object.updated,
-    };
+    return { access_methods, checksums, created_time, mime_type, name, size, updated_time };
 }
 
 /** *************************************************************************************************

--- a/package-lock.json
+++ b/package-lock.json
@@ -3697,9 +3697,9 @@
       }
     },
     "node-fetch": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.3.0.tgz",
-      "integrity": "sha512-MOd8pV3fxENbryESLgVIeaGKrdl+uaYhCSSVkjeOb/31/njTpcis5aWfdqgNlHIrKOLRbMnfPINPOML2CIFeXA=="
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
+      "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw=="
     },
     "node-forge": {
       "version": "0.9.1",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "integration_v3": "ava --timeout 10m --match integration_v3*",
     "integration_fileSummaryV1": "ava -m integration_fileSummaryV1*",
     "report-coverage": "nyc report --reporter=text-lcov > coverage.lcov",
-    "lint": "eslint ."
+    "lint": "eslint .",
+    "lint_fix": "eslint --fix ."
   },
   "dependencies": {
     "@google-cloud/functions-framework": "^1.6.0",

--- a/package.json
+++ b/package.json
@@ -14,9 +14,7 @@
     "integration_v2": "ava -m integration_v2*",
     "integration_v3": "ava --timeout 10m --match integration_v3*",
     "integration_fileSummaryV1": "ava -m integration_fileSummaryV1*",
-    "report-coverage": "nyc report --reporter=text-lcov > coverage.lcov",
-    "lint": "eslint .",
-    "lint_fix": "eslint --fix ."
+    "report-coverage": "nyc report --reporter=text-lcov > coverage.lcov"
   },
   "dependencies": {
     "@google-cloud/functions-framework": "^1.6.0",

--- a/test/common/bond_test.js
+++ b/test/common/bond_test.js
@@ -52,8 +52,12 @@ test('determineBondProvider should not return a provider if the URL host is JDR"
     t.falsy(determineBondProvider('drs://jade.datarepo-dev.broadinstitute.org/identifier'));
 });
 
-test('determineBondProvider should return the AnVIL BondProvider if the URL host is the AnVIL', (t) => {
+test('determineBondProvider should return the AnVIL BondProvider if the URL host is the AnVIL prefix dg.ANV0', (t) => {
     t.is(determineBondProvider('drs://dg.ANV0/00008531-03d7-418c-b3d3-b7b22b5381a0'), BondProviders.ANVIL);
+});
+
+test('determineBondProvider should return the AnVIL BondProvider if the URL host is the AnVIL host', (t) => {
+    t.is(determineBondProvider('drs://gen3.theanvil.io/dg.ANV0/00008531-03d7-418c-b3d3-b7b22b5381a0'), BondProviders.ANVIL);
 });
 
 test('determineBondProvider should return the default BondProvider if the URL host is Kids First', (t) => {
@@ -62,3 +66,23 @@ test('determineBondProvider should return the default BondProvider if the URL ho
         BondProviders.default,
     );
 });
+
+test('determineBondProvider should return the default BondProvider if the URL host is CRDC', (t) => {
+    t.is(
+        determineBondProvider('drs://nci-crdc.datacommons.io/0027045b-9ed6-45af-a68e-f55037b5184c'),
+        BondProviders.default,
+    );
+});
+
+test(
+    'determineBondProvider should return the default BondProvider if the URL host is drs.dev.singlecell.gi.ucsc.edu',
+    (t) => {
+        t.is(
+            determineBondProvider(
+                'drs://drs.dev.singlecell.gi.ucsc.edu' +
+                '/bee7a822-ea28-4374-8e18-8b9941392723?version=2019-05-15T205839.080730Z'
+            ),
+            BondProviders.default,
+        );
+    }
+);

--- a/test/common/bond_test.js
+++ b/test/common/bond_test.js
@@ -35,7 +35,7 @@ test('determineBondProvider should be "dcf-fence" if the URL host is "dg.foo"', 
     t.is(determineBondProvider('drs://dg.foo/anything'), BondProviders.DCF_FENCE);
 });
 
-test('determineBondProvider should be "HCA" if the URL host ends with ".humancellatlas.org"', (t) => {
+test('determineBondProvider should not return a provider if the URL host ends with ".humancellatlas.org"', (t) => {
     t.falsy(determineBondProvider('drs://someservice.humancellatlas.org'));
 });
 
@@ -48,6 +48,6 @@ test('determineBondProvider should return the default BondProvider if the URL ho
     t.is(determineBondProvider('drs://some-host/anything'), BondProviders.default);
 });
 
-test('determineBondProvider should return the "jade-data-repo" as the provider for JDR host"', (t) => {
+test('determineBondProvider should not return a provider if the URL host is JDR"', (t) => {
     t.falsy(determineBondProvider('drs://jade.datarepo-dev.broadinstitute.org/identifier'));
 });

--- a/test/common/bond_test.js
+++ b/test/common/bond_test.js
@@ -10,13 +10,17 @@ test('BondProviders default should be "dcf-fence"', (t) => {
     t.is(BondProviders.default, BondProviders.DCF_FENCE);
 });
 
-test('BondProviders should contain "dcf-fence" and "fence"', (t) => {
+test('BondProviders should contain "dcf-fence" and "fence" and "anvil"', (t) => {
     t.truthy(BondProviders.DCF_FENCE);
     t.truthy(BondProviders.FENCE);
+    t.truthy(BondProviders.ANVIL);
 });
 
-test('BondProviders should contain "jade-data-repo"', (t) => {
-    t.truthy(BondProviders.JADE_DATA_REPO);
+test('determineBondProvider should be "dcf-fence" if the URL host is "dataguids.org"', (t) => {
+    t.is(
+        determineBondProvider('dos://dataguids.org/a41b0c4f-ebfb-4277-a941-507340dea85d'),
+        BondProviders.DCF_FENCE
+    );
 });
 
 test('determineBondProvider should be "fence" if the URL host is "dg.4503"', (t) => {
@@ -32,7 +36,7 @@ test('determineBondProvider should be "dcf-fence" if the URL host is "dg.foo"', 
 });
 
 test('determineBondProvider should be "HCA" if the URL host ends with ".humancellatlas.org"', (t) => {
-    t.is(determineBondProvider('drs://someservice.humancellatlas.org'), BondProviders.HCA);
+    t.falsy(determineBondProvider('drs://someservice.humancellatlas.org'));
 });
 
 test('determineBondProvider should return the default BondProvider if the URL host does not end with ' +
@@ -45,5 +49,5 @@ test('determineBondProvider should return the default BondProvider if the URL ho
 });
 
 test('determineBondProvider should return the "jade-data-repo" as the provider for JDR host"', (t) => {
-    t.is(determineBondProvider('drs://jade.datarepo-dev.broadinstitute.org/identifier'), BondProviders.JADE_DATA_REPO);
+    t.falsy(determineBondProvider('drs://jade.datarepo-dev.broadinstitute.org/identifier'));
 });

--- a/test/common/bond_test.js
+++ b/test/common/bond_test.js
@@ -51,3 +51,14 @@ test('determineBondProvider should return the default BondProvider if the URL ho
 test('determineBondProvider should not return a provider if the URL host is JDR"', (t) => {
     t.falsy(determineBondProvider('drs://jade.datarepo-dev.broadinstitute.org/identifier'));
 });
+
+test('determineBondProvider should return the AnVIL BondProvider if the URL host is the AnVIL', (t) => {
+    t.is(determineBondProvider('drs://dg.ANV0/00008531-03d7-418c-b3d3-b7b22b5381a0'), BondProviders.ANVIL);
+});
+
+test('determineBondProvider should return the default BondProvider if the URL host is Kids First', (t) => {
+    t.is(
+        determineBondProvider('drs://data.kidsfirstdrc.org/ed6be7ab-068e-46c8-824a-f39cfbb885cc'),
+        BondProviders.default,
+    );
+});

--- a/test/common/helpers.test.js
+++ b/test/common/helpers.test.js
@@ -227,7 +227,18 @@ test('getHashesMap should throw error if the checksums array contains duplicate 
  * Test the convertToMarthaV3Response() function
  */
 test('convertToMarthaV3Response should return null for all fields in an unlikely event of empty drs and bond responses', (t) => {
-    const expectedResponse = new MarthaV3Response('application/octet-stream', null, null, null, null, null, null, null, null);
+    const expectedResponse = new MarthaV3Response(
+        'application/octet-stream',
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null
+    );
     t.deepEqual(convertToMarthaV3Response({}, {}), expectedResponse);
 });
 
@@ -241,7 +252,18 @@ test('convertToMarthaV3Response should return null for fields that are missing i
         mime_type: 'application/octet-stream',
         size: 123456
     };
-    const expectedResponse = new MarthaV3Response('application/octet-stream', 123456, '2020-04-27T15:56:09.696Z', null, null, null, null, null, null);
+    const expectedResponse = new MarthaV3Response(
+        'application/octet-stream',
+        123456,
+        '2020-04-27T15:56:09.696Z',
+        null,
+        null,
+        null,
+        null,
+        null,
+        '123.mapped.abc.bam',
+        null
+    );
 
     t.deepEqual(convertToMarthaV3Response(mockDrsResponse, {}), expectedResponse);
 });
@@ -259,7 +281,18 @@ test('convertToMarthaV3Response should return null for fields that are empty in 
         checksums: [],
         access_methods: []
     };
-    const expectedResponse = new MarthaV3Response('application/octet-stream', 123456, '2020-04-27T15:56:09.696Z', '2020-04-27T15:56:09.696Z', null, null, null, null, null);
+    const expectedResponse = new MarthaV3Response(
+        'application/octet-stream',
+        123456,
+        '2020-04-27T15:56:09.696Z',
+        '2020-04-27T15:56:09.696Z',
+        null,
+        null,
+        null,
+        null,
+        '123.mapped.abc.bam',
+        null
+    );
 
     t.deepEqual(convertToMarthaV3Response(mockDrsResponse, {}), expectedResponse);
 });
@@ -299,6 +332,7 @@ test('convertToMarthaV3Response should return null for googleServiceAccount if b
         '123',
         'gs://abc/123',
         null,
+        '123.mapped.abc.bam',
         { md5: '123abc' }
     );
 

--- a/test/common/helpers.test.js
+++ b/test/common/helpers.test.js
@@ -236,7 +236,6 @@ test('convertToMarthaV3Response should return null for all fields in an unlikely
         null,
         null,
         null,
-        null,
         null
     );
     t.deepEqual(convertToMarthaV3Response({}, {}), expectedResponse);
@@ -261,7 +260,6 @@ test('convertToMarthaV3Response should return null for fields that are missing i
         null,
         null,
         null,
-        '123.mapped.abc.bam',
         null
     );
 
@@ -290,7 +288,6 @@ test('convertToMarthaV3Response should return null for fields that are empty in 
         null,
         null,
         null,
-        '123.mapped.abc.bam',
         null
     );
 
@@ -332,7 +329,6 @@ test('convertToMarthaV3Response should return null for googleServiceAccount if b
         '123',
         'gs://abc/123',
         null,
-        '123.mapped.abc.bam',
         { md5: '123abc' }
     );
 

--- a/test/fileSummaryV1/integration_fileSummaryV1.test.js
+++ b/test/fileSummaryV1/integration_fileSummaryV1.test.js
@@ -15,6 +15,10 @@ let unauthorizedToken;
 let authorizedToken;
 
 const myEnv = process.env.ENV ? process.env.ENV : 'dev';
+const myBondBaseUrl =
+    process.env.BOND_BASE_URL ?
+        process.env.BOND_BASE_URL :
+        `https://bond-fiab.dsde-${myEnv}.broadinstitute.org:31443`;
 const emailDomain = `${myEnv === 'qa' ? 'quality' : 'test'}.firecloud.org`;
 
 const keyFile = 'automation/firecloud-account.pem';
@@ -25,8 +29,10 @@ const authorizedEmail = `hermione.owner@${emailDomain}`;
 
 const dataObjectUri = 'dos://dg.4503/preview_dos.json';
 const gsUri = 'gs://wb-mock-drs-dev/public/dos_test.txt';
-// TODO: GAWB-4053 -- remove static link so bond host can be changed depending on env
-const fenceAuthLink = `https://bond-fiab.dsde-${myEnv}.broadinstitute.org:31443/api/link/v1/fence/oauthcode?oauthcode=IgnoredByMockProvider&redirect_uri=http%3A%2F%2Flocal.broadinstitute.org%2F%23fence-callback`;
+const fenceAuthLink =
+    `${myBondBaseUrl}/api/link/v1/fence/oauthcode` +
+    '?oauthcode=IgnoredByMockProvider' +
+    '&redirect_uri=http%3A%2F%2Flocal.broadinstitute.org%2F%23fence-callback';
 
 test.before(async () => {
     unauthorizedToken = await new GoogleToken({

--- a/test/martha/_martha_v3_resources.js
+++ b/test/martha/_martha_v3_resources.js
@@ -26,6 +26,7 @@ const expectedObjWithMissingFields = {
     name: null,
     gsUri: null,
     googleServiceAccount: null,
+    fileName: '123.mapped.abc.bam',
     hashes: null
 };
 
@@ -70,13 +71,65 @@ const sampleDosMarthaResult = (expectedGoogleServiceAccount) => {
         timeUpdated: '2020-04-27T15:56:09.696Z',
         bucket: 'bogus',
         name: 'my_data',
-        gsUri:
-            'gs://bogus/my_data',
+        gsUri: 'gs://bogus/my_data',
         googleServiceAccount: expectedGoogleServiceAccount,
+        fileName: 'my_data',
         hashes: {
             md5: '336ea55913bc261b72875bd259753046',
             sha256: 'f76877f8e86ec3932fd2ae04239fbabb8c90199dab0019ae55fa42b31c314c44',
             crc32c: '8a366443'
+        }
+    };
+};
+
+// dataguids.org
+// returned via `curl https://dataguids.org/ga4gh/dos/v1/dataobjects/a41b0c4f-ebfb-4277-a941-507340dea85d`
+const dataGuidsOrgResponse = {
+    data_object: {
+        checksums: [
+            {
+                checksum: '0d22c86537e22ad9e924c7c756b23131',
+                type: 'md5'
+            }
+        ],
+        created: '2018-06-26T18:53:21.416896',
+        description: '',
+        id: 'a41b0c4f-ebfb-4277-a941-507340dea85d',
+        mime_type: '',
+        name: null,
+        size: 39830,
+        updated: '2018-06-26T18:53:21.416908',
+        urls: [
+            {
+                'url':
+                    'gs://gdc-tcga-phs000178-open/a41b0c4f-ebfb-4277-a941-507340dea85d' +
+                    '/nationwidechildrens.org_clinical.TCGA-56-A4BY.xml'
+            },
+            {
+                'url':
+                    's3://tcga-2-open/a41b0c4f-ebfb-4277-a941-507340dea85d' +
+                    '/nationwidechildrens.org_clinical.TCGA-56-A4BY.xml'
+            }
+        ],
+        version: 'a095f638'
+    }
+};
+
+const dataGuidsOrgMarthaResult = (expectedGoogleServiceAccount) => {
+    return {
+        contentType: 'application/octet-stream',
+        size: 39830,
+        timeCreated: '2018-06-26T18:53:21.416Z',
+        timeUpdated: '2018-06-26T18:53:21.416Z',
+        bucket: 'gdc-tcga-phs000178-open',
+        name: 'a41b0c4f-ebfb-4277-a941-507340dea85d/nationwidechildrens.org_clinical.TCGA-56-A4BY.xml',
+        gsUri:
+            'gs://gdc-tcga-phs000178-open/a41b0c4f-ebfb-4277-a941-507340dea85d' +
+            '/nationwidechildrens.org_clinical.TCGA-56-A4BY.xml',
+        googleServiceAccount: expectedGoogleServiceAccount,
+        fileName: 'nationwidechildrens.org_clinical.TCGA-56-A4BY.xml',
+        hashes: {
+            md5: '0d22c86537e22ad9e924c7c756b23131'
         }
     };
 };
@@ -118,23 +171,22 @@ const jadeDrsResponse = {
     ]
 };
 
-const jadeDrsMarthaResult = (expectedGoogleServiceAccount) => {
-    return {
-        contentType: 'application/octet-stream',
-        size: 15601108255,
-        timeCreated: '2020-04-27T15:56:09.696Z',
-        timeUpdated: '2020-04-27T15:56:09.696Z',
-        bucket: 'broad-jade-dev-data-bucket',
-        name: 'fd8d8492-ad02-447d-b54e-35a7ffd0e7a5/8b07563a-542f-4b5c-9e00-e8fe6b1861de',
-        gsUri:
-            'gs://broad-jade-dev-data-bucket/fd8d8492-ad02-447d-b54e-35a7ffd0e7a5/8b07563a-542f-4b5c-9e00-e8fe6b1861de',
-        googleServiceAccount: expectedGoogleServiceAccount,
-        hashes: {
-            md5: '336ea55913bc261b72875bd259753046',
-            sha256: 'f76877f8e86ec3932fd2ae04239fbabb8c90199dab0019ae55fa42b31c314c44',
-            crc32c: '8a366443'
-        }
-    };
+const jadeDrsMarthaResult = {
+    contentType: 'application/octet-stream',
+    size: 15601108255,
+    timeCreated: '2020-04-27T15:56:09.696Z',
+    timeUpdated: '2020-04-27T15:56:09.696Z',
+    bucket: 'broad-jade-dev-data-bucket',
+    name: 'fd8d8492-ad02-447d-b54e-35a7ffd0e7a5/8b07563a-542f-4b5c-9e00-e8fe6b1861de',
+    gsUri:
+        'gs://broad-jade-dev-data-bucket/fd8d8492-ad02-447d-b54e-35a7ffd0e7a5/8b07563a-542f-4b5c-9e00-e8fe6b1861de',
+    googleServiceAccount: null,
+    fileName: 'HG00096.mapped.ILLUMINA.bwa.GBR.low_coverage.20120522.bam',
+    hashes: {
+        md5: '336ea55913bc261b72875bd259753046',
+        sha256: 'f76877f8e86ec3932fd2ae04239fbabb8c90199dab0019ae55fa42b31c314c44',
+        crc32c: '8a366443'
+    }
 };
 
 // Gen3/CRDC
@@ -181,21 +233,23 @@ const gen3CrdcResponse = {
     version: "5eb15d8b"
 };
 
-const gen3CrdcDrsMarthaResult = (expectedGoogleServiceAccount) => {
-    return {
-        contentType: 'application/json',
-        size: 6703858793,
-        timeCreated: '2018-06-27T10:28:06.398Z',
-        timeUpdated: '2018-06-27T10:28:06.398Z',
-        bucket: 'gdc-tcga-phs000178-controlled',
-        name: 'BRCA/RNA/RNA-Seq/UNC-LCCC/ILLUMINA/UNCID_2210188.c71ca9f7-248f-460c-b5d3-afb2c648fef2.110412_UNC13-SN749_0051_AB0168ABXX_4.tar.gz',
-        gsUri:
-            'gs://gdc-tcga-phs000178-controlled/BRCA/RNA/RNA-Seq/UNC-LCCC/ILLUMINA/UNCID_2210188.c71ca9f7-248f-460c-b5d3-afb2c648fef2.110412_UNC13-SN749_0051_AB0168ABXX_4.tar.gz',
-        googleServiceAccount: expectedGoogleServiceAccount,
-        hashes: {
-            md5: '2edd5fdb4f1deac4ef2bdf969de9f8ad'
-        }
-    };
+const gen3CrdcDrsMarthaResult = {
+    contentType: 'application/json',
+    size: 6703858793,
+    timeCreated: '2018-06-27T10:28:06.398Z',
+    timeUpdated: '2018-06-27T10:28:06.398Z',
+    bucket: 'gdc-tcga-phs000178-controlled',
+    name:
+        'BRCA/RNA/RNA-Seq/UNC-LCCC/ILLUMINA' +
+        '/UNCID_2210188.c71ca9f7-248f-460c-b5d3-afb2c648fef2.110412_UNC13-SN749_0051_AB0168ABXX_4.tar.gz',
+    gsUri:
+        'gs://gdc-tcga-phs000178-controlled/BRCA/RNA/RNA-Seq/UNC-LCCC/ILLUMINA' +
+        '/UNCID_2210188.c71ca9f7-248f-460c-b5d3-afb2c648fef2.110412_UNC13-SN749_0051_AB0168ABXX_4.tar.gz',
+    googleServiceAccount: null,
+    fileName: 'UNCID_2210188.c71ca9f7-248f-460c-b5d3-afb2c648fef2.110412_UNC13-SN749_0051_AB0168ABXX_4.tar.gz',
+    hashes: {
+        md5: '2edd5fdb4f1deac4ef2bdf969de9f8ad'
+    }
 };
 
 // Anvil
@@ -240,10 +294,14 @@ const anvilDrsMarthaResult = (expectedGoogleServiceAccount) => {
         timeCreated: '2020-07-08T18:52:53.194Z',
         timeUpdated: '2020-07-08T18:52:53.194Z',
         bucket: 'fc-secure-ff8156a3-ddf3-42e4-9211-0fd89da62108',
-        name: 'GTEx_Analysis_2017-06-05_v8_RNAseq_bigWig_files/GTEX-1GZHY-0011-R6a-SM-9OSWL.Aligned.sortedByCoord.out.patched.md.bigWig',
+        name:
+            'GTEx_Analysis_2017-06-05_v8_RNAseq_bigWig_files' +
+            '/GTEX-1GZHY-0011-R6a-SM-9OSWL.Aligned.sortedByCoord.out.patched.md.bigWig',
         gsUri:
-            'gs://fc-secure-ff8156a3-ddf3-42e4-9211-0fd89da62108/GTEx_Analysis_2017-06-05_v8_RNAseq_bigWig_files/GTEX-1GZHY-0011-R6a-SM-9OSWL.Aligned.sortedByCoord.out.patched.md.bigWig',
+            'gs://fc-secure-ff8156a3-ddf3-42e4-9211-0fd89da62108/GTEx_Analysis_2017-06-05_v8_RNAseq_bigWig_files' +
+            '/GTEX-1GZHY-0011-R6a-SM-9OSWL.Aligned.sortedByCoord.out.patched.md.bigWig',
         googleServiceAccount: expectedGoogleServiceAccount,
+        fileName: 'GTEX-1GZHY-0011-R6a-SM-9OSWL.Aligned.sortedByCoord.out.patched.md.bigWig',
         hashes: {
             md5: '18156430a5eea715b9b58fb53d0cef99'
         }
@@ -282,7 +340,7 @@ const kidsFirstDrsResponse = {
     "id": "ed6be7ab-068e-46c8-824a-f39cfbb885cc",
     "mime_type": "application/json",
     "name": "fa9c2cb04f614f90b75323b05bfdd231.bam",
-    "Self_uri":
+    "self_uri":
         "drs://data.kidsfirstdrc.org/ed6be7ab-068e-46c8-824a-f39cfbb885cc",
     "size": 55121736836,
     "updated_time": "2018-05-23T12:32:32.594480",
@@ -299,6 +357,7 @@ const kidsFirstDrsMarthaResult = (expectedGoogleServiceAccount) => {
         name: null, // there is definitely a name in the server response, why isn't Martha using it?
         gsUri: null, // expected, uses S3
         googleServiceAccount: expectedGoogleServiceAccount,
+        fileName: 'fa9c2cb04f614f90b75323b05bfdd231.bam',
         hashes: {
             // This case captures current Martha behavior, selectively allow `undefined`
             etag: undefined // eslint-disable-line no-undefined
@@ -341,84 +400,110 @@ const bdcDrsResponse = {
     version: "f443f632"
 };
 
-const bdcDrsMarthaResult = {
-    contentType: 'application/json',
-    size: 14772393959,
-    timeCreated: '2020-01-15T15:35:09.184Z',
-    timeUpdated: '2020-01-15T15:35:09.184Z',
-    bucket: 'fc-56ac46ea-efc4-4683-b6d5-6d95bed41c5e',
-    name: 'CCDG_13607/Project_CCDG_13607_B01_GRM_WGS.cram.2019-02-06/Sample_HG02014/analysis/HG02014.final.cram',
-    gsUri:
-        'gs://fc-56ac46ea-efc4-4683-b6d5-6d95bed41c5e/CCDG_13607/Project_CCDG_13607_B01_GRM_WGS.cram.2019-02-06/Sample_HG02014/analysis/HG02014.final.cram',
-    googleServiceAccount: null,
-    hashes: {
-        md5: 'bb193a5b603ae6ac5eb39890b6ca1bb5'
-    }
+const bdcDrsMarthaResult = (expectedGoogleServiceAccount) => {
+    return {
+        contentType: 'application/json',
+        size: 14772393959,
+        timeCreated: '2020-01-15T15:35:09.184Z',
+        timeUpdated: '2020-01-15T15:35:09.184Z',
+        bucket: 'fc-56ac46ea-efc4-4683-b6d5-6d95bed41c5e',
+        name: 'CCDG_13607/Project_CCDG_13607_B01_GRM_WGS.cram.2019-02-06/Sample_HG02014/analysis/HG02014.final.cram',
+        gsUri:
+            'gs://fc-56ac46ea-efc4-4683-b6d5-6d95bed41c5e' +
+            '/CCDG_13607' +
+            '/Project_CCDG_13607_B01_GRM_WGS.cram.2019-02-06' +
+            '/Sample_HG02014' +
+            '/analysis' +
+            '/HG02014.final.cram',
+        googleServiceAccount: expectedGoogleServiceAccount,
+        fileName: 'HG02014.final.cram',
+        hashes: {
+            md5: 'bb193a5b603ae6ac5eb39890b6ca1bb5'
+        }
+    };
 };
 
 // HCA
-
+// returned via
+//   `curl https://drs.data.humancellatlas.org/ga4gh/dos/v1/dataobjects/4cf48dbf-cf09-452e-bb5b-fd016af0c747?version=2019-09-14T024754.281908Z`
 const hcaDosResponse = {
-    data_object:
-        {
-            id: "8aca942c-17f7-4e34-b8fd-3c12e50f9291",
-            urls:
-                [
-                    {
-                        url: "https://drs.data.humancellatlas.org/dss/files/8aca942c-17f7-4e34-b8fd-3c12e50f9291?version=2019-07-04T151444.185805Z&replica=aws&wait=1&fileName=SRR3879608_1.fastq.gz"
-                    },
-                    {
-                        url: "gs://org-hca-dss-checkout-prod/blobs/44d320c9606e32d6df04d8a4023e6474efaa2f99de436e07f7241942972d5703.c3349268e528c844c528a427aa13034e72b7b39d.16c68f2306435b7cf990153b37adeb20-134.64d51664"
-                    }
-                ],
-            size: "8933233597",
-            checksums:
-                [
-                    {
-                        checksum: "44d320c9606e32d6df04d8a4023e6474efaa2f99de436e07f7241942972d5703",
-                        type: "sha256"
-                    }
-                ],
-            aliases:
-                [
-                    "SRR3879608_1.fastq.gz"
-                ],
-            version: "2019-07-04T151444.185805Z",
-            name: "SRR3879608_1.fastq.gz"
-        }
+    data_object: {
+        id: '4cf48dbf-cf09-452e-bb5b-fd016af0c747',
+        urls: [
+            {
+                url:
+                    'https://drs.data.humancellatlas.org/dss/files/4cf48dbf-cf09-452e-bb5b-fd016af0c747' +
+                    '?version=2019-09-14T024754.281908Z' +
+                    '&replica=aws' +
+                    '&wait=1' +
+                    '&fileName=eb32bfc6-e7be-4093-8959-b8bf27f2404f.zarr%21.zattrs'
+            },
+            {
+                url:
+                    'gs://org-hca-dss-checkout-prod/blobs' +
+                    '/160fde1559f7154b03a6f645b4c7ff0eb2af37241e2cab3961e7780ead93860a' +
+                    '.b0fcf2baaadb4aa6545804998867eff29330762a' +
+                    '.d18ef9b8fd14ac922588baeec4853c0d' +
+                    '.0ba92b16'
+            }
+        ],
+        size: '148', // Yes, this is a string returned by the `curl` above
+        checksums: [
+            {
+                checksum: '160fde1559f7154b03a6f645b4c7ff0eb2af37241e2cab3961e7780ead93860a',
+                type: 'sha256'
+            }
+        ],
+        aliases: [
+            'eb32bfc6-e7be-4093-8959-b8bf27f2404f.zarr!.zattrs'
+        ],
+        version: '2019-09-14T024754.281908Z',
+        name: 'eb32bfc6-e7be-4093-8959-b8bf27f2404f.zarr!.zattrs'
+    }
 };
 
-const hcaDosMarthaResult = (expectedGoogleServiceAccount) => {
-    return {
-        contentType: 'application/octet-stream',
-        size: 8933233597,
-        timeCreated: null,
-        timeUpdated: null,
-        bucket: "org-hca-dss-checkout-prod",
-        name: "blobs/44d320c9606e32d6df04d8a4023e6474efaa2f99de436e07f7241942972d5703.c3349268e528c844c528a427aa13034e72b7b39d.16c68f2306435b7cf990153b37adeb20-134.64d51664",
-        gsUri: "gs://org-hca-dss-checkout-prod/blobs/44d320c9606e32d6df04d8a4023e6474efaa2f99de436e07f7241942972d5703.c3349268e528c844c528a427aa13034e72b7b39d.16c68f2306435b7cf990153b37adeb20-134.64d51664",
-        googleServiceAccount: expectedGoogleServiceAccount,
-        hashes: {
-            sha256: '44d320c9606e32d6df04d8a4023e6474efaa2f99de436e07f7241942972d5703'
-        }
-    };
+const hcaDosMarthaResult = {
+    contentType: 'application/octet-stream',
+    size: 148,
+    timeCreated: null,
+    timeUpdated: null,
+    bucket: 'org-hca-dss-checkout-prod',
+    name:
+        'blobs' +
+        '/160fde1559f7154b03a6f645b4c7ff0eb2af37241e2cab3961e7780ead93860a' +
+        '.b0fcf2baaadb4aa6545804998867eff29330762a' +
+        '.d18ef9b8fd14ac922588baeec4853c0d' +
+        '.0ba92b16',
+    gsUri:
+        'gs://org-hca-dss-checkout-prod/blobs' +
+        '/160fde1559f7154b03a6f645b4c7ff0eb2af37241e2cab3961e7780ead93860a' +
+        '.b0fcf2baaadb4aa6545804998867eff29330762a' +
+        '.d18ef9b8fd14ac922588baeec4853c0d' +
+        '.0ba92b16',
+    googleServiceAccount: null,
+    fileName: 'eb32bfc6-e7be-4093-8959-b8bf27f2404f.zarr!.zattrs',
+    hashes: {
+        sha256: '160fde1559f7154b03a6f645b4c7ff0eb2af37241e2cab3961e7780ead93860a'
+    }
 };
 
 module.exports = {
     expectedObjWithMissingFields,
     dosObjectWithMissingFields,
     sampleDosResponse,
-    jadeDrsResponse,
-    hcaDosMarthaResult,
-    hcaDosResponse,
-    bdcDrsMarthaResult,
-    bdcDrsResponse,
-    kidsFirstDrsResponse,
-    anvilDrsMarthaResult,
-    anvilDrsResponse,
-    gen3CrdcDrsMarthaResult,
-    gen3CrdcResponse,
     sampleDosMarthaResult,
+    dataGuidsOrgResponse,
+    dataGuidsOrgMarthaResult,
+    jadeDrsResponse,
     jadeDrsMarthaResult,
+    hcaDosResponse,
+    hcaDosMarthaResult,
+    bdcDrsResponse,
+    bdcDrsMarthaResult,
+    anvilDrsResponse,
+    anvilDrsMarthaResult,
+    gen3CrdcResponse,
+    gen3CrdcDrsMarthaResult,
+    kidsFirstDrsResponse,
     kidsFirstDrsMarthaResult
 };

--- a/test/martha/_martha_v3_resources.js
+++ b/test/martha/_martha_v3_resources.js
@@ -26,7 +26,6 @@ const expectedObjWithMissingFields = {
     name: null,
     gsUri: null,
     googleServiceAccount: null,
-    fileName: '123.mapped.abc.bam',
     hashes: null
 };
 
@@ -73,7 +72,6 @@ const sampleDosMarthaResult = (expectedGoogleServiceAccount) => {
         name: 'my_data',
         gsUri: 'gs://bogus/my_data',
         googleServiceAccount: expectedGoogleServiceAccount,
-        fileName: 'my_data',
         hashes: {
             md5: '336ea55913bc261b72875bd259753046',
             sha256: 'f76877f8e86ec3932fd2ae04239fbabb8c90199dab0019ae55fa42b31c314c44',
@@ -127,7 +125,6 @@ const dataGuidsOrgMarthaResult = (expectedGoogleServiceAccount) => {
             'gs://gdc-tcga-phs000178-open/a41b0c4f-ebfb-4277-a941-507340dea85d' +
             '/nationwidechildrens.org_clinical.TCGA-56-A4BY.xml',
         googleServiceAccount: expectedGoogleServiceAccount,
-        fileName: 'nationwidechildrens.org_clinical.TCGA-56-A4BY.xml',
         hashes: {
             md5: '0d22c86537e22ad9e924c7c756b23131'
         }
@@ -181,7 +178,6 @@ const jadeDrsMarthaResult = {
     gsUri:
         'gs://broad-jade-dev-data-bucket/fd8d8492-ad02-447d-b54e-35a7ffd0e7a5/8b07563a-542f-4b5c-9e00-e8fe6b1861de',
     googleServiceAccount: null,
-    fileName: 'HG00096.mapped.ILLUMINA.bwa.GBR.low_coverage.20120522.bam',
     hashes: {
         md5: '336ea55913bc261b72875bd259753046',
         sha256: 'f76877f8e86ec3932fd2ae04239fbabb8c90199dab0019ae55fa42b31c314c44',
@@ -246,7 +242,6 @@ const gen3CrdcDrsMarthaResult = {
         'gs://gdc-tcga-phs000178-controlled/BRCA/RNA/RNA-Seq/UNC-LCCC/ILLUMINA' +
         '/UNCID_2210188.c71ca9f7-248f-460c-b5d3-afb2c648fef2.110412_UNC13-SN749_0051_AB0168ABXX_4.tar.gz',
     googleServiceAccount: null,
-    fileName: 'UNCID_2210188.c71ca9f7-248f-460c-b5d3-afb2c648fef2.110412_UNC13-SN749_0051_AB0168ABXX_4.tar.gz',
     hashes: {
         md5: '2edd5fdb4f1deac4ef2bdf969de9f8ad'
     }
@@ -301,7 +296,6 @@ const anvilDrsMarthaResult = (expectedGoogleServiceAccount) => {
             'gs://fc-secure-ff8156a3-ddf3-42e4-9211-0fd89da62108/GTEx_Analysis_2017-06-05_v8_RNAseq_bigWig_files' +
             '/GTEX-1GZHY-0011-R6a-SM-9OSWL.Aligned.sortedByCoord.out.patched.md.bigWig',
         googleServiceAccount: expectedGoogleServiceAccount,
-        fileName: 'GTEX-1GZHY-0011-R6a-SM-9OSWL.Aligned.sortedByCoord.out.patched.md.bigWig',
         hashes: {
             md5: '18156430a5eea715b9b58fb53d0cef99'
         }
@@ -357,7 +351,6 @@ const kidsFirstDrsMarthaResult = (expectedGoogleServiceAccount) => {
         name: null, // there is definitely a name in the server response, why isn't Martha using it?
         gsUri: null, // expected, uses S3
         googleServiceAccount: expectedGoogleServiceAccount,
-        fileName: 'fa9c2cb04f614f90b75323b05bfdd231.bam',
         hashes: {
             // This case captures current Martha behavior, selectively allow `undefined`
             etag: undefined // eslint-disable-line no-undefined
@@ -416,7 +409,6 @@ const bdcDrsMarthaResult = (expectedGoogleServiceAccount) => {
             '/analysis' +
             '/HG02014.final.cram',
         googleServiceAccount: expectedGoogleServiceAccount,
-        fileName: 'HG02014.final.cram',
         hashes: {
             md5: 'bb193a5b603ae6ac5eb39890b6ca1bb5'
         }
@@ -481,7 +473,6 @@ const hcaDosMarthaResult = {
         '.d18ef9b8fd14ac922588baeec4853c0d' +
         '.0ba92b16',
     googleServiceAccount: null,
-    fileName: 'eb32bfc6-e7be-4093-8959-b8bf27f2404f.zarr!.zattrs',
     hashes: {
         sha256: '160fde1559f7154b03a6f645b4c7ff0eb2af37241e2cab3961e7780ead93860a'
     }

--- a/test/martha/integration_v2.test.js
+++ b/test/martha/integration_v2.test.js
@@ -15,6 +15,10 @@ let unauthorizedToken;
 let authorizedToken;
 
 const myEnv = process.env.ENV ? process.env.ENV : 'dev';
+const myBondBaseUrl =
+    process.env.BOND_BASE_URL ?
+        process.env.BOND_BASE_URL :
+        `https://bond-fiab.dsde-${myEnv}.broadinstitute.org:31443`;
 const emailDomain = `${myEnv === 'qa' ? 'quality' : 'test'}.firecloud.org`;
 
 const keyFile = 'automation/firecloud-account.pem';
@@ -25,8 +29,10 @@ const authorizedEmail = `hermione.owner@${emailDomain}`;
 
 const publicFenceUrl = 'dos://dg.4503/preview_dos.json';
 const protectedFenceUrl = 'dos://dg.4503/65e4cd14-f549-4a7f-ad0c-d29212ff6e46';
-// TODO: remove static link so bond host can be changed depending on env
-const fenceAuthLink = `https://bond-fiab.dsde-${myEnv}.broadinstitute.org:31443/api/link/v1/fence/oauthcode?oauthcode=IgnoredByMockProvider&redirect_uri=http%3A%2F%2Flocal.broadinstitute.org%2F%23fence-callback`;
+const fenceAuthLink =
+    `${myBondBaseUrl}/api/link/v1/fence/oauthcode` +
+    '?oauthcode=IgnoredByMockProvider' +
+    '&redirect_uri=http%3A%2F%2Flocal.broadinstitute.org%2F%23fence-callback';
 
 test.before(async () => {
     unauthorizedToken = await new GoogleToken({

--- a/test/martha/integration_v3.test.js
+++ b/test/martha/integration_v3.test.js
@@ -28,7 +28,6 @@ const authorizedEmail = `hermione.owner@${emailDomain}`;
 
 const publicFenceUrl = 'dos://dg.4503/preview_dos.json';
 const protectedFenceUrl = 'dos://dg.4503/65e4cd14-f549-4a7f-ad0c-d29212ff6e46';
-// TODO: remove static link so bond host can be changed depending on env
 const fenceAuthLink =
     `${myBondBaseUrl}/api/link/v1/fence/oauthcode` +
     '?oauthcode=IgnoredByMockProvider' +

--- a/test/martha/integration_v3.test.js
+++ b/test/martha/integration_v3.test.js
@@ -236,7 +236,6 @@ test.cb('integration_v3 responds with Data Object for authorized user for jade d
                         'gs://broad-jade-dev-data-bucket/fd8d8492-ad02-447d-b54e-35a7ffd0e7a5/' +
                         '8b07563a-542f-4b5c-9e00-e8fe6b1861de',
                     googleServiceAccount: null,
-                    fileName: 'HG00096.mapped.ILLUMINA.bwa.GBR.low_coverage.20120522.bam',
                     hashes: {
                         md5: '336ea55913bc261b72875bd259753046',
                         crc32c: 'ecb19226'

--- a/test/martha/integration_v3.test.js
+++ b/test/martha/integration_v3.test.js
@@ -237,6 +237,7 @@ test.cb('integration_v3 responds with Data Object for authorized user for jade d
                         'gs://broad-jade-dev-data-bucket/fd8d8492-ad02-447d-b54e-35a7ffd0e7a5/' +
                         '8b07563a-542f-4b5c-9e00-e8fe6b1861de',
                     googleServiceAccount: null,
+                    fileName: 'HG00096.mapped.ILLUMINA.bwa.GBR.low_coverage.20120522.bam',
                     hashes: {
                         md5: '336ea55913bc261b72875bd259753046',
                         crc32c: 'ecb19226'

--- a/test/martha/martha_v2.test.js
+++ b/test/martha/martha_v2.test.js
@@ -32,7 +32,7 @@ const mockResponse = () => {
 const dataObject = { fake: 'A fake Data Object' };
 const googleSAKeyObject = { key: 'A Google Service Account private key json object' };
 
-const bondRegEx = /^([^/]+)\/api\/link\/v1\/([a-z-]+)\/serviceaccount\/key$/;
+const bondRegEx = /^https:\/\/([^/]+)\/api\/link\/v1\/([a-z-]+)\/serviceaccount\/key$/;
 
 let getJsonFromApiStub;
 const getJsonFromApiMethodName = 'getJsonFrom';

--- a/test/martha/martha_v3.test.js
+++ b/test/martha/martha_v3.test.js
@@ -367,7 +367,8 @@ test.serial('martha_v3 returns null for fields missing in drs and bond response'
     t.is(response.statusCode, 200);
 });
 
-function generateUrl(testUrl) {
+// Test utility for generating server URL from a DRS URL
+function determineDrsTypeTestWrapper(testUrl) {
     const parsedUrl = new URL(testUrl);
     return determineDrsType(parsedUrl).urlGenerator(parsedUrl);
 }
@@ -376,23 +377,23 @@ function generateUrl(testUrl) {
  * determineDrsType(uri) -> drsUrl Scenario 1: data objects uri with non-dg host and path
  */
 test('determineDrsType should parse dos:// Data Object uri', (t) => {
-    t.is(generateUrl('dos://fo.o/bar'), 'https://fo.o/ga4gh/dos/v1/dataobjects/bar');
+    t.is(determineDrsTypeTestWrapper('dos://fo.o/bar'), 'https://fo.o/ga4gh/dos/v1/dataobjects/bar');
 });
 
 test('determineDrsType should parse drs:// Data Object uri', (t) => {
-    t.is(generateUrl('drs://fo.o/bar'), 'https://fo.o/ga4gh/dos/v1/dataobjects/bar');
+    t.is(determineDrsTypeTestWrapper('drs://fo.o/bar'), 'https://fo.o/ga4gh/dos/v1/dataobjects/bar');
 });
 
 test('determineDrsType should parse drs:// Data Object uri with query part', (t) => {
     t.is(
-        generateUrl('drs://fo.o/bar?version=1&bananas=yummy'),
+        determineDrsTypeTestWrapper('drs://fo.o/bar?version=1&bananas=yummy'),
         'https://fo.o/ga4gh/dos/v1/dataobjects/bar?version=1&bananas=yummy'
     );
 });
 
 test('determineDrsType should parse drs:// Data Object uri when host includes a port number', (t) => {
     t.is(
-        generateUrl('drs://foo.com:1234/bar'),
+        determineDrsTypeTestWrapper('drs://foo.com:1234/bar'),
         'https://foo.com:1234/ga4gh/dos/v1/dataobjects/bar'
     );
 });
@@ -403,23 +404,23 @@ test('determineDrsType should parse drs:// Data Object uri when host includes a 
 /**
  * determineDrsType(uri) -> drsUrl Scenario 2: data objects uri with dg host
  */
-test('dataObjectUriToHttps should parse "dos://" Data Object uri with a host and path', (t) => {
+test('determineDrsType should parse "dos://" Data Object uri with a host and path', (t) => {
     t.is(
-        generateUrl('dos://dg.2345/bar'),
+        determineDrsTypeTestWrapper('dos://dg.2345/bar'),
         `https://${config.dataObjectResolutionHost}/ga4gh/dos/v1/dataobjects/dg.2345/bar`
     );
 });
 
-test('dataObjectUriToHttps should parse "drs://" Data Object uri with a host and path', (t) => {
+test('determineDrsType should parse "drs://" Data Object uri with a host and path', (t) => {
     t.is(
-        generateUrl('drs://dg.2345/bar'),
+        determineDrsTypeTestWrapper('drs://dg.2345/bar'),
         `https://${config.dataObjectResolutionHost}/ga4gh/dos/v1/dataobjects/dg.2345/bar`
     );
 });
 
-test('dataObjectUriToHttps should parse "drs://dg." Data Object uri with query part', (t) => {
+test('determineDrsType should parse "drs://dg." Data Object uri with query part', (t) => {
     t.is(
-        generateUrl('drs://dg.2345/bar?version=1&bananas=yummy'),
+        determineDrsTypeTestWrapper('drs://dg.2345/bar?version=1&bananas=yummy'),
         `https://${config.dataObjectResolutionHost}/ga4gh/dos/v1/dataobjects/dg.2345/bar?version=1&bananas=yummy`
     );
 });
@@ -432,21 +433,21 @@ test('dataObjectUriToHttps should parse "drs://dg." Data Object uri with query p
  */
 test('should parse "dos://dg." Data Object uri with only a host part without a path', (t) => {
     t.is(
-        generateUrl('dos://dg.bAz'),
+        determineDrsTypeTestWrapper('dos://dg.bAz'),
         `https://${config.dataObjectResolutionHost}/ga4gh/dos/v1/dataobjects/dg.bAz`
     );
 });
 
 test('should parse "drs://foo-bar.baz" Data Object uri with only a host part without a path', (t) => {
     t.is(
-        generateUrl('drs://foo-BAR.baz'),
+        determineDrsTypeTestWrapper('drs://foo-BAR.baz'),
         `https://foo-BAR.baz/ga4gh/dos/v1/dataobjects/foo-BAR.baz`
     );
 });
 
 test('should parse "drs://dg." Data Object uri with only a host part with a query part', (t) => {
     t.is(
-        generateUrl('drs://dg.foo-bar-baz?version=1&bananas=yummy'),
+        determineDrsTypeTestWrapper('drs://dg.foo-bar-baz?version=1&bananas=yummy'),
         `https://${config.dataObjectResolutionHost}/ga4gh/dos/v1/dataobjects/dg.foo-bar-baz?version=1&bananas=yummy`
     );
 });
@@ -459,28 +460,28 @@ test('should parse "drs://dg." Data Object uri with only a host part with a quer
  */
 test('should parse Data Object uri with jade data repo DEV as host', (t) => {
     t.is(
-        generateUrl('drs://jade.datarepo-dev.broadinstitute.org/973b5e79-6433-40ce-bf38-686ab7f17820'),
+        determineDrsTypeTestWrapper('drs://jade.datarepo-dev.broadinstitute.org/973b5e79-6433-40ce-bf38-686ab7f17820'),
         'https://jade.datarepo-dev.broadinstitute.org/ga4gh/drs/v1/objects/973b5e79-6433-40ce-bf38-686ab7f17820'
     );
 });
 
 test('should parse Data Object uri with jade data repo DEV as host and path with snapshot id', (t) => {
     t.is(
-        generateUrl('drs://jade.datarepo-dev.broadinstitute.org/v1_c78919df-5d71-414b-ad29-7c3c0d810657_973b5e79-6433-40ce-bf38-686ab7f17820'),
+        determineDrsTypeTestWrapper('drs://jade.datarepo-dev.broadinstitute.org/v1_c78919df-5d71-414b-ad29-7c3c0d810657_973b5e79-6433-40ce-bf38-686ab7f17820'),
         'https://jade.datarepo-dev.broadinstitute.org/ga4gh/drs/v1/objects/v1_c78919df-5d71-414b-ad29-7c3c0d810657_973b5e79-6433-40ce-bf38-686ab7f17820'
     );
 });
 
 test('should parse Data Object uri with jade data repo PROD as host', (t) => {
     t.is(
-        generateUrl('drs://jade-terra.datarepo-prod.broadinstitute.org/anything'),
+        determineDrsTypeTestWrapper('drs://jade-terra.datarepo-prod.broadinstitute.org/anything'),
         'https://jade-terra.datarepo-prod.broadinstitute.org/ga4gh/drs/v1/objects/anything'
     );
 });
 
 test('should parse Data Object uri with host that looks like jade data repo host', (t) => {
     t.is(
-        generateUrl('drs://jade-data-repo.datarepo-dev.broadinstitute.org/v1_anything'),
+        determineDrsTypeTestWrapper('drs://jade-data-repo.datarepo-dev.broadinstitute.org/v1_anything'),
         'https://jade-data-repo.datarepo-dev.broadinstitute.org/ga4gh/drs/v1/objects/v1_anything'
     );
 });

--- a/test/martha/martha_v3.test.js
+++ b/test/martha/martha_v3.test.js
@@ -9,26 +9,27 @@
 
 const {
     sampleDosResponse,
+    sampleDosMarthaResult,
+    dataGuidsOrgResponse,
+    dataGuidsOrgMarthaResult,
     jadeDrsResponse,
+    jadeDrsMarthaResult,
     hcaDosMarthaResult,
     hcaDosResponse,
     bdcDrsMarthaResult,
     bdcDrsResponse,
     kidsFirstDrsResponse,
+    kidsFirstDrsMarthaResult,
     anvilDrsMarthaResult,
     anvilDrsResponse,
     gen3CrdcDrsMarthaResult,
     gen3CrdcResponse,
-    sampleDosMarthaResult,
-    jadeDrsMarthaResult,
-    kidsFirstDrsMarthaResult,
     dosObjectWithMissingFields,
     expectedObjWithMissingFields
 } = require('./_martha_v3_resources.js');
 
 const test = require('ava');
 const sinon = require('sinon');
-const url = require('url');
 const { marthaV3Handler: marthaV3, determineDrsType } = require('../../martha/martha_v3');
 const apiAdapter = require('../../common/api_adapter');
 const config = require('../../config.json');
@@ -52,7 +53,7 @@ const mockResponse = () => {
 
 const googleSAKeyObject = { key: 'A Google Service Account private key json object' };
 
-const bondRegEx = /^([^/]+)\/api\/link\/v1\/([a-z-]+)\/serviceaccount\/key$/;
+const bondRegEx = /^https:\/\/([^/]+)\/api\/link\/v1\/([a-z-]+)\/serviceaccount\/key$/;
 
 let getJsonFromApiStub;
 const getJsonFromApiMethodName = 'getJsonFrom';
@@ -73,8 +74,15 @@ test.serial('martha_v3 resolves a valid DOS-style url', async (t) => {
     const response = mockResponse();
     await marthaV3(mockRequest({ body: { 'url': 'dos://abc/123' } }), response);
     const result = response.send.lastCall.args[0];
-    t.deepEqual(Object.assign({}, result), sampleDosMarthaResult(googleSAKeyObject));
+    t.true(getJsonFromApiStub.calledTwice); // Bond was called to get SA key
+    t.deepEqual({ ...result }, sampleDosMarthaResult(googleSAKeyObject));
     t.is(response.statusCode, 200);
+    const requestedBondUrl = getJsonFromApiStub.secondCall.args[0];
+    const matches = requestedBondUrl.match(bondRegEx);
+    t.truthy(matches, 'Bond URL called does not match Bond URL regular expression');
+    const expectedProvider = 'dcf-fence';
+    const actualProvider = matches[2];
+    t.is(actualProvider, expectedProvider);
 });
 
 // According to the DRS specification authors [0] it's OK for a client to call Martha with a `drs://` URI and get
@@ -88,8 +96,15 @@ test.serial('martha_v3 resolves a valid DRS-style url', async (t) => {
     const response = mockResponse();
     await marthaV3(mockRequest({ body: { 'url': 'drs://abc/123' } }), response);
     const result = response.send.lastCall.args[0];
-    t.deepEqual(Object.assign({}, result), sampleDosMarthaResult(googleSAKeyObject));
+    t.true(getJsonFromApiStub.calledTwice); // Bond was called to get SA key
+    t.deepEqual({ ...result }, sampleDosMarthaResult(googleSAKeyObject));
     t.is(response.statusCode, 200);
+    const requestedBondUrl = getJsonFromApiStub.secondCall.args[0];
+    const matches = requestedBondUrl.match(bondRegEx);
+    t.truthy(matches, 'Bond URL called does not match Bond URL regular expression');
+    const expectedProvider = 'dcf-fence';
+    const actualProvider = matches[2];
+    t.is(actualProvider, expectedProvider);
 });
 
 test.serial('martha_v3 resolves successfully and ignores extra data submitted besides a \'url\'', async (t) => {
@@ -103,8 +118,15 @@ test.serial('martha_v3 resolves successfully and ignores extra data submitted be
         }
     }), response);
     const result = response.send.lastCall.args[0];
-    t.deepEqual(Object.assign({}, result), sampleDosMarthaResult(googleSAKeyObject));
+    t.true(getJsonFromApiStub.calledTwice); // Bond was called to get SA key
+    t.deepEqual({ ...result }, sampleDosMarthaResult(googleSAKeyObject));
     t.is(response.statusCode, 200);
+    const requestedBondUrl = getJsonFromApiStub.secondCall.args[0];
+    const matches = requestedBondUrl.match(bondRegEx);
+    t.truthy(matches, 'Bond URL called does not match Bond URL regular expression');
+    const expectedProvider = 'dcf-fence';
+    const actualProvider = matches[2];
+    t.is(actualProvider, expectedProvider);
 });
 
 test.serial('martha_v3 should return 400 if a Data Object without authorization header is provided', async (t) => {
@@ -144,7 +166,7 @@ test.serial('martha_v3 should return 400 if given a \'url\' with an invalid valu
     const result = response.send.lastCall.args[0];
     t.is(response.statusCode, 400);
     t.is(result.status, 400);
-    t.is(result.response.text, '"Not a valid URI" is not a properly-formatted URI.');
+    t.is(result.response.text, 'Invalid URL: Not a valid URI');
 });
 
 test.serial('martha_v3 should return 500 if Data Object resolution fails', async (t) => {
@@ -199,10 +221,32 @@ test.serial('martha_v3 does not call Bond or return SA key when the Data Object 
     await marthaV3(mockRequest({ body: { 'url': 'drs://someservice.humancellatlas.org/this_part_can_be_anything' } }), response);
     const result = response.send.lastCall.args[0];
     t.true(getJsonFromApiStub.calledOnce); // Bond was not called to get SA key
-    t.deepEqual(Object.assign({}, result), sampleDosMarthaResult(null));
+    t.deepEqual({ ...result }, sampleDosMarthaResult(null));
     t.falsy(result.googleServiceAccount);
     t.is(response.statusCode, 200);
 });
+
+test.serial(
+    'martha_v3 does call Bond and return SA key when the host url is for dataguids.org',
+    async (t) => {
+        getJsonFromApiStub.onFirstCall().resolves(dataGuidsOrgResponse);
+        const response = mockResponse();
+        await marthaV3(
+            mockRequest({ body: { 'url': 'dos://dataguids.org/a41b0c4f-ebfb-4277-a941-507340dea85d' } }),
+            response
+        );
+        const result = response.send.lastCall.args[0];
+        t.true(getJsonFromApiStub.calledTwice); // Bond was called to get SA key
+        t.deepEqual({ ...result }, dataGuidsOrgMarthaResult(googleSAKeyObject));
+        t.is(response.statusCode, 200);
+        const requestedBondUrl = getJsonFromApiStub.secondCall.args[0];
+        const matches = requestedBondUrl.match(bondRegEx);
+        t.truthy(matches, 'Bond URL called does not match Bond URL regular expression');
+        const expectedProvider = 'dcf-fence';
+        const actualProvider = matches[2];
+        t.is(actualProvider, expectedProvider);
+    }
+);
 
 test.serial('martha_v3 does not call Bond or return SA key when the host url is for jade data repo', async (t) => {
     getJsonFromApiStub.onFirstCall().resolves(jadeDrsResponse);
@@ -210,7 +254,7 @@ test.serial('martha_v3 does not call Bond or return SA key when the host url is 
     await marthaV3(mockRequest({ body: { 'url': 'drs://jade.datarepo-dev.broadinstitute.org/abc' } }), response);
     const result = response.send.lastCall.args[0];
     t.true(getJsonFromApiStub.calledOnce); // Bond was not called to get SA key
-    t.deepEqual(Object.assign({}, result), jadeDrsMarthaResult(null));
+    t.deepEqual({ ...result }, jadeDrsMarthaResult);
     t.falsy(result.googleServiceAccount);
     t.is(response.statusCode, 200);
 });
@@ -218,10 +262,13 @@ test.serial('martha_v3 does not call Bond or return SA key when the host url is 
 test.serial('martha_v3 parses Gen3 CRDC response correctly', async (t) => {
     getJsonFromApiStub.onFirstCall().resolves(gen3CrdcResponse);
     const response = mockResponse();
-    await marthaV3(mockRequest({ body: { 'url': 'drs://nci-crdc.datacommons.io/asdfasdfasdf' } }), response);
+    await marthaV3(
+        mockRequest({ body: { 'url': 'dos://nci-crdc-staging.datacommons.io/206dfaa6-bcf1-4bc9-b2d0-77179f0f48fc' } }),
+        response,
+    );
     const result = response.send.lastCall.args[0];
     t.true(getJsonFromApiStub.calledOnce); // Bond was not called to get SA key
-    t.deepEqual(Object.assign({}, result), gen3CrdcDrsMarthaResult(null));
+    t.deepEqual({ ...result }, gen3CrdcDrsMarthaResult);
     t.falsy(result.googleServiceAccount);
     t.is(response.statusCode, 200);
 });
@@ -229,43 +276,78 @@ test.serial('martha_v3 parses Gen3 CRDC response correctly', async (t) => {
 test.serial('martha_v3 parses BDC response correctly', async (t) => {
     getJsonFromApiStub.onFirstCall().resolves(bdcDrsResponse);
     const response = mockResponse();
-    await marthaV3(mockRequest({ body: { 'url': 'dos://jade.datarepo-dev.broadinstitute.org/abc' } }), response);
+    await marthaV3(
+        mockRequest({ body: { 'url': 'drs://dg.4503/fc046e84-6cf9-43a3-99cc-ffa2964b88cb' } }),
+        response,
+    );
     const result = response.send.lastCall.args[0];
-    t.true(getJsonFromApiStub.calledOnce); // Bond was not called to get SA key
-    t.deepEqual(Object.assign({}, result), bdcDrsMarthaResult);
-    t.falsy(result.googleServiceAccount);
+    t.true(getJsonFromApiStub.calledTwice); // Bond was called to get SA key
+    t.deepEqual({ ...result }, bdcDrsMarthaResult(googleSAKeyObject));
     t.is(response.statusCode, 200);
+    const requestedBondUrl = getJsonFromApiStub.secondCall.args[0];
+    const matches = requestedBondUrl.match(bondRegEx);
+    t.truthy(matches, 'Bond URL called does not match Bond URL regular expression');
+    const expectedProvider = 'fence';
+    const actualProvider = matches[2];
+    t.is(actualProvider, expectedProvider);
 });
 
 test.serial('martha_v3 parses Anvil response correctly', async (t) => {
     getJsonFromApiStub.onFirstCall().resolves(anvilDrsResponse);
     const response = mockResponse();
-    await marthaV3(mockRequest({ body: { 'url': 'dos://jade.datarepo-dev.broadinstitute.org/abc' } }), response);
+    await marthaV3(
+        mockRequest({ body: { 'url': 'drs://dg.ANV0/00008531-03d7-418c-b3d3-b7b22b5381a0' } }),
+        response,
+    );
     const result = response.send.lastCall.args[0];
-    t.true(getJsonFromApiStub.calledOnce); // Bond was not called to get SA key
-    t.deepEqual(Object.assign({}, result), anvilDrsMarthaResult(null));
-    t.falsy(result.googleServiceAccount);
+    t.true(getJsonFromApiStub.calledTwice); // Bond was called to get SA key
+    t.deepEqual({ ...result }, anvilDrsMarthaResult(googleSAKeyObject));
     t.is(response.statusCode, 200);
+    const requestedBondUrl = getJsonFromApiStub.secondCall.args[0];
+    const matches = requestedBondUrl.match(bondRegEx);
+    t.truthy(matches, 'Bond URL called does not match Bond URL regular expression');
+    const expectedProvider = 'anvil';
+    const actualProvider = matches[2];
+    t.is(actualProvider, expectedProvider);
 });
 
 test.serial('martha_v3 parses Kids First response correctly', async (t) => {
     getJsonFromApiStub.onFirstCall().resolves(kidsFirstDrsResponse);
     const response = mockResponse();
-    await marthaV3(mockRequest({ body: { 'url': 'dos://jade.datarepo-dev.broadinstitute.org/abc' } }), response);
+    await marthaV3(
+        mockRequest({ body: { 'url': 'drs://data.kidsfirstdrc.org/ed6be7ab-068e-46c8-824a-f39cfbb885cc' } }),
+        response
+    );
     const result = response.send.lastCall.args[0];
-    t.true(getJsonFromApiStub.calledOnce); // Bond was not called to get SA key
-    t.deepEqual(Object.assign({}, result), kidsFirstDrsMarthaResult(null));
-    t.falsy(result.googleServiceAccount);
+    t.true(getJsonFromApiStub.calledTwice); // Bond was called to get SA key
+    t.deepEqual({ ...result }, kidsFirstDrsMarthaResult(googleSAKeyObject));
     t.is(response.statusCode, 200);
+    const requestedBondUrl = getJsonFromApiStub.secondCall.args[0];
+    const matches = requestedBondUrl.match(bondRegEx);
+    t.truthy(matches, 'Bond URL called does not match Bond URL regular expression');
+    const expectedProvider = 'dcf-fence';
+    const actualProvider = matches[2];
+    t.is(actualProvider, expectedProvider);
 });
 
 test.serial('martha_v3 parses HCA response correctly', async (t) => {
     getJsonFromApiStub.onFirstCall().resolves(hcaDosResponse);
     const response = mockResponse();
-    await marthaV3(mockRequest({ body: { 'url': 'dos://someservice.humancellatlas.org/abc' } }), response);
+    await marthaV3(
+        mockRequest(
+            {
+                body: {
+                    'url':
+                        'dos://drs.data.humancellatlas.org/4bb2740b-e6b2-4c99-824e-6963d505cda0' +
+                        '?version=2019-05-15T210546.628682Z'
+                }
+            }
+        ),
+        response
+    );
     const result = response.send.lastCall.args[0];
     t.true(getJsonFromApiStub.calledOnce); // Bond was not called to get SA key
-    t.deepEqual(Object.assign({}, result), hcaDosMarthaResult(null));
+    t.deepEqual({ ...result }, hcaDosMarthaResult);
     t.falsy(result.googleServiceAccount);
     t.is(response.statusCode, 200);
 });
@@ -281,28 +363,38 @@ test.serial('martha_v3 returns null for fields missing in drs and bond response'
     const response = mockResponse();
     await marthaV3(mockRequest({ body: { 'url': 'drs://abc/123' } }), response);
     const result = response.send.lastCall.args[0];
-    t.deepEqual(Object.assign({}, result), expectedObjWithMissingFields);
+    t.deepEqual({ ...result }, expectedObjWithMissingFields);
     t.is(response.statusCode, 200);
 });
 
+function generateUrl(testUrl) {
+    const parsedUrl = new URL(testUrl);
+    return determineDrsType(parsedUrl).urlGenerator(parsedUrl);
+}
 
 /**
  * determineDrsType(uri) -> drsUrl Scenario 1: data objects uri with non-dg host and path
  */
 test('determineDrsType should parse dos:// Data Object uri', (t) => {
-    t.is(determineDrsType(url.parse('dos://fo.o/bar')).drsUrl, 'https://fo.o/ga4gh/dos/v1/dataobjects/bar');
+    t.is(generateUrl('dos://fo.o/bar'), 'https://fo.o/ga4gh/dos/v1/dataobjects/bar');
 });
 
 test('determineDrsType should parse drs:// Data Object uri', (t) => {
-    t.is(determineDrsType(url.parse('drs://fo.o/bar')).drsUrl, 'https://fo.o/ga4gh/dos/v1/dataobjects/bar');
+    t.is(generateUrl('drs://fo.o/bar'), 'https://fo.o/ga4gh/dos/v1/dataobjects/bar');
 });
 
 test('determineDrsType should parse drs:// Data Object uri with query part', (t) => {
-    t.is(determineDrsType(url.parse('drs://fo.o/bar?version=1&bananas=yummy')).drsUrl, 'https://fo.o/ga4gh/dos/v1/dataobjects/bar?version=1&bananas=yummy');
+    t.is(
+        generateUrl('drs://fo.o/bar?version=1&bananas=yummy'),
+        'https://fo.o/ga4gh/dos/v1/dataobjects/bar?version=1&bananas=yummy'
+    );
 });
 
 test('determineDrsType should parse drs:// Data Object uri when host includes a port number', (t) => {
-    t.is(determineDrsType(url.parse('drs://foo.com:1234/bar')).drsUrl, 'https://foo.com:1234/ga4gh/dos/v1/dataobjects/bar');
+    t.is(
+        generateUrl('drs://foo.com:1234/bar'),
+        'https://foo.com:1234/ga4gh/dos/v1/dataobjects/bar'
+    );
 });
 /**
  * End Scenario 1
@@ -312,15 +404,24 @@ test('determineDrsType should parse drs:// Data Object uri when host includes a 
  * determineDrsType(uri) -> drsUrl Scenario 2: data objects uri with dg host
  */
 test('dataObjectUriToHttps should parse "dos://" Data Object uri with a host and path', (t) => {
-    t.is(determineDrsType(url.parse('dos://dg.2345/bar')).drsUrl, `https://${config.dataObjectResolutionHost}/ga4gh/dos/v1/dataobjects/dg.2345/bar`);
+    t.is(
+        generateUrl('dos://dg.2345/bar'),
+        `https://${config.dataObjectResolutionHost}/ga4gh/dos/v1/dataobjects/dg.2345/bar`
+    );
 });
 
 test('dataObjectUriToHttps should parse "drs://" Data Object uri with a host and path', (t) => {
-    t.is(determineDrsType(url.parse('drs://dg.2345/bar')).drsUrl, `https://${config.dataObjectResolutionHost}/ga4gh/dos/v1/dataobjects/dg.2345/bar`);
+    t.is(
+        generateUrl('drs://dg.2345/bar'),
+        `https://${config.dataObjectResolutionHost}/ga4gh/dos/v1/dataobjects/dg.2345/bar`
+    );
 });
 
 test('dataObjectUriToHttps should parse "drs://dg." Data Object uri with query part', (t) => {
-    t.is(determineDrsType(url.parse('drs://dg.2345/bar?version=1&bananas=yummy')).drsUrl, `https://${config.dataObjectResolutionHost}/ga4gh/dos/v1/dataobjects/dg.2345/bar?version=1&bananas=yummy`);
+    t.is(
+        generateUrl('drs://dg.2345/bar?version=1&bananas=yummy'),
+        `https://${config.dataObjectResolutionHost}/ga4gh/dos/v1/dataobjects/dg.2345/bar?version=1&bananas=yummy`
+    );
 });
 /**
  * End Scenario 2
@@ -330,15 +431,24 @@ test('dataObjectUriToHttps should parse "drs://dg." Data Object uri with query p
  * determineDrsType(uri) -> drsUrl Scenario 3: data objects uri with non-dg host and NO path
  */
 test('should parse "dos://dg." Data Object uri with only a host part without a path', (t) => {
-    t.is(determineDrsType(url.parse('dos://dg.baz')).drsUrl, `https://${config.dataObjectResolutionHost}/ga4gh/dos/v1/dataobjects/dg.baz`);
+    t.is(
+        generateUrl('dos://dg.bAz'),
+        `https://${config.dataObjectResolutionHost}/ga4gh/dos/v1/dataobjects/dg.bAz`
+    );
 });
 
 test('should parse "drs://foo-bar.baz" Data Object uri with only a host part without a path', (t) => {
-    t.is(determineDrsType(url.parse('drs://foo-bar.baz')).drsUrl, `https://foo-bar.baz/ga4gh/dos/v1/dataobjects/foo-bar.baz`);
+    t.is(
+        generateUrl('drs://foo-BAR.baz'),
+        `https://foo-BAR.baz/ga4gh/dos/v1/dataobjects/foo-BAR.baz`
+    );
 });
 
 test('should parse "drs://dg." Data Object uri with only a host part with a query part', (t) => {
-    t.is(determineDrsType(url.parse('drs://dg.foo-bar-baz?version=1&bananas=yummy')).drsUrl, `https://${config.dataObjectResolutionHost}/ga4gh/dos/v1/dataobjects/dg.foo-bar-baz?version=1&bananas=yummy`);
+    t.is(
+        generateUrl('drs://dg.foo-bar-baz?version=1&bananas=yummy'),
+        `https://${config.dataObjectResolutionHost}/ga4gh/dos/v1/dataobjects/dg.foo-bar-baz?version=1&bananas=yummy`
+    );
 });
 /**
  * End Scenario 3
@@ -349,28 +459,28 @@ test('should parse "drs://dg." Data Object uri with only a host part with a quer
  */
 test('should parse Data Object uri with jade data repo DEV as host', (t) => {
     t.is(
-        determineDrsType(url.parse('drs://jade.datarepo-dev.broadinstitute.org/973b5e79-6433-40ce-bf38-686ab7f17820')).drsUrl,
+        generateUrl('drs://jade.datarepo-dev.broadinstitute.org/973b5e79-6433-40ce-bf38-686ab7f17820'),
         'https://jade.datarepo-dev.broadinstitute.org/ga4gh/drs/v1/objects/973b5e79-6433-40ce-bf38-686ab7f17820'
     );
 });
 
 test('should parse Data Object uri with jade data repo DEV as host and path with snapshot id', (t) => {
     t.is(
-        determineDrsType(url.parse('drs://jade.datarepo-dev.broadinstitute.org/v1_c78919df-5d71-414b-ad29-7c3c0d810657_973b5e79-6433-40ce-bf38-686ab7f17820')).drsUrl,
+        generateUrl('drs://jade.datarepo-dev.broadinstitute.org/v1_c78919df-5d71-414b-ad29-7c3c0d810657_973b5e79-6433-40ce-bf38-686ab7f17820'),
         'https://jade.datarepo-dev.broadinstitute.org/ga4gh/drs/v1/objects/v1_c78919df-5d71-414b-ad29-7c3c0d810657_973b5e79-6433-40ce-bf38-686ab7f17820'
     );
 });
 
 test('should parse Data Object uri with jade data repo PROD as host', (t) => {
     t.is(
-        determineDrsType(url.parse('drs://jade-terra.datarepo-prod.broadinstitute.org/anything')).drsUrl,
+        generateUrl('drs://jade-terra.datarepo-prod.broadinstitute.org/anything'),
         'https://jade-terra.datarepo-prod.broadinstitute.org/ga4gh/drs/v1/objects/anything'
     );
 });
 
 test('should parse Data Object uri with host that looks like jade data repo host', (t) => {
     t.is(
-        determineDrsType(url.parse('drs://jade-data-repo.datarepo-dev.broadinstitute.org/v1_anything')).drsUrl,
+        generateUrl('drs://jade-data-repo.datarepo-dev.broadinstitute.org/v1_anything'),
         'https://jade-data-repo.datarepo-dev.broadinstitute.org/ga4gh/drs/v1/objects/v1_anything'
     );
 });

--- a/test/martha/martha_v3.test.js
+++ b/test/martha/martha_v3.test.js
@@ -30,7 +30,7 @@ const {
 
 const test = require('ava');
 const sinon = require('sinon');
-const { marthaV3Handler: marthaV3, determineDrsType } = require('../../martha/martha_v3');
+const { marthaV3Handler: marthaV3, determineDrsType, httpsUrlGenerator } = require('../../martha/martha_v3');
 const apiAdapter = require('../../common/api_adapter');
 const config = require('../../config.json');
 
@@ -370,7 +370,8 @@ test.serial('martha_v3 returns null for fields missing in drs and bond response'
 // Test utility for generating server URL from a DRS URL
 function determineDrsTypeTestWrapper(testUrl) {
     const parsedUrl = new URL(testUrl);
-    return determineDrsType(parsedUrl).urlGenerator(parsedUrl);
+    const { dataGuidExpansion, protocolPrefix } = determineDrsType(parsedUrl);
+    return httpsUrlGenerator(parsedUrl, dataGuidExpansion, protocolPrefix);
 }
 
 /**
@@ -487,4 +488,40 @@ test('should parse Data Object uri with host that looks like jade data repo host
 });
 /**
  * End Scenario 4
+ */
+
+/**
+ * determineDrsType(uri) -> drsUrl Scenario 5: data objects uri with the AnVIL data repo host
+ */
+test('should parse Data Object uri with the AnVIL prefix dg.ANV0', (t) => {
+    t.is(
+        determineDrsTypeTestWrapper(
+            'drs://dg.ANV0/00008531-03d7-418c-b3d3-b7b22b5381a0'),
+        'https://gen3.theanvil.io/ga4gh/dos/v1/dataobjects/dg.ANV0/00008531-03d7-418c-b3d3-b7b22b5381a0',
+    );
+});
+
+test('should parse Data Object uri with the AnVIL host', (t) => {
+    t.is(
+        determineDrsTypeTestWrapper(
+            'drs://gen3.theanvil.io/dg.ANV0/00008531-03d7-418c-b3d3-b7b22b5381a0'),
+        'https://gen3.theanvil.io/ga4gh/dos/v1/dataobjects/dg.ANV0/00008531-03d7-418c-b3d3-b7b22b5381a0',
+    );
+});
+/**
+ * End Scenario 5
+ */
+
+/**
+ * determineDrsType(uri) -> drsUrl Scenario 6: data objects uri with the Kids First
+ */
+test('should parse Data Object uri with the Kids First repo as host', (t) => {
+    t.is(
+        determineDrsTypeTestWrapper(
+            'drs://data.kidsfirstdrc.org/ed6be7ab-068e-46c8-824a-f39cfbb885cc'),
+        'https://data.kidsfirstdrc.org/ga4gh/dos/v1/dataobjects/ed6be7ab-068e-46c8-824a-f39cfbb885cc',
+    );
+});
+/**
+ * End Scenario 6
  */

--- a/test/martha/martha_v3.test.js
+++ b/test/martha/martha_v3.test.js
@@ -495,16 +495,14 @@ test('should parse Data Object uri with host that looks like jade data repo host
  */
 test('should parse Data Object uri with the AnVIL prefix dg.ANV0', (t) => {
     t.is(
-        determineDrsTypeTestWrapper(
-            'drs://dg.ANV0/00008531-03d7-418c-b3d3-b7b22b5381a0'),
+        determineDrsTypeTestWrapper('drs://dg.ANV0/00008531-03d7-418c-b3d3-b7b22b5381a0'),
         'https://gen3.theanvil.io/ga4gh/dos/v1/dataobjects/dg.ANV0/00008531-03d7-418c-b3d3-b7b22b5381a0',
     );
 });
 
 test('should parse Data Object uri with the AnVIL host', (t) => {
     t.is(
-        determineDrsTypeTestWrapper(
-            'drs://gen3.theanvil.io/dg.ANV0/00008531-03d7-418c-b3d3-b7b22b5381a0'),
+        determineDrsTypeTestWrapper('drs://gen3.theanvil.io/dg.ANV0/00008531-03d7-418c-b3d3-b7b22b5381a0'),
         'https://gen3.theanvil.io/ga4gh/dos/v1/dataobjects/dg.ANV0/00008531-03d7-418c-b3d3-b7b22b5381a0',
     );
 });
@@ -517,8 +515,7 @@ test('should parse Data Object uri with the AnVIL host', (t) => {
  */
 test('should parse Data Object uri with the Kids First repo as host', (t) => {
     t.is(
-        determineDrsTypeTestWrapper(
-            'drs://data.kidsfirstdrc.org/ed6be7ab-068e-46c8-824a-f39cfbb885cc'),
+        determineDrsTypeTestWrapper('drs://data.kidsfirstdrc.org/ed6be7ab-068e-46c8-824a-f39cfbb885cc'),
         'https://data.kidsfirstdrc.org/ga4gh/dos/v1/dataobjects/ed6be7ab-068e-46c8-824a-f39cfbb885cc',
     );
 });


### PR DESCRIPTION
- `martha_v3` mock tests ensure the correct Bond link has been contacted
- Added The AnVIL to the list of DOS/DRS servers that need to talk to Bond in `martha_v3`
- Stopping enumerating and comparing servers that don't talk to Bond, just use undefined or `null`
- Add `getSignedUrlV1` tests to ensure non-Bond DOS/DRS servers query their SA from SAM
- Update the Bond prefix in the committed `config.json` to send `https` instead of `http`
- Use `https` to talk to FiaB Bond instead of relying on the server to force the redirection
- Updated test regex to account for `https` in the Bond configs
- Update tests to remove static link so Bond host can be changed using `BOND_BASE_URL`
- When functions only require part of an object only pass that part
- More use of `&&` shortcutting instead of using `if`
- Add guess-comment as to where the `martha_v3` fields `bucket` and `name` originated
- Consolidate and add comment on converting `size` to a `Number()`
- `DrsType` fields now contain dg.* expansion and the `provider` to contact on Bond
- Composing instead of duplicating URL generator logic across DOS/DRS vs. Full/Compact
- Consolidated response parsers into one DOS vs. DRS response parser
- Preserve `dg.aBcD` casing by switching from the deprecated `url.parse()` to `new URL()`
- Updated tests to use `Error` text returned by `new URL()`
- Added more mock tests including a `https://dataguids.org` DOS resolution test
- In mocks of real servers use real URIs so folks can try them out if they have access
- Don't pass `expectedGoogleServiceAccount` to mock providers that will never use the value
- Do pass `expectedGoogleServiceAccount` to mock providers that should return the SA
- Swapped in a new mock HCA response and added a `curl` reference as to where it came from
- Use object spread instead of `Object.assign()` and validate using `eslint`
- Updated README.md based on URLs discovered in other prior updates to the mock tests