### PR TITLE
Don't fail from martha_v3 if there's a problem fetching a signed URL [BT-259]

### DIFF
--- a/common/helpers.js
+++ b/common/helpers.js
@@ -470,6 +470,10 @@ function logAndSendServerError(res, error, description) {
     res.status(errorStatusCode).send(failureResponse);
 }
 
+const delay = (ms) => {
+    return new Promise((resolve) => setTimeout(resolve, ms));
+};
+
 module.exports = {
     dataObjectUriToHttps,
     samBaseUrl,
@@ -489,4 +493,5 @@ module.exports = {
     RemoteServerError,
     logAndSendBadRequest,
     logAndSendServerError,
+    delay,
 };

--- a/martha/martha_v3.js
+++ b/martha/martha_v3.js
@@ -593,21 +593,21 @@ async function retrieveFromServers(params) {
         }
     };
 
-    let ranOutOfTime;
+    const timeout = Symbol.for('timeout');
     const waitUntilTimeIsAlmostUp = async () => {
         await delay(pencilsDownSeconds * 1000);
-        ranOutOfTime = true;
+        return timeout;
     };
 
     // For now, since we can still return native object URLs, we don't want to fail if it takes too
     // long to fetch a signed URL. Eventually, we won't have native object URLs to fall back on so
     // we'll have to throw an error, at which point we can remove all of this `Promise.race` stuff.
