### PR TITLE
Fail when asked to resolve dataguids.org DRS URIs [BT-320]

### DIFF
--- a/martha/martha_v3.js
+++ b/martha/martha_v3.js
@@ -407,6 +407,11 @@ function determineDrsType(url) {
         );
     }
 
+    // RIP dataguids.org
+    if (host.endsWith('dataguids.org')) {
+        throw new BadRequestError('dataguids.org data has moved. See: https://support.terra.bio/hc/en-us/articles/360060681132');
+    }
+
     // If we don't recognize the server assume like martha_v2 that everyone else
     // speaks DOS, doesn't require auth, and uses dcf-fence.
     return new DrsType(

--- a/test/martha/_martha_v3_resources.js
+++ b/test/martha/_martha_v3_resources.js
@@ -98,60 +98,6 @@ const sampleDosMarthaResult = (expectedGoogleServiceAccount) => {
     };
 };
 
-// dataguids.org
-// returned via `curl https://dataguids.org/ga4gh/dos/v1/dataobjects/a41b0c4f-ebfb-4277-a941-507340dea85d`
-const dataGuidsOrgResponse = {
-    data_object: {
-        checksums: [
-            {
-                checksum: '0d22c86537e22ad9e924c7c756b23131',
-                type: 'md5'
-            }
-        ],
-        created: '2018-06-26T18:53:21.416896',
-        description: '',
-        id: 'a41b0c4f-ebfb-4277-a941-507340dea85d',
-        mime_type: '',
-        name: null,
-        size: 39830,
-        updated: '2018-06-26T18:53:21.416908',
-        urls: [
-            {
-                'url':
-                    'gs://gdc-tcga-phs000178-open/a41b0c4f-ebfb-4277-a941-507340dea85d' +
-                    '/nationwidechildrens.org_clinical.TCGA-56-A4BY.xml'
-            },
-            {
-                'url':
-                    's3://tcga-2-open/a41b0c4f-ebfb-4277-a941-507340dea85d' +
-                    '/nationwidechildrens.org_clinical.TCGA-56-A4BY.xml'
-            }
-        ],
-        version: 'a095f638'
-    }
-};
-
-const dataGuidsOrgMarthaResult = (expectedGoogleServiceAccount) => {
-    return {
-        contentType: 'application/octet-stream',
-        size: 39830,
-        timeCreated: '2018-06-26T18:53:21.416Z',
-        timeUpdated: '2018-06-26T18:53:21.416Z',
-        bucket: 'gdc-tcga-phs000178-open',
-        name: 'a41b0c4f-ebfb-4277-a941-507340dea85d/nationwidechildrens.org_clinical.TCGA-56-A4BY.xml',
-        accessUrl: null,
-        gsUri:
-            'gs://gdc-tcga-phs000178-open/a41b0c4f-ebfb-4277-a941-507340dea85d' +
-            '/nationwidechildrens.org_clinical.TCGA-56-A4BY.xml',
-        googleServiceAccount: expectedGoogleServiceAccount,
-        bondProvider: 'dcf-fence',
-        fileName: 'nationwidechildrens.org_clinical.TCGA-56-A4BY.xml',
-        hashes: {
-            md5: '0d22c86537e22ad9e924c7c756b23131'
-        }
-    };
-};
-
 // Jade
 
 const jadeDrsResponse = {
@@ -561,8 +507,6 @@ module.exports = {
     drsObjectWithInvalidFields,
     sampleDosResponse,
     sampleDosMarthaResult,
-    dataGuidsOrgResponse,
-    dataGuidsOrgMarthaResult,
     jadeDrsResponse,
     jadeDrsMarthaResult,
     hcaDrsResponse,

--- a/test/martha/martha_v3.test.js
+++ b/test/martha/martha_v3.test.js
@@ -507,10 +507,6 @@ test.serial('martha_v3 calls bond Bond with the "fence" provider when the Data O
 });
 
 test.serial('martha_v3 does call Bond and return SA key when the host url is for dataguids.org', async (t) => {
-    const bond = bondUrls('dcf-fence');
-    const dos = dosUrls('dataguids.org', 'a41b0c4f-ebfb-4277-a941-507340dea85d');
-    getJsonFromApiStub.withArgs(bond.serviceAccountKeyUrl, terraAuth).resolves(googleSAKeyObject);
-    getJsonFromApiStub.withArgs(dos.dataobjectsUrl, null).resolves(dataGuidsOrgResponse);
     const response = mockResponse();
 
     await marthaV3(
@@ -518,10 +514,12 @@ test.serial('martha_v3 does call Bond and return SA key when the host url is for
         response
     );
 
-    t.is(response.statusCode, 200);
-    t.deepEqual(response.body, dataGuidsOrgMarthaResult(googleSAKeyObject));
+    t.is(response.statusCode, 400);
+    t.is(response.body.response.text,
+        'Request is invalid. dataguids.org data has moved. See: https://support.terra.bio/hc/en-us/articles/360060681132'
+    );
 
-    sinon.assert.callCount(getJsonFromApiStub, 2);
+    sinon.assert.callCount(getJsonFromApiStub, 0);
 });
 
 test.serial('martha_v3 does not call Bond or return SA key when the host url is for jade data repo', async (t) => {

--- a/test/martha/martha_v3.test.js
+++ b/test/martha/martha_v3.test.js
@@ -10,8 +10,6 @@
 const {
     sampleDosResponse,
     sampleDosMarthaResult,
-    dataGuidsOrgResponse,
-    dataGuidsOrgMarthaResult,
     jadeDrsResponse,
     jadeDrsMarthaResult,
     hcaDrsMarthaResult,


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/BT-320

Since this is an emergency fix, instead of removing the default case, I chose to specifically identify the dataguids.org case and return a (hopefully) helpful error.