-    await Promise.race([
+    const winner = await Promise.race([
         fetch(),
         waitUntilTimeIsAlmostUp(),
     ]);
 
-    if (ranOutOfTime && !hypotheticalErrorMessage) {
+    if (winner === timeout && !hypotheticalErrorMessage) {
         console.log('Ran out of time fetching a signed URL; returning the native URL instead of throwing an error.');
     }
 

--- a/martha/martha_v3.js
+++ b/martha/martha_v3.js
@@ -608,7 +608,7 @@ async function retrieveFromServers(params) {
     ]);
 
     if (ranOutOfTime && !hypotheticalErrorMessage) {
-        console.log('Ran out of time fetching a signed URL, but returning everything else we fetched instead of throwing an error.');
+        console.log('Ran out of time fetching a signed URL; returning the native URL instead of throwing an error.');
     }
 
     if (hypotheticalErrorMessage) {

--- a/martha/martha_v3.js
+++ b/martha/martha_v3.js
@@ -90,12 +90,12 @@ const DG_COMPACT_KIDS_FIRST = 'dg.f82a1a';
 
 // Google Cloud Functions gives us 60 seconds to respond. We'll use most of it to fetch what we can,
 // but not fail if we happen to time out when fetching a signed URL takes too long.
-let pencilsDownTime = 58;
+let pencilsDownSeconds = 58;
 
 // For tests that need to probe the behavior near the limit of the Cloud Function timeout, we don't
 // want to have to wait 60 seconds.
-const overridePencilsDownTime = (seconds) => {
-    pencilsDownTime = seconds;
+const overridePencilsDownSeconds = (seconds) => {
+    pencilsDownSeconds = seconds;
 };
 
 // noinspection JSUnusedGlobalSymbols
@@ -595,7 +595,7 @@ async function retrieveFromServers(params) {
 
     let ranOutOfTime;
     const waitUntilTimeIsAlmostUp = async () => {
-        await delay(pencilsDownTime * 1000);
+        await delay(pencilsDownSeconds * 1000);
         ranOutOfTime = true;
     };
 
@@ -697,4 +697,4 @@ exports.generateAccessUrl = generateAccessUrl;
 exports.getDrsAccessId = getDrsAccessId;
 exports.getHttpsUrlParts = getHttpsUrlParts;
 exports.MARTHA_V3_ALL_FIELDS = MARTHA_V3_ALL_FIELDS;
-exports.overridePencilsDownTime = overridePencilsDownTime;
+exports.overridePencilsDownSeconds = overridePencilsDownSeconds;

--- a/test/martha/martha_v3.test.js
+++ b/test/martha/martha_v3.test.js
@@ -732,7 +732,11 @@ const testWithTimeout = (ms, asyncTestFn) => (t) => {
     return Promise.race([asyncTestFn(t), waitThenFail()]);
 };
 
-test.serial('martha_v3 succeeds within 60 seconds even if fetching a signed URL never returns', testWithTimeout(5 * 1000, async (t) => {
+test.serial('martha_v3 succeeds even if fetching a signed URL never returns', testWithTimeout(5 * 1000, async (t) => {
+    // martha_v3 should return the native access URL instead of letting the Google Cloud Function
+    // infrastructure time out after 60 seconds. For the purposes of this test, `testWithTimeout`
+    // above fails the test after 5 seconds (playing the role of a very impatient GCF timeout).
+    // Meanwhile here, we'll give martha_v3 3 seconds before it gives up on fetching a signed URL.
     overridePencilsDownSeconds(3);
     const {
         id: objectId, self_uri: drsUri,

--- a/test/martha/martha_v3.test.js
+++ b/test/martha/martha_v3.test.js
@@ -43,7 +43,7 @@ const {
     getDrsAccessId,
     getHttpsUrlParts,
     MARTHA_V3_ALL_FIELDS,
-    overridePencilsDownTime,
+    overridePencilsDownSeconds,
 } = require('../../martha/martha_v3');
 const apiAdapter = require('../../common/api_adapter');
 const config = require('../../common/config');
@@ -733,7 +733,7 @@ const testWithTimeout = (ms, asyncTestFn) => (t) => {
 };
 
 test.serial('martha_v3 succeeds within 60 seconds even if fetching a signed URL never returns', testWithTimeout(5 * 1000, async (t) => {
-    overridePencilsDownTime(3);
+    overridePencilsDownSeconds(3);
     const {
         id: objectId, self_uri: drsUri,
         access_methods: { 0: { access_id: accessId } }
@@ -756,7 +756,7 @@ test.serial('martha_v3 succeeds within 60 seconds even if fetching a signed URL 
 }));
 
 test.serial('martha_v3 fails if something times out before trying to fetch a signed URL', testWithTimeout(5 * 1000, async (t) => {
-    overridePencilsDownTime(3);
+    overridePencilsDownSeconds(3);
     const { id: objectId, self_uri: drsUri } = kidsFirstDrsResponse;
     const drs = drsUrls(config.HOST_KIDS_FIRST_STAGING, objectId);
     getJsonFromApiStub.withArgs(drs.objectsUrl, null).callsFake(async () => {

--- a/test/martha/martha_v3.test.js
+++ b/test/martha/martha_v3.test.js
@@ -43,9 +43,11 @@ const {
     getDrsAccessId,
     getHttpsUrlParts,
     MARTHA_V3_ALL_FIELDS,
+    overridePencilsDownTime,
 } = require('../../martha/martha_v3');
 const apiAdapter = require('../../common/api_adapter');
 const config = require('../../common/config');
+const { delay } = require('../../common/helpers');
 const mask = require('json-mask');
 
 const terraAuth = 'bearer abc123';
@@ -458,8 +460,6 @@ test.serial('martha_v3 should return 500 if Data Object resolution fails', async
     t.is(response.statusCode, 500);
     t.is(response.body.status, 500);
     t.is(response.body.response.text, 'Received error while resolving DRS URL. Data Object Resolution forced to fail by testing stub');
-
-    sinon.assert.callCount(getJsonFromApiStub, 1);
 });
 
 test.serial('martha_v3 should return the underlying status if Data Object resolution fails', async (t) => {
@@ -477,8 +477,6 @@ test.serial('martha_v3 should return the underlying status if Data Object resolu
         response.body.response.text,
         'Received error while resolving DRS URL. Data Object Resolution forced to fail by testing stub',
     );
-
-    sinon.assert.callCount(getJsonFromApiStub, 1);
 });
 
 test.serial('martha_v3 should return 500 if key retrieval from Bond fails', async (t) => {
@@ -493,8 +491,6 @@ test.serial('martha_v3 should return 500 if key retrieval from Bond fails', asyn
     t.is(response.statusCode, 500);
     t.is(response.body.status, 500);
     t.is(response.body.response.text, 'Received error contacting Bond. Bond key lookup forced to fail by testing stub');
-
-    sinon.assert.callCount(getJsonFromApiStub, 2);
 });
 
 test.serial('martha_v3 calls bond Bond with the "fence" provider when the Data Object URL host is "dg.4503"', async (t) => {
@@ -726,6 +722,83 @@ test.serial('martha_v3 parses HCA response correctly', async (t) => {
     t.deepEqual(response.body, hcaDrsMarthaResult);
 
     sinon.assert.callCount(getJsonFromApiStub, 1);
+});
+
+const testWithTimeout = (ms, asyncTestFn) => (t) => {
+    const waitThenFail = async () => {
+        await delay(ms);
+        t.fail(`Test did not complete within ${ms}ms`);
+    };
+    return Promise.race([asyncTestFn(t), waitThenFail()]);
+};
+
+test.serial('martha_v3 succeeds within 60 seconds even if fetching a signed URL never returns', testWithTimeout(5 * 1000, async (t) => {
+    overridePencilsDownTime(3);
+    const {
+        id: objectId, self_uri: drsUri,
+        access_methods: { 0: { access_id: accessId } }
+    } = kidsFirstDrsResponse;
+    const bond = bondUrls('kids-first');
+    const drs = drsUrls(config.HOST_KIDS_FIRST_STAGING, objectId, accessId);
+    getJsonFromApiStub.withArgs(drs.objectsUrl, null).resolves(kidsFirstDrsResponse);
+    getJsonFromApiStub.withArgs(bond.accessTokenUrl, terraAuth).resolves(bondAccessTokenResponse);
+    getJsonFromApiStub.withArgs(drs.accessUrl, `Bearer ${bondAccessTokenResponse.token}`).callsFake(async () => {
+        await delay(90 * 1000);
+        return 'Boom!';
+    });
+    const response = mockResponse();
+
+    await marthaV3(mockRequest({ body: { 'url': drsUri } }), response);
+
+    t.is(response.statusCode, 200);
+    t.deepEqual(response.body, kidsFirstDrsMarthaResult(null));
+    sinon.assert.callCount(getJsonFromApiStub, 3);
+}));
+
+test.serial('martha_v3 fails if something times out before trying to fetch a signed URL', testWithTimeout(5 * 1000, async (t) => {
+    overridePencilsDownTime(3);
+    const { id: objectId, self_uri: drsUri } = kidsFirstDrsResponse;
+    const drs = drsUrls(config.HOST_KIDS_FIRST_STAGING, objectId);
+    getJsonFromApiStub.withArgs(drs.objectsUrl, null).callsFake(async () => {
+        await delay(90 * 1000);
+        return 'Boom!';
+    });
+    const response = mockResponse();
+
+    await marthaV3(mockRequest({ body: { 'url': drsUri } }), response);
+
+    t.is(response.statusCode, 500);
+    t.deepEqual(
+        response.body,
+        {
+            response: {
+                status: 500,
+                text: 'Timed out resolving DRS URI. Could not fetch DRS metadata.',
+            },
+            status: 500,
+        },
+    );
+}));
+
+test.serial('martha_v3 succeeds if an error is encountered while fetching a signed URL', async (t) => {
+    const {
+        id: objectId, self_uri: drsUri,
+        access_methods: { 0: { access_id: accessId } }
+    } = kidsFirstDrsResponse;
+    const bond = bondUrls('kids-first');
+    const drs = drsUrls(config.HOST_KIDS_FIRST_STAGING, objectId, accessId);
+    getJsonFromApiStub.withArgs(drs.objectsUrl, null).resolves(kidsFirstDrsResponse);
+    getJsonFromApiStub.withArgs(bond.accessTokenUrl, terraAuth).resolves(bondAccessTokenResponse);
+    getJsonFromApiStub.withArgs(drs.accessUrl, `Bearer ${bondAccessTokenResponse.token}`)
+        .throws(new Error('Test exception from DRS provider'));
+
+    const response = mockResponse();
+
+    await marthaV3(mockRequest({ body: { 'url': drsUri } }), response);
+
+    t.is(response.statusCode, 200);
+    t.deepEqual(response.body, kidsFirstDrsMarthaResult(null));
+    sinon.assert.callCount(getJsonFromApiStub, 3);
 });
 
 test.serial('martha_v3 returns null for fields missing in drs and bond response', async (t) => {


### PR DESCRIPTION
After the previous test refactoring, this completes https://broadworkbench.atlassian.net/browse/BT-259.

This code is... kinda ugly. I don't really like it, but it'll get the job done. Eventually, errors fetching signed URLs will be fatal and most/all of the ugliness added in this PR will go away.