### PR TITLE
Refactor to allow for getting signed URLs from TDR [BT-406]

### DIFF
--- a/martha/drs_providers.js
+++ b/martha/drs_providers.js
@@ -109,7 +109,7 @@ class DrsProvider {
             overlapFields(requestedFields, MARTHA_V3_BOND_SA_FIELDS);
     }
 
-    static shouldFailOnAccessUrlFail(accessMethod) {
+    shouldFailOnAccessUrlFail(accessMethod) {
         // Fail this request if Martha was unable to get an access/signed URL and the access method is truthy but its
         // type is not GCS. Martha clients currently can't deal with cloud paths other than GCS so there isn't a
         // fallback way of accessing the object.
@@ -119,11 +119,11 @@ class DrsProvider {
         // support headers, which at the time of this writing is not true at least for the Cromwell localizer using getm
         // 0.0.4. This also presumes that the Martha response would fall back to a different access method than the
         // GCS/Azure one for which Martha tried and failed to get a signed URL. The current code does not support this.
-        return accessMethod && accessMethod.type !== AccessMethodType.GCS;
+        return this && accessMethod && accessMethod.type !== AccessMethodType.GCS;
     }
 
-    static shouldRequestMetadata(requestedFields) {
-        return overlapFields(requestedFields, MARTHA_V3_METADATA_FIELDS);
+    shouldRequestMetadata(requestedFields) {
+        return this && overlapFields(requestedFields, MARTHA_V3_METADATA_FIELDS);
     }
 
     accessUrlAuth(accessMethod, accessToken, requestAuth) {

--- a/martha/drs_providers.js
+++ b/martha/drs_providers.js
@@ -16,14 +16,14 @@ const AccessMethodType = {
     S3: 's3'
 };
 
-const SignedUrlAuth = {
+const AccessAuth = {
     FENCE_TOKEN: "FENCE_TOKEN",
-    CURRENT_AUTH: "CURRENT_AUTH"
+    CURRENT_REQUEST: "CURRENT_REQUEST"
 };
 
-const SignedUrlEnabled = {
-    ON: "ON",
-    OFF: "OFF",
+const Enabled = {
+    TRUE: "TRUE",
+    FALSE: "FALSE",
 };
 
 const BondProvider = {
@@ -74,8 +74,8 @@ class DrsProvider {
             overlapFields(requestedFields, MARTHA_V3_ACCESS_ID_FIELDS) &&
             (forceSignedUrl || (accessMethod &&
                 this.accessMethods.find((m) => m.accessMethodType === accessMethod.type &&
-                    m.signedUrlAuth === SignedUrlAuth.FENCE_TOKEN &&
-                    m.signedUrlEnabled === SignedUrlEnabled.ON)));
+                    m.signedUrlAuth === AccessAuth.FENCE_TOKEN &&
+                    m.signedUrlEnabled === Enabled.TRUE)));
     }
 
     /**
@@ -89,7 +89,7 @@ class DrsProvider {
         return overlapFields(requestedFields, MARTHA_V3_ACCESS_ID_FIELDS) &&
             (forceSignedUrl || (accessMethod &&
                 this.accessMethods.find((m) => m.accessMethodType === accessMethod.type &&
-                    m.signedUrlEnabled === SignedUrlEnabled.ON)));
+                    m.signedUrlEnabled === Enabled.TRUE)));
     }
 
     /**
@@ -118,9 +118,9 @@ class DrsProvider {
     accessUrlAuth(accessMethod, accessToken, requestAuth) {
         const providerAccessMethod = this.accessMethodHavingSameTypeAs(accessMethod);
         switch (providerAccessMethod.signedUrlAuth) {
-            case SignedUrlAuth.FENCE_TOKEN:
+            case AccessAuth.FENCE_TOKEN:
                 return `Bearer ${accessToken}`;
-            case SignedUrlAuth.CURRENT_AUTH:
+            case AccessAuth.CURRENT_REQUEST:
                 return requestAuth;
             default:
                 throw new BadRequestError(
@@ -137,7 +137,7 @@ const BioDataCatalystDrsProvider = new DrsProvider(
     BondProvider.FENCE,
     [
         //  BT-236 BDC signed URLs temporarily turned off
-        new AccessMethod(AccessMethodType.GCS, SignedUrlAuth.FENCE_TOKEN, SignedUrlEnabled.OFF)
+        new AccessMethod(AccessMethodType.GCS, AccessAuth.FENCE_TOKEN, Enabled.FALSE)
     ]
 );
 
@@ -146,7 +146,7 @@ const TerraDataRepoDrsProvider = new DrsProvider(
     MetadataAuth.YES,
     BondProvider.NONE,
     [
-        new AccessMethod(AccessMethodType.GCS, SignedUrlAuth.CURRENT_AUTH, SignedUrlEnabled.OFF)
+        new AccessMethod(AccessMethodType.GCS, AccessAuth.CURRENT_REQUEST, Enabled.FALSE)
     ]
 );
 
@@ -155,7 +155,7 @@ const KidsFirstDrsProvider = new DrsProvider(
     MetadataAuth.NO,
     BondProvider.KIDS_FIRST,
     [
-        new AccessMethod(AccessMethodType.S3, SignedUrlAuth.FENCE_TOKEN, SignedUrlEnabled.ON)
+        new AccessMethod(AccessMethodType.S3, AccessAuth.FENCE_TOKEN, Enabled.TRUE)
     ]
 );
 
@@ -164,7 +164,7 @@ const AnvilDrsProvider = new DrsProvider(
     MetadataAuth.NO,
     BondProvider.ANVIL,
     [
-        new AccessMethod(AccessMethodType.GCS, SignedUrlAuth.FENCE_TOKEN, SignedUrlEnabled.OFF)
+        new AccessMethod(AccessMethodType.GCS, AccessAuth.FENCE_TOKEN, Enabled.FALSE)
     ]
 );
 
@@ -173,8 +173,8 @@ const CrdcProvider = new DrsProvider(
     MetadataAuth.NO,
     BondProvider.DCF_FENCE,
     [
-        new AccessMethod(AccessMethodType.GCS, SignedUrlAuth.FENCE_TOKEN, SignedUrlEnabled.OFF),
-        new AccessMethod(AccessMethodType.S3, SignedUrlAuth.FENCE_TOKEN, SignedUrlEnabled.ON)
+        new AccessMethod(AccessMethodType.GCS, AccessAuth.FENCE_TOKEN, Enabled.FALSE),
+        new AccessMethod(AccessMethodType.S3, AccessAuth.FENCE_TOKEN, Enabled.TRUE)
     ]
 );
 

--- a/martha/drs_providers.js
+++ b/martha/drs_providers.js
@@ -48,12 +48,13 @@ class AccessMethod {
 }
 
 class DrsProvider {
-    constructor(providerName, sendMetadataAuth, bondProvider, accessMethods) {
+    constructor(providerName, sendMetadataAuth, bondProvider, accessMethods, forceSignedUrl = false) {
         this.providerName = providerName;
         this.sendMetadataAuth = sendMetadataAuth;
         this.bondProvider = bondProvider;
         this.accessMethods = accessMethods;
         this.accessMethodTypes = accessMethods && accessMethods.map((m) => m.accessMethodType);
+        this.forceSignedUrl = forceSignedUrl;
     }
 
     accessMethodHavingSameTypeAs(accessMethod) {
@@ -66,13 +67,12 @@ class DrsProvider {
      * URL flows (TDR uses the same auth supplied to the current Martha request for calling `access`).
      * @param accessMethod
      * @param requestedFields
-     * @param forceSignedUrl
      * @return {boolean}
      */
-    shouldFetchFenceToken(accessMethod, requestedFields, forceSignedUrl) {
+    shouldFetchFenceToken(accessMethod, requestedFields) {
         return this.bondProvider &&
             overlapFields(requestedFields, MARTHA_V3_ACCESS_ID_FIELDS) &&
-            (forceSignedUrl || (accessMethod &&
+            (this.forceSignedUrl || (accessMethod &&
                 this.accessMethods.find((m) => m.accessMethodType === accessMethod.type &&
                     m.signedUrlAuth === AccessAuth.FENCE_TOKEN &&
                     m.signedUrlEnabled === Enabled.TRUE)));
@@ -82,12 +82,11 @@ class DrsProvider {
      * Should Martha call the DRS provider's `access` endpoint to get a signed URL.
      * @param accessMethod
      * @param requestedFields
-     * @param forceSignedUrl
      * @return {boolean}
      */
-    shouldFetchAccessUrl(accessMethod, requestedFields, forceSignedUrl) {
+    shouldFetchAccessUrl(accessMethod, requestedFields) {
         return overlapFields(requestedFields, MARTHA_V3_ACCESS_ID_FIELDS) &&
-            (forceSignedUrl || (accessMethod &&
+            (this.forceSignedUrl || (accessMethod &&
                 this.accessMethods.find((m) => m.accessMethodType === accessMethod.type &&
                     m.signedUrlEnabled === Enabled.TRUE)));
     }

--- a/martha/drs_providers.js
+++ b/martha/drs_providers.js
@@ -185,7 +185,7 @@ const DrsProviderInstances = {
  * @param drsProviderInstances {Object} Mapping of DRS provider keys to implementations, useful for testing.
  * @return {DrsProvider}
  */
-function determineDrsProvider(url, urlParts, drsProviderInstances = DrsProviderInstances) {
+function determineDrsProvider(url, urlParts, drsProviderInstances) {
     const host = urlParts.httpsUrlHost;
 
     // BDC, but skip DOS/DRS URIs that might be a fake `martha_v2`-compatible BDC
@@ -225,3 +225,4 @@ function determineDrsProvider(url, urlParts, drsProviderInstances = DrsProviderI
 
 exports.DrsProvider = DrsProvider;
 exports.determineDrsProvider = determineDrsProvider;
+exports.DrsProviderInstances = DrsProviderInstances;

--- a/martha/drs_providers.js
+++ b/martha/drs_providers.js
@@ -9,7 +9,7 @@ const {
     MARTHA_V3_ACCESS_ID_FIELDS,
     MARTHA_V3_BOND_SA_FIELDS,
     overlapFields
-} = require("martha_fields");
+} = require("./martha_fields");
 
 const AccessMethodType = {
     GCS: 'gs',
@@ -224,4 +224,5 @@ function determineDrsProvider(url, urlParts, drsProviderInstances = DrsProviderI
     throw new BadRequestError(`Could not determine DRS provider for id '${url}'`);
 }
 
+exports.DrsProvider = DrsProvider;
 exports.determineDrsProvider = determineDrsProvider;

--- a/martha/drs_providers.js
+++ b/martha/drs_providers.js
@@ -53,13 +53,16 @@ class DrsProvider {
         this.sendMetadataAuth = sendMetadataAuth;
         this.bondProvider = bondProvider;
         this.accessMethods = accessMethods;
-        this.accessMethodTypes = accessMethods && accessMethods.map((m) => m.accessMethodType);
         // may be overridden in request headers or tests, set it explicitly here to placate eslint.
         this.forceAccessUrl = false;
     }
 
     accessMethodHavingSameTypeAs(accessMethod) {
         return this.accessMethods.find((o) => o.accessMethodType === accessMethod.type);
+    }
+
+    accessMethodTypes() {
+        return this && this.accessMethods && this.accessMethods.map((m) => m.accessMethodType);
     }
 
     /**
@@ -105,7 +108,7 @@ class DrsProvider {
             // "Not definitely not GCS". A falsy accessMethod is okay because there may not have been a preceding
             // metadata request to determine the accessMethod.
             (!accessMethod || accessMethod.type === AccessMethodType.GCS) &&
-            this.accessMethodTypes.includes(AccessMethodType.GCS) &&
+            this.accessMethodTypes().includes(AccessMethodType.GCS) &&
             overlapFields(requestedFields, MARTHA_V3_BOND_SA_FIELDS);
     }
 

--- a/martha/drs_providers.js
+++ b/martha/drs_providers.js
@@ -50,7 +50,7 @@ class DrsProvider {
         this.accessMethods = accessMethods;
     }
 
-    accessMethodMatchingType(accessMethod) {
+    accessMethodHavingSameTypeAs(accessMethod) {
         return this.accessMethods.find((o) => o.accessMethodType === accessMethod.type);
     }
 
@@ -65,9 +65,8 @@ class DrsProvider {
     shouldFetchFenceToken(accessMethod, requestedFields) {
         return this.bondProvider &&
             accessMethod &&
-            accessMethod.type === AccessMethodType.S3 &&
             overlapFields(requestedFields, MARTHA_V3_ACCESS_ID_FIELDS) &&
-            this.accessMethodMatchingType(accessMethod).signedUrlDisposition === SignedUrls.YES_USING_FENCE_TOKEN;
+            this.accessMethodHavingSameTypeAs(accessMethod).signedUrlDisposition === SignedUrls.YES_USING_FENCE_TOKEN;
     }
 
     /**
@@ -78,7 +77,7 @@ class DrsProvider {
      */
     shouldFetchAccessUrl(accessMethod, requestedFields) {
         return overlapFields(requestedFields, MARTHA_V3_ACCESS_ID_FIELDS) &&
-            this.accessMethodMatchingType(accessMethod).signedUrlDisposition !== SignedUrls.NO;
+            this.accessMethodHavingSameTypeAs(accessMethod).signedUrlDisposition !== SignedUrls.NO;
     }
 
     /**
@@ -109,7 +108,7 @@ class DrsProvider {
     }
 
     accessUrlAuth(accessMethod, accessToken, requestAuth) {
-        const providerAccessMethod = this.accessMethodMatchingType(accessMethod);
+        const providerAccessMethod = this.accessMethodHavingSameTypeAs(accessMethod);
         switch (providerAccessMethod.signedUrlDisposition) {
             case SignedUrls.YES_USING_FENCE_TOKEN:
                 return `Bearer ${accessToken}`;

--- a/martha/drs_providers.js
+++ b/martha/drs_providers.js
@@ -48,6 +48,7 @@ class DrsProvider {
         this.sendMetadataAuth = sendMetadataAuth;
         this.bondProvider = bondProvider;
         this.accessMethods = accessMethods;
+        this.accessMethodTypes = accessMethods && accessMethods.map((m) => m.accessMethodType);
     }
 
     accessMethodHavingSameTypeAs(accessMethod) {
@@ -93,12 +94,8 @@ class DrsProvider {
             // "Not definitely not GCS". A falsy accessMethod is okay because there may not have been a preceding
             // metadata request to determine the accessMethod.
             (!accessMethod || accessMethod.type === AccessMethodType.GCS) &&
-            this.accessMethodTypes().includes(AccessMethodType.GCS) &&
+            this.accessMethodTypes.includes(AccessMethodType.GCS) &&
             overlapFields(requestedFields, MARTHA_V3_BOND_SA_FIELDS);
-    }
-
-    accessMethodTypes() {
-        return this.accessMethods.map((m) => m.accessMethodType);
     }
 
     shouldFailOnAccessUrlFail(accessMethod) {

--- a/martha/drs_providers.js
+++ b/martha/drs_providers.js
@@ -213,6 +213,7 @@ class CrdcProvider extends DrsProvider {
  *
  * @param url {String} The full URL to be tested
  * @param urlParts {Object} The URL parts to be tested
+ * @param forceAccessUrl {Boolean} Whether to force Martha to call `access` for a (signed) access URL.
  * @return {DrsProvider}
  */
 function determineDrsProvider(url, urlParts, forceAccessUrl) {

--- a/martha/drs_providers.js
+++ b/martha/drs_providers.js
@@ -129,7 +129,7 @@ class DrsProvider {
         return this && overlapFields(requestedFields, MARTHA_V3_METADATA_FIELDS);
     }
 
-    accessUrlAuth(accessMethod, accessToken, requestAuth) {
+    determineAccessUrlAuth(accessMethod, accessToken, requestAuth) {
         const providerAccessMethod = this.accessMethodHavingSameTypeAs(accessMethod);
         switch (providerAccessMethod.accessUrlAuth) {
             case AccessUrlAuth.FENCE_TOKEN:
@@ -138,7 +138,7 @@ class DrsProvider {
                 return requestAuth;
             default:
                 throw new BadRequestError(
-                    `Programmer error: 'accessUrlAuth' called with signed URL disposition ${providerAccessMethod.SignedUrlEnabled} for provider ${this.providerName}`);
+                    `Programmer error: 'determineAccessUrlAuth' called with AccessUrlAuth.${providerAccessMethod.accessUrlAuth} for provider ${this.providerName}`);
         }
     }
 }

--- a/martha/drs_providers.js
+++ b/martha/drs_providers.js
@@ -208,7 +208,7 @@ const DrsProviderInstances = {
  * @param drsProviderInstances {Object} Mapping of DRS provider keys to implementations, useful for testing.
  * @return {DrsProvider}
  */
-function determineDrsProvider(url, urlParts, drsProviderInstances) {
+function determineDrsProvider(url, urlParts, drsProviderInstances = DrsProviderInstances) {
     const host = urlParts.httpsUrlHost;
 
     // BDC, but skip DOS/DRS URIs that might be a fake `martha_v2`-compatible BDC

--- a/martha/drs_providers.js
+++ b/martha/drs_providers.js
@@ -1,0 +1,227 @@
+const {
+    BadRequestError,
+    jadeDataRepoHostRegex
+} = require("../common/helpers");
+
+const config = require("../common/config");
+
+const {
+    MARTHA_V3_ACCESS_ID_FIELDS,
+    MARTHA_V3_BOND_SA_FIELDS,
+    overlapFields
+} = require("martha_fields");
+
+const AccessMethodType = {
+    GCS: 'gs',
+    S3: 's3'
+};
+
+const SignedUrls = {
+    NO: 'NO',
+    YES_USING_FENCE_TOKEN: 'YES_USING_FENCE_TOKEN',
+    YES_USING_CURRENT_AUTH: 'YES_USING_CURRENT_AUTH'
+};
+
+const BondProvider = {
+    DCF_FENCE: 'dcf-fence',
+    FENCE: 'fence',
+    ANVIL: 'anvil',
+    KIDS_FIRST: 'kids-first',
+    NONE: null
+};
+
+const MetadataAuth = {
+    YES: true,
+    NO: false
+};
+
+class AccessMethod {
+    constructor(accessMethodType, signedUrlDisposition) {
+        this.accessMethodType = accessMethodType;
+        this.signedUrlDisposition = signedUrlDisposition;
+    }
+}
+
+class DrsProvider {
+    constructor(providerName, sendMetadataAuth, bondProvider, accessMethods) {
+        this.providerName = providerName;
+        this.sendMetadataAuth = sendMetadataAuth;
+        this.bondProvider = bondProvider;
+        this.accessMethods = accessMethods;
+    }
+
+    accessMethodMatchingType(accessMethod) {
+        return this.accessMethods.find((o) => o.accessMethodType === accessMethod.type);
+    }
+
+    /**
+     * Should Martha call Bond to retrieve a Fence access token to use when later calling the `access` endpoint to
+     * retrieve a signed URL. Should return `true` for Gen3 signed URL flows and `false` otherwise, including TDR signed
+     * URL flows (TDR uses the same auth supplied to the current Martha request as the auth for calling `access`).
+     * @param accessMethod
+     * @param requestedFields
+     * @return {boolean}
+     */
+    shouldFetchFenceToken(accessMethod, requestedFields) {
+        return this.bondProvider &&
+            accessMethod &&
+            accessMethod.type === AccessMethodType.S3 &&
+            overlapFields(requestedFields, MARTHA_V3_ACCESS_ID_FIELDS) &&
+            this.accessMethodMatchingType(accessMethod).signedUrlDisposition === SignedUrls.YES_USING_FENCE_TOKEN;
+    }
+
+    /**
+     * Should Martha call the DRS provider's `access` endpoint to get a signed URL.
+     * @param accessMethod
+     * @param requestedFields
+     * @return {boolean}
+     */
+    shouldFetchAccessUrl(accessMethod, requestedFields) {
+        return overlapFields(requestedFields, MARTHA_V3_ACCESS_ID_FIELDS) &&
+            this.accessMethodMatchingType(accessMethod).signedUrlDisposition !== SignedUrls.NO;
+    }
+
+    /**
+     * Should Martha fetch the Google user service account from Bond. Because this account is Google-specific it should
+     * not be fetched if we know the underlying data is not GCS-based.
+     * @param accessMethod
+     * @param requestedFields
+     * @return {boolean}
+     */
+    shouldFetchUserServiceAccount(accessMethod, requestedFields) {
+        // This account would be stored in Bond so no Bond means no account.
+        return this.bondProvider !== BondProvider.NONE &&
+            // "Not definitely not GCS". A falsy accessMethod is okay because there may not have been a preceding
+            // metadata request to determine the accessMethod.
+            (!accessMethod || accessMethod.type === AccessMethodType.GCS) &&
+            this.accessMethodTypes().includes(AccessMethodType.GCS) &&
+            overlapFields(requestedFields, MARTHA_V3_BOND_SA_FIELDS);
+    }
+
+    accessMethodTypes() {
+        return this.accessMethods.map((m) => m.accessMethodType);
+    }
+
+    shouldFailOnAccessUrlFail(accessMethod) {
+        // Fail if we failed to get a signed URL and the access method is truthy but its type is not GCS. Martha clients
+        // currently can't deal with cloud paths other than GCS so there isn't a fallback way of accessing the object.
+        return this && accessMethod && accessMethod.type !== AccessMethodType.GCS;
+    }
+
+    accessUrlAuth(accessMethod, accessToken, requestAuth) {
+        const providerAccessMethod = this.accessMethodMatchingType(accessMethod);
+        switch (providerAccessMethod.signedUrlDisposition) {
+            case SignedUrls.YES_USING_FENCE_TOKEN:
+                return `Bearer ${accessToken}`;
+            case SignedUrls.YES_USING_CURRENT_AUTH:
+                return requestAuth;
+            default:
+                throw new BadRequestError(
+                    `Programmer error: 'accessUrlAuth' called with signed URL disposition ${providerAccessMethod.signedUrlDisposition} for provider ${this.providerName}`);
+        }
+    }
+}
+
+// Define the default provider implementations here and insert them as the values in the `DrsProviderInstances` object
+// below. Test should override the map values to ensure providers work as expected with signed URLs turned on or off.
+const BioDataCatalystDrsProvider = new DrsProvider(
+    'BioData Catalyst (BDC)',
+    MetadataAuth.NO,
+    BondProvider.FENCE,
+    [
+        new AccessMethod(AccessMethodType.GCS, SignedUrls.NO) //  BT-236 BDC signed URLs temporarily turned off
+    ]
+);
+
+const TerraDataRepoDrsProvider = new DrsProvider(
+    'Terra Data Repo (TDR)',
+    MetadataAuth.YES,
+    BondProvider.NONE,
+    [
+        new AccessMethod(AccessMethodType.GCS, SignedUrls.NO)
+    ]
+);
+
+const KidsFirstDrsProvider = new DrsProvider(
+    'Gabriella Miller Kids First DRC',
+    MetadataAuth.NO,
+    BondProvider.KIDS_FIRST,
+    [
+        new AccessMethod(AccessMethodType.S3, SignedUrls.YES_USING_FENCE_TOKEN)
+    ]
+);
+
+const AnvilDrsProvider = new DrsProvider(
+    'NHGRI Analysis Visualization and Informatics Lab-space (The AnVIL)',
+    MetadataAuth.NO,
+    BondProvider.ANVIL,
+    [
+        new AccessMethod(AccessMethodType.GCS, SignedUrls.NO)
+    ]
+);
+
+const CrdcProvider = new DrsProvider(
+    'NCI Cancer Research / Proteomics Data Commons (CRDC / PDC)',
+    MetadataAuth.NO,
+    BondProvider.DCF_FENCE,
+    [
+        new AccessMethod(AccessMethodType.GCS, SignedUrls.NO),
+        new AccessMethod(AccessMethodType.S3, SignedUrls.YES_USING_FENCE_TOKEN)
+    ]
+);
+
+const DrsProviderInstances = {
+    BIO_DATA_CATALYST: BioDataCatalystDrsProvider,
+    CRDC_PDC: CrdcProvider,
+    TERRA_DATA_REPO: TerraDataRepoDrsProvider,
+    KIDS_FIRST: KidsFirstDrsProvider,
+    ANVIL: AnvilDrsProvider
+};
+
+/** *************************************************************************************************
+ * Here is where all the logic lives that pairs a particular kind of URI with its DRS Provider.
+ *
+ * @param url {String} The full URL to be tested
+ * @param urlParts {Object} The URL parts to be tested
+ * @param drsProviderInstances {Object} Mapping of DRS provider keys to implementations, useful for testing.
+ * @return {DrsProvider}
+ */
+function determineDrsProvider(url, urlParts, drsProviderInstances = DrsProviderInstances) {
+    const host = urlParts.httpsUrlHost;
+
+    // BDC, but skip DOS/DRS URIs that might be a fake `martha_v2`-compatible BDC
+    if ((host.endsWith('.biodatacatalyst.nhlbi.nih.gov') || (host === config.HOST_MOCK_DRS))
+        && !urlParts.httpsUrlMaybeNotBdc) {
+        return drsProviderInstances.BIO_DATA_CATALYST;
+    }
+
+    // The AnVIL
+    if (host.endsWith('.theanvil.io')) {
+        return drsProviderInstances.ANVIL;
+    }
+
+    // Jade Data Repo
+    if (jadeDataRepoHostRegex.test(host)) {
+        return drsProviderInstances.TERRA_DATA_REPO;
+    }
+
+    // CRDC / PDC
+    if (host.endsWith('.datacommons.io')) {
+        return drsProviderInstances.CRDC_PDC;
+    }
+
+    // Kids First
+    if (host.endsWith('.kidsfirstdrc.org')) {
+        return drsProviderInstances.KIDS_FIRST;
+    }
+
+    // RIP dataguids.org
+    if (host.endsWith('dataguids.org')) {
+        throw new BadRequestError('dataguids.org data has moved. See: https://support.terra.bio/hc/en-us/articles/360060681132');
+    }
+
+    // Fail explicitly for DRS ids for which Martha can not determine a provider.
+    throw new BadRequestError(`Could not determine DRS provider for id '${url}'`);
+}
+
+exports.determineDrsProvider = determineDrsProvider;

--- a/martha/martha_fields.js
+++ b/martha/martha_fields.js
@@ -1,0 +1,59 @@
+const MARTHA_V3_CORE_FIELDS = [
+    'gsUri',
+    'bucket',
+    'name',
+    'fileName',
+    'contentType',
+    'size',
+    'hashes',
+    'timeCreated',
+    'timeUpdated',
+];
+
+// All fields that can be returned in the martha_v3 response.
+const MARTHA_V3_ALL_FIELDS = [
+    ...MARTHA_V3_CORE_FIELDS,
+    'googleServiceAccount',
+    'bondProvider',
+    'accessUrl',
+];
+
+const MARTHA_V3_DEFAULT_FIELDS = [
+    ...MARTHA_V3_CORE_FIELDS,
+    'googleServiceAccount',
+];
+
+// Response fields dependent on the DOS or DRS servers
+const MARTHA_V3_METADATA_FIELDS = [
+    ...MARTHA_V3_CORE_FIELDS,
+    'accessUrl',
+];
+
+// Response fields dependent on the Bond service account
+const MARTHA_V3_BOND_SA_FIELDS = [
+    'googleServiceAccount',
+];
+
+// Response fields dependent on the the access_id
+const MARTHA_V3_ACCESS_ID_FIELDS = [
+    'accessUrl',
+];
+
+/**
+ * Used to check if any of the requested fields overlap with fields dependent on an underlying service.
+ *
+ * @param {string[]} requestedFields
+ * @param {string[]} serviceFields
+ * @returns {boolean} true if the requested fields overlap
+ */
+function overlapFields(requestedFields, serviceFields) {
+    // via https://medium.com/@alvaro.saburido/set-theory-for-arrays-in-es6-eb2f20a61848
+    return requestedFields.filter((field) => serviceFields.includes(field)).length !== 0;
+}
+
+exports.MARTHA_V3_ALL_FIELDS = MARTHA_V3_ALL_FIELDS;
+exports.MARTHA_V3_DEFAULT_FIELDS = MARTHA_V3_DEFAULT_FIELDS;
+exports.MARTHA_V3_ACCESS_ID_FIELDS = MARTHA_V3_ACCESS_ID_FIELDS;
+exports.MARTHA_V3_METADATA_FIELDS = MARTHA_V3_METADATA_FIELDS;
+exports.MARTHA_V3_BOND_SA_FIELDS = MARTHA_V3_BOND_SA_FIELDS;
+exports.overlapFields = overlapFields;

--- a/martha/martha_v3.js
+++ b/martha/martha_v3.js
@@ -8,10 +8,8 @@ const {
 } = require('../common/helpers');
 
 const {
-    MARTHA_V3_METADATA_FIELDS,
     MARTHA_V3_DEFAULT_FIELDS,
     MARTHA_V3_ALL_FIELDS,
-    overlapFields,
 } = require("./martha_fields");
 
 const {
@@ -42,10 +40,6 @@ let pencilsDownSeconds = 58;
 const overridePencilsDownSeconds = (seconds) => {
     pencilsDownSeconds = seconds;
 };
-
-function shouldRequestMetadata(requestedFields) {
-    return overlapFields(requestedFields, MARTHA_V3_METADATA_FIELDS);
-}
 
 /**
  * Returns the first access method in `drsProvider.accessMethodTypes` with a type that matches the type of an access
@@ -354,7 +348,7 @@ async function retrieveFromServers(params) {
 
     const fetch = async () => {
         let response;
-        if (shouldRequestMetadata(requestedFields)) {
+        if (drsProvider.shouldRequestMetadata(requestedFields)) {
             try {
                 hypotheticalErrorMessage = 'Could not fetch DRS metadata.';
                 const httpsMetadataUrl = generateMetadataUrl(drsProvider, urlParts);
@@ -405,7 +399,7 @@ async function retrieveFromServers(params) {
 
         try {
             let accessToken;
-            if (drsProvider.shouldFetchFenceToken(accessMethod, requestedFields)) {
+            if (drsProvider.shouldFetchFenceAccessToken(accessMethod, requestedFields)) {
                 try {
                     const bondAccessTokenUrl = `${config.bondBaseUrl}/api/link/v1/${bondProvider}/accesstoken`;
                     console.log(`Requesting Bond access token for '${url}' from '${bondAccessTokenUrl}'`);

--- a/martha/martha_v3.js
+++ b/martha/martha_v3.js
@@ -76,11 +76,6 @@ const SignedUrls = {
     YES_USING_CURRENT_AUTH: "YES_USING_CURRENT_AUTH"
 };
 
-const CouldHaveGoogleServiceAccount = {
-    NO: false,
-    YES: true
-};
-
 const BondProvider = {
     DCF_FENCE: 'dcf-fence',
     FENCE: 'fence',
@@ -481,8 +476,7 @@ function determineDrsProvider(url) {
             BondProvider.KIDS_FIRST,
             [
                 new AccessMethod(Type.S3, SignedUrls.YES_USING_ACCESS_TOKEN)
-            ],
-            CouldHaveGoogleServiceAccount.NO
+            ]
         );
     }
 

--- a/martha/martha_v3.js
+++ b/martha/martha_v3.js
@@ -14,7 +14,6 @@ const {
 
 const {
     determineDrsProvider,
-    DrsProviderInstances: DefaultDrsProviderInstances,
 } = require("./drs_providers");
 
 const config = require('../common/config');
@@ -295,13 +294,12 @@ function buildRequestInfo(params) {
         url,
         requestedFields,
         auth,
-        drsProviderInstances,
         forceAccessUrl,
     } = params;
 
     validateRequest(url, auth, requestedFields);
     const urlParts = getHttpsUrlParts(url);
-    const drsProvider = determineDrsProvider(url, urlParts, drsProviderInstances);
+    const drsProvider = determineDrsProvider(url, urlParts);
     // Force the retrieval of a (signed) access URL for this request if the `martha-force-access-url` header is set.
     Object.assign(drsProvider, {forceAccessUrl: Boolean(forceAccessUrl)});
 
@@ -331,6 +329,7 @@ async function retrieveFromServers(params) {
     const {sendMetadataAuth, bondProvider} = drsProvider;
 
     // TODO: figure out JSON logging for Martha (and Bond), the multiline logging situation is a mess.
+    // e.g. any stack traces for Martha / Bond appear as one log entry per frame
     console.log(
         `DRS URI '${url}' will use DRS provider:\n${JSON.stringify(drsProvider, null, 2)}`
     );
@@ -497,7 +496,7 @@ function buildResponseInfo(params) {
  *   5. Fetches a signed URL from DRS server [+]
  * ([+] only for some data providers and some objects)
  */
-async function marthaV3Handler(req, res, drsProviderInstances = DefaultDrsProviderInstances) {
+async function marthaV3Handler(req, res) {
     try {
         // This function counts on the request posting data as "application/json" content-type.
         // See: https://cloud.google.com/functions/docs/writing/http#parsing_http_requests for more details
@@ -511,7 +510,6 @@ async function marthaV3Handler(req, res, drsProviderInstances = DefaultDrsProvid
             requestedFields,
             auth,
             forceAccessUrl,
-            drsProviderInstances
         };
 
         buildRequestInfo(params);

--- a/martha/martha_v3.js
+++ b/martha/martha_v3.js
@@ -302,11 +302,14 @@ function buildRequestInfo(params) {
         requestedFields,
         auth,
         drsProviderInstances,
+        forceSignedUrl,
     } = params;
 
     validateRequest(url, auth, requestedFields);
     const urlParts = getHttpsUrlParts(url);
     const drsProvider = determineDrsProvider(url, urlParts, drsProviderInstances);
+    // Force the retrieval of a signed URL for this request if the `martha-force-signed-url` header is set.
+    Object.assign(drsProvider, {forceSignedUrl});
 
     Object.assign(params, {
         drsProvider,
@@ -505,7 +508,7 @@ async function marthaV3Handler(req, res, drsProviderInstances = DefaultDrsProvid
         // This function counts on the request posting data as "application/json" content-type.
         // See: https://cloud.google.com/functions/docs/writing/http#parsing_http_requests for more details
         const {url, fields: requestedFields = MARTHA_V3_DEFAULT_FIELDS} = (req && req.body) || {};
-        const {authorization: auth, 'user-agent': userAgent} = req.headers;
+        const {authorization: auth, 'user-agent': userAgent, 'martha-force-signed-url': forceSignedUrl} = req.headers;
         const ip = req.ip;
         console.log(`Received URL '${url}' from agent '${userAgent}' on IP '${ip}'`);
 
@@ -513,6 +516,7 @@ async function marthaV3Handler(req, res, drsProviderInstances = DefaultDrsProvid
             url,
             requestedFields,
             auth,
+            forceSignedUrl,
             drsProviderInstances
         };
 

--- a/martha/martha_v3.js
+++ b/martha/martha_v3.js
@@ -121,7 +121,7 @@ class DrsType {
     }
 
     shouldFetchAccessTokenFor(accessMethodType) {
-        return this.accessMethodTypes[accessMethodType] === SignedUrlDisposition.YES_WITH_ACCESS_TOKEN;
+        return this.accessMethodTypes.find((o) => Object.keys(o)[0] === accessMethodType)[accessMethodType] === SignedUrlDisposition.YES_WITH_ACCESS_TOKEN;
     }
 
     accessMethodTypeKeys() {

--- a/martha/martha_v3.js
+++ b/martha/martha_v3.js
@@ -166,9 +166,9 @@ class DrsProvider {
     }
 
     shouldFailOnAccessUrlFail(accessMethod) {
-        // Throw if the access method was S3 and we failed to get a signed URL. Martha's clients can't currently deal
-        // with a native S3 path so the caller will not have a fallback means of accessing the object.
-        return this && accessMethod && accessMethod.type === Type.S3;
+        // Fail if we failed to get a signed URL and the access method is truthy but not GCS. Martha clients currently
+        // can't deal with cloud native paths other than GCS so there won't be a fallback way of accessing the object.
+        return this && accessMethod && accessMethod.type !== Type.GCS;
     }
 }
 

--- a/martha/martha_v3.js
+++ b/martha/martha_v3.js
@@ -309,7 +309,7 @@ function buildRequestInfo(params) {
     const urlParts = getHttpsUrlParts(url);
     const drsProvider = determineDrsProvider(url, urlParts, drsProviderInstances);
     // Force the retrieval of a signed URL for this request if the `martha-force-signed-url` header is set.
-    Object.assign(drsProvider, {forceSignedUrl});
+    Object.assign(drsProvider, {forceSignedUrl: Boolean(forceSignedUrl)});
 
     Object.assign(params, {
         drsProvider,

--- a/martha/martha_v3.js
+++ b/martha/martha_v3.js
@@ -48,7 +48,7 @@ function shouldRequestMetadata(requestedFields) {
 }
 
 /**
- * Returns the first access method in `drsProvider.accessMethodTypes()` with a type that matches the type of an access
+ * Returns the first access method in `drsProvider.accessMethodTypes` with a type that matches the type of an access
  * method in `drsResponse`, otherwise `undefined`.
  */
 function getAccessMethod(drsResponse, drsProvider) {
@@ -56,7 +56,7 @@ function getAccessMethod(drsResponse, drsProvider) {
         return;
     }
 
-    for (const accessMethodType of drsProvider.accessMethodTypes()) {
+    for (const accessMethodType of drsProvider.accessMethodTypes) {
         for (const accessMethod of drsResponse.access_methods) {
             if (accessMethod.type === accessMethodType) {
                 return accessMethod;
@@ -335,7 +335,7 @@ async function retrieveFromServers(params) {
 
     console.log(
         `DRS URI '${url}' will use metadata auth required '${sendMetadataAuth}', bond provider '${bondProvider}', ` +
-        `and access method types '${drsProvider.accessMethodTypes().join(", ")}'`
+        `and access method types '${drsProvider.accessMethodTypes.join(", ")}'`
     );
     console.log(`Requested martha_v3 fields: ${requestedFields.join(", ")}`);
 

--- a/martha/martha_v3.js
+++ b/martha/martha_v3.js
@@ -116,10 +116,9 @@ class AccessMethod {
     }
 }
 
-// noinspection JSUnusedGlobalSymbols
 class DrsProvider {
-    constructor(name, urlParts, protocolPrefix, sendAuth, bondProvider, accessMethods, couldHaveGoogleServiceAccount) {
-        this.name = name;
+    constructor(providerName, urlParts, protocolPrefix, sendAuth, bondProvider, accessMethods, couldHaveGoogleServiceAccount) {
+        this.providerName = providerName;
         this.urlParts = urlParts;
         this.protocolPrefix = protocolPrefix;
         this.sendAuth = sendAuth;
@@ -404,9 +403,7 @@ function determineDrsProvider(url) {
             PROTOCOL_PREFIX_DRS,
             AUTH_SKIPPED,
             BOND_PROVIDER_FENCE,
-            /*
-            BT-236 BDC signed URLs temporarily turned off
-            */
+            //  BT-236 BDC signed URLs temporarily turned off
             [
                 new AccessMethod(Type.GCS, SignedUrls.NO)
             ],
@@ -417,7 +414,7 @@ function determineDrsProvider(url) {
     // The AnVIL
     if (host.endsWith('.theanvil.io')) {
         return new DrsProvider(
-            "NHGRI Analysis Visualization and Informatics Lab-space (AnVIL)",
+            "NHGRI Analysis Visualization and Informatics Lab-space (The AnVIL)",
             urlParts,
             PROTOCOL_PREFIX_DRS,
             AUTH_SKIPPED,
@@ -445,7 +442,7 @@ function determineDrsProvider(url) {
         );
     }
 
-    // CRDC
+    // CRDC / PDC
     if (host.endsWith('.datacommons.io')) {
         return new DrsProvider(
             "NCI Cancer Research / Proteomics Data Commons (CRDC / PDC)",

--- a/martha/martha_v3.js
+++ b/martha/martha_v3.js
@@ -66,14 +66,14 @@ const MARTHA_V3_ACCESS_ID_FIELDS = [
 ];
 
 const Type = {
-    GCS: "gs",
-    S3: "s3"
+    GCS: 'gs',
+    S3: 's3'
 };
 
 const SignedUrls = {
-    NO: "NO",
-    YES_USING_ACCESS_TOKEN: "YES_USING_ACCESS_TOKEN",
-    YES_USING_CURRENT_AUTH: "YES_USING_CURRENT_AUTH"
+    NO: 'NO',
+    YES_USING_ACCESS_TOKEN: 'YES_USING_ACCESS_TOKEN',
+    YES_USING_CURRENT_AUTH: 'YES_USING_CURRENT_AUTH'
 };
 
 const BondProvider = {
@@ -418,10 +418,10 @@ function determineDrsProvider(url) {
     const host = urlParts.httpsUrlHost;
 
     // BDC, but skip DOS/DRS URIs that might be a fake `martha_v2`-compatible BDC
-    if ((host.endsWith(".biodatacatalyst.nhlbi.nih.gov") || (host === config.HOST_MOCK_DRS))
+    if ((host.endsWith('.biodatacatalyst.nhlbi.nih.gov') || (host === config.HOST_MOCK_DRS))
         && !urlParts.httpsUrlMaybeNotBdc) {
         return new DrsProvider(
-            "BioData Catalyst (BDC)",
+            'BioData Catalyst (BDC)',
             MetadataAuth.NO,
             BondProvider.FENCE,
             [
@@ -433,7 +433,7 @@ function determineDrsProvider(url) {
     // The AnVIL
     if (host.endsWith('.theanvil.io')) {
         return new DrsProvider(
-            "NHGRI Analysis Visualization and Informatics Lab-space (The AnVIL)",
+            'NHGRI Analysis Visualization and Informatics Lab-space (The AnVIL)',
             MetadataAuth.NO,
             BondProvider.ANVIL,
             // For more info see comment above for BDC's `accessMethodType`
@@ -446,7 +446,7 @@ function determineDrsProvider(url) {
     // Jade Data Repo
     if (jadeDataRepoHostRegex.test(host)) {
         return new DrsProvider(
-            "Terra Data Repo (TDR)",
+            'Terra Data Repo (TDR)',
             MetadataAuth.YES,
             BondProvider.NONE,
             [
@@ -458,7 +458,7 @@ function determineDrsProvider(url) {
     // CRDC / PDC
     if (host.endsWith('.datacommons.io')) {
         return new DrsProvider(
-            "NCI Cancer Research / Proteomics Data Commons (CRDC / PDC)",
+            'NCI Cancer Research / Proteomics Data Commons (CRDC / PDC)',
             MetadataAuth.NO,
             BondProvider.DCF_FENCE,
             [
@@ -471,7 +471,7 @@ function determineDrsProvider(url) {
     // Kids First
     if (host.endsWith('.kidsfirstdrc.org')) {
         return new DrsProvider(
-            "Gabriella Miller Kids First DRC",
+            'Gabriella Miller Kids First DRC',
             MetadataAuth.NO,
             BondProvider.KIDS_FIRST,
             [
@@ -545,7 +545,7 @@ async function retrieveFromServers(params) {
         urlParts
     } = params;
 
-    const {sendMetadataAuth: sendMetadataAuth, bondProvider} = drsProvider;
+    const {sendMetadataAuth, bondProvider} = drsProvider;
 
     console.log(
         `DRS URI '${url}' will use metadata auth required '${sendMetadataAuth}', bond provider '${bondProvider}', ` +

--- a/martha/martha_v3.js
+++ b/martha/martha_v3.js
@@ -348,7 +348,7 @@ async function retrieveFromServers(params) {
 
     const fetch = async () => {
         let response;
-        if (drsProvider.shouldRequestMetadata(requestedFields)) {
+        if (DrsProvider.shouldRequestMetadata(requestedFields)) {
             try {
                 hypotheticalErrorMessage = 'Could not fetch DRS metadata.';
                 const httpsMetadataUrl = generateMetadataUrl(drsProvider, urlParts);

--- a/martha/martha_v3.js
+++ b/martha/martha_v3.js
@@ -15,7 +15,8 @@ const {
 } = require("./martha_fields");
 
 const {
-    determineDrsProvider
+    determineDrsProvider,
+    DrsProviderInstances: DefaultDrsProviderInstances,
 } = require("./drs_providers");
 
 const config = require('../common/config');
@@ -300,11 +301,12 @@ function buildRequestInfo(params) {
         url,
         requestedFields,
         auth,
+        drsProviderInstances,
     } = params;
 
     validateRequest(url, auth, requestedFields);
     const urlParts = getHttpsUrlParts(url);
-    const drsProvider = determineDrsProvider(url, urlParts);
+    const drsProvider = determineDrsProvider(url, urlParts, drsProviderInstances);
 
     Object.assign(params, {
         drsProvider,
@@ -498,7 +500,7 @@ function buildResponseInfo(params) {
  *   5. Fetches a signed URL from DRS server [+]
  * ([+] only for some data providers and some objects)
  */
-async function marthaV3Handler(req, res) {
+async function marthaV3Handler(req, res, drsProviderInstances = DefaultDrsProviderInstances) {
     try {
         // This function counts on the request posting data as "application/json" content-type.
         // See: https://cloud.google.com/functions/docs/writing/http#parsing_http_requests for more details
@@ -511,6 +513,7 @@ async function marthaV3Handler(req, res) {
             url,
             requestedFields,
             auth,
+            drsProviderInstances
         };
 
         buildRequestInfo(params);

--- a/martha/martha_v3.js
+++ b/martha/martha_v3.js
@@ -138,7 +138,6 @@ class DrsProvider {
         this.sendAuth = sendAuth;
         this.bondProvider = bondProvider;
         this.accessMethods = accessMethods;
-        this.protocolPrefix = PROTOCOL_PREFIX_DRS;
     }
 
     accessMethodMatchingType(accessMethod) {
@@ -287,7 +286,7 @@ function expandCibSuffix(cibHost, cibSuffix, cibSeparator) {
 }
 
 /**
- * Returns the url parts of the DOS or DRS url, minus the protocol prefix as that is dependent on the host.
+ * Returns the url parts of the DOS or DRS url.
  */
 function getHttpsUrlParts(url) {
     /*
@@ -365,7 +364,7 @@ function generateMetadataUrl(drsProvider, urlParts) {
     // Construct a WHATWG URL by first only setting the protocol and the hostname: https://github.com/whatwg/url/issues/354
     const generatedUrl = new URL(`https://${urlParts.httpsUrlHost}`);
     generatedUrl.port = urlParts.httpsUrlPort;
-    generatedUrl.pathname = `${drsProvider.protocolPrefix}/${urlParts.protocolSuffix}`;
+    generatedUrl.pathname = `${PROTOCOL_PREFIX_DRS}/${urlParts.protocolSuffix}`;
     if (urlParts.httpsUrlSearch) {
         generatedUrl.search = urlParts.httpsUrlSearch;
     }
@@ -376,7 +375,7 @@ function generateAccessUrl(drsProvider, urlParts, accessId) {
     // Construct a WHATWG URL by first only setting the protocol and the hostname: https://github.com/whatwg/url/issues/354
     const generatedUrl = new URL(`https://${urlParts.httpsUrlHost}`);
     generatedUrl.port = urlParts.httpsUrlPort;
-    generatedUrl.pathname = `${drsProvider.protocolPrefix}/${urlParts.protocolSuffix}/access/${accessId}`;
+    generatedUrl.pathname = `${PROTOCOL_PREFIX_DRS}/${urlParts.protocolSuffix}/access/${accessId}`;
     if (urlParts.httpsUrlSearch) {
         generatedUrl.search = urlParts.httpsUrlSearch;
     }

--- a/martha/martha_v3.js
+++ b/martha/martha_v3.js
@@ -502,7 +502,8 @@ async function marthaV3Handler(req, res) {
         // This function counts on the request posting data as "application/json" content-type.
         // See: https://cloud.google.com/functions/docs/writing/http#parsing_http_requests for more details
         const {url, fields: requestedFields = MARTHA_V3_DEFAULT_FIELDS} = (req && req.body) || {};
-        let {authorization: auth, 'user-agent': userAgent, 'martha-force-access-url': forceAccessUrl} = req.headers;
+        const {authorization: auth, 'user-agent': userAgent} = req.headers;
+        let {'martha-force-access-url': forceAccessUrl} = req.headers;
         const ip = req.ip;
         console.log(`Received URL '${url}' from agent '${userAgent}' on IP '${ip}'`);
 

--- a/martha/martha_v3.js
+++ b/martha/martha_v3.js
@@ -148,10 +148,7 @@ class DrsProvider {
     }
 
     shouldFetchAccessUrl(accessMethod, requestedFields) {
-        return this.bondProvider &&
-            accessMethod &&
-            accessMethod.type === Type.S3 &&
-            overlapFields(requestedFields, MARTHA_V3_ACCESS_ID_FIELDS) &&
+        return overlapFields(requestedFields, MARTHA_V3_ACCESS_ID_FIELDS) &&
             this.accessMethodMatchingType(accessMethod).signedUrlDisposition !== SignedUrls.NO;
     }
 
@@ -177,11 +174,6 @@ class DrsProvider {
 
     accessUrlAuth(accessMethod, accessToken, requestAuth) {
         const providerAccessMethod = this.accessMethodMatchingType(accessMethod);
-        if (!providerAccessMethod) {
-            throw new BadRequestError(
-                `Programmer error: no access method of type '${accessMethod.type}' found in DRS Provider '${this.providerName}'`
-            );
-        }
         switch (providerAccessMethod.signedUrlDisposition) {
             case SignedUrls.YES_USING_ACCESS_TOKEN:
                 return `Bearer ${accessToken}`;
@@ -432,11 +424,11 @@ function responseParser (response) {
  *
  * If you update this function update the README too!
  *
- * @param url {string} The URL to be tested
+ * @param url {String} The full URL to be tested
+ * @param urlParts {Object} The URL parts to be tested
  * @return {DrsProvider}
  */
-function determineDrsProvider(url) {
-    const urlParts = getHttpsUrlParts(url);
+function determineDrsProvider(url, urlParts) {
     const host = urlParts.httpsUrlHost;
 
     // BDC, but skip DOS/DRS URIs that might be a fake `martha_v2`-compatible BDC
@@ -541,8 +533,8 @@ function buildRequestInfo(params) {
     } = params;
 
     validateRequest(url, auth, requestedFields);
-    const drsProvider = determineDrsProvider(url);
     const urlParts = getHttpsUrlParts(url);
+    const drsProvider = determineDrsProvider(url, urlParts);
 
     Object.assign(params, {
         drsProvider,

--- a/martha/martha_v3.js
+++ b/martha/martha_v3.js
@@ -42,7 +42,7 @@ const overridePencilsDownSeconds = (seconds) => {
 };
 
 /**
- * Returns the first access method in `drsProvider.accessMethodTypes` with a type that matches the type of an access
+ * Returns the first access method in `drsProvider.accessMethodTypes()` with a type that matches the type of an access
  * method in `drsResponse`, otherwise `undefined`.
  */
 function getAccessMethod(drsResponse, drsProvider) {
@@ -50,7 +50,7 @@ function getAccessMethod(drsResponse, drsProvider) {
         return;
     }
 
-    for (const accessMethodType of drsProvider.accessMethodTypes) {
+    for (const accessMethodType of drsProvider.accessMethodTypes()) {
         for (const accessMethod of drsResponse.access_methods) {
             if (accessMethod.type === accessMethodType) {
                 return accessMethod;
@@ -330,9 +330,9 @@ async function retrieveFromServers(params) {
 
     const {sendMetadataAuth, bondProvider} = drsProvider;
 
+    // TODO: figure out JSON logging for Martha (and Bond), the multiline logging situation is a mess.
     console.log(
-        `DRS URI '${url}' will use metadata auth required '${sendMetadataAuth}', bond provider '${bondProvider}', ` +
-        `and access method types '${drsProvider.accessMethodTypes.join(", ")}'`
+        `DRS URI '${url}' will use DRS provider:\n${JSON.stringify(drsProvider, null, 2)}`
     );
     console.log(`Requested martha_v3 fields: ${requestedFields.join(", ")}`);
 

--- a/martha/martha_v3.js
+++ b/martha/martha_v3.js
@@ -302,14 +302,14 @@ function buildRequestInfo(params) {
         requestedFields,
         auth,
         drsProviderInstances,
-        forceSignedUrl,
+        forceAccessUrl,
     } = params;
 
     validateRequest(url, auth, requestedFields);
     const urlParts = getHttpsUrlParts(url);
     const drsProvider = determineDrsProvider(url, urlParts, drsProviderInstances);
-    // Force the retrieval of a signed URL for this request if the `martha-force-signed-url` header is set.
-    Object.assign(drsProvider, {forceSignedUrl: Boolean(forceSignedUrl)});
+    // Force the retrieval of a (signed) access URL for this request if the `martha-force-access-url` header is set.
+    Object.assign(drsProvider, {forceAccessUrl: Boolean(forceAccessUrl)});
 
     Object.assign(params, {
         drsProvider,
@@ -508,7 +508,7 @@ async function marthaV3Handler(req, res, drsProviderInstances = DefaultDrsProvid
         // This function counts on the request posting data as "application/json" content-type.
         // See: https://cloud.google.com/functions/docs/writing/http#parsing_http_requests for more details
         const {url, fields: requestedFields = MARTHA_V3_DEFAULT_FIELDS} = (req && req.body) || {};
-        const {authorization: auth, 'user-agent': userAgent, 'martha-force-signed-url': forceSignedUrl} = req.headers;
+        const {authorization: auth, 'user-agent': userAgent, 'martha-force-access-url': forceAccessUrl} = req.headers;
         const ip = req.ip;
         console.log(`Received URL '${url}' from agent '${userAgent}' on IP '${ip}'`);
 
@@ -516,7 +516,7 @@ async function marthaV3Handler(req, res, drsProviderInstances = DefaultDrsProvid
             url,
             requestedFields,
             auth,
-            forceSignedUrl,
+            forceAccessUrl,
             drsProviderInstances
         };
 

--- a/martha/martha_v3.js
+++ b/martha/martha_v3.js
@@ -81,14 +81,18 @@ const CouldHaveGoogleServiceAccount = {
     YES: true
 };
 
-const BOND_PROVIDER_NONE = null; // Used for servers that should NOT contact bond
-const BOND_PROVIDER_DCF_FENCE = 'dcf-fence';
-const BOND_PROVIDER_FENCE = 'fence';
-const BOND_PROVIDER_ANVIL = 'anvil';
-const BOND_PROVIDER_KIDS_FIRST = 'kids-first';
+const BondProvider = {
+    DCF_FENCE: 'dcf-fence',
+    FENCE: 'fence',
+    ANVIL: 'anvil',
+    KIDS_FIRST: 'kids-first',
+    NONE: null
+};
 
-const AUTH_REQUIRED = true;
-const AUTH_SKIPPED = false;
+const MetadataAuth = {
+    YES: true,
+    NO: false
+};
 
 const PROTOCOL_PREFIX_DRS='/ga4gh/drs/v1/objects';
 
@@ -129,13 +133,13 @@ class AccessMethod {
 }
 
 class DrsProvider {
-    constructor(providerName, protocolPrefix, sendAuth, bondProvider, accessMethods, couldHaveGoogleServiceAccount) {
+    constructor(providerName, sendAuth, bondProvider, accessMethods, couldHaveGoogleServiceAccount) {
         this.providerName = providerName;
-        this.protocolPrefix = protocolPrefix;
         this.sendAuth = sendAuth;
         this.bondProvider = bondProvider;
         this.accessMethods = accessMethods;
         this.couldHaveGoogleServiceAccount = couldHaveGoogleServiceAccount;
+        this.protocolPrefix = PROTOCOL_PREFIX_DRS;
     }
 
     accessMethodMatchingType(accessMethod) {
@@ -424,9 +428,8 @@ function determineDrsProvider(url) {
         && !urlParts.httpsUrlMaybeNotBdc) {
         return new DrsProvider(
             "BioData Catalyst (BDC)",
-            PROTOCOL_PREFIX_DRS,
-            AUTH_SKIPPED,
-            BOND_PROVIDER_FENCE,
+            MetadataAuth.NO,
+            BondProvider.FENCE,
             //  BT-236 BDC signed URLs temporarily turned off
             [
                 new AccessMethod(Type.GCS, SignedUrls.NO)
@@ -439,9 +442,8 @@ function determineDrsProvider(url) {
     if (host.endsWith('.theanvil.io')) {
         return new DrsProvider(
             "NHGRI Analysis Visualization and Informatics Lab-space (The AnVIL)",
-            PROTOCOL_PREFIX_DRS,
-            AUTH_SKIPPED,
-            BOND_PROVIDER_ANVIL,
+            MetadataAuth.NO,
+            BondProvider.ANVIL,
             // For more info see comment above for BDC's `accessMethodType`
             [
                 new AccessMethod(Type.GCS, SignedUrls.NO)
@@ -454,9 +456,8 @@ function determineDrsProvider(url) {
     if (jadeDataRepoHostRegex.test(host)) {
         return new DrsProvider(
             "Terra Data Repo (TDR)",
-            PROTOCOL_PREFIX_DRS,
-            AUTH_REQUIRED,
-            BOND_PROVIDER_NONE,
+            MetadataAuth.YES,
+            BondProvider.NONE,
             [
                 new AccessMethod(Type.GCS, SignedUrls.YES_USING_CURRENT_AUTH)
             ],
@@ -468,9 +469,8 @@ function determineDrsProvider(url) {
     if (host.endsWith('.datacommons.io')) {
         return new DrsProvider(
             "NCI Cancer Research / Proteomics Data Commons (CRDC / PDC)",
-            PROTOCOL_PREFIX_DRS,
-            AUTH_SKIPPED,
-            BOND_PROVIDER_DCF_FENCE,
+            MetadataAuth.NO,
+            BondProvider.DCF_FENCE,
             [
                 new AccessMethod(Type.GCS, SignedUrls.NO),
                 new AccessMethod(Type.S3, SignedUrls.YES_USING_ACCESS_TOKEN)
@@ -483,9 +483,8 @@ function determineDrsProvider(url) {
     if (host.endsWith('.kidsfirstdrc.org')) {
         return new DrsProvider(
             "Gabriella Miller Kids First DRC",
-            PROTOCOL_PREFIX_DRS,
-            AUTH_SKIPPED,
-            BOND_PROVIDER_KIDS_FIRST,
+            MetadataAuth.NO,
+            BondProvider.KIDS_FIRST,
             [
                 new AccessMethod(Type.S3, SignedUrls.YES_USING_ACCESS_TOKEN)
             ],
@@ -766,3 +765,4 @@ exports.generateAccessUrl = generateAccessUrl;
 exports.getHttpsUrlParts = getHttpsUrlParts;
 exports.MARTHA_V3_ALL_FIELDS = MARTHA_V3_ALL_FIELDS;
 exports.overridePencilsDownSeconds = overridePencilsDownSeconds;
+exports.PROTOCOL_PREFIX_DRS = PROTOCOL_PREFIX_DRS;

--- a/martha/martha_v3.js
+++ b/martha/martha_v3.js
@@ -348,7 +348,7 @@ async function retrieveFromServers(params) {
 
     const fetch = async () => {
         let response;
-        if (DrsProvider.shouldRequestMetadata(requestedFields)) {
+        if (drsProvider.shouldRequestMetadata(requestedFields)) {
             try {
                 hypotheticalErrorMessage = 'Could not fetch DRS metadata.';
                 const httpsMetadataUrl = generateMetadataUrl(drsProvider, urlParts);

--- a/martha/martha_v3.js
+++ b/martha/martha_v3.js
@@ -133,12 +133,11 @@ class AccessMethod {
 }
 
 class DrsProvider {
-    constructor(providerName, sendAuth, bondProvider, accessMethods, couldHaveGoogleServiceAccount) {
+    constructor(providerName, sendAuth, bondProvider, accessMethods) {
         this.providerName = providerName;
         this.sendAuth = sendAuth;
         this.bondProvider = bondProvider;
         this.accessMethods = accessMethods;
-        this.couldHaveGoogleServiceAccount = couldHaveGoogleServiceAccount;
         this.protocolPrefix = PROTOCOL_PREFIX_DRS;
     }
 
@@ -164,10 +163,11 @@ class DrsProvider {
 
     // eslint-disable-next-line id-length
     shouldFetchGoogleServiceAccount(accessMethod, requestedFields) {
-        return this.couldHaveGoogleServiceAccount &&
+        return this.bondProvider !== BondProvider.NONE &&
             // "Not definitely not GCS". A falsy accessMethod is okay because there may not have been a preceding
             // metadata request.
             (!accessMethod || accessMethod.type === Type.GCS) &&
+            this.accessMethodTypes().includes(Type.GCS) &&
             overlapFields(requestedFields, MARTHA_V3_BOND_SA_FIELDS);
     }
 
@@ -430,11 +430,9 @@ function determineDrsProvider(url) {
             "BioData Catalyst (BDC)",
             MetadataAuth.NO,
             BondProvider.FENCE,
-            //  BT-236 BDC signed URLs temporarily turned off
             [
-                new AccessMethod(Type.GCS, SignedUrls.NO)
-            ],
-            CouldHaveGoogleServiceAccount.YES
+                new AccessMethod(Type.GCS, SignedUrls.NO) //  BT-236 BDC signed URLs temporarily turned off
+            ]
         );
     }
 
@@ -447,8 +445,7 @@ function determineDrsProvider(url) {
             // For more info see comment above for BDC's `accessMethodType`
             [
                 new AccessMethod(Type.GCS, SignedUrls.NO)
-            ],
-            CouldHaveGoogleServiceAccount.YES
+            ]
         );
     }
 
@@ -460,8 +457,7 @@ function determineDrsProvider(url) {
             BondProvider.NONE,
             [
                 new AccessMethod(Type.GCS, SignedUrls.YES_USING_CURRENT_AUTH)
-            ],
-            CouldHaveGoogleServiceAccount.NO
+            ]
         );
     }
 
@@ -474,8 +470,7 @@ function determineDrsProvider(url) {
             [
                 new AccessMethod(Type.GCS, SignedUrls.NO),
                 new AccessMethod(Type.S3, SignedUrls.YES_USING_ACCESS_TOKEN)
-            ],
-            CouldHaveGoogleServiceAccount.YES
+            ]
         );
     }
 

--- a/martha/martha_v3.js
+++ b/martha/martha_v3.js
@@ -415,7 +415,7 @@ async function retrieveFromServers(params) {
                     const httpsAccessUrl = generateAccessUrl(drsProvider, urlParts, accessMethod.access_id);
                     // Use the access token fetched in the call above or the auth submitted to Martha directly by the
                     // caller as appropriate.
-                    const accessUrlAuth = drsProvider.accessUrlAuth(accessMethod, accessToken, auth);
+                    const accessUrlAuth = drsProvider.determineAccessUrlAuth(accessMethod, accessToken, auth);
                     console.log(`Requesting DRS access URL for '${url}' from '${httpsAccessUrl}'`);
                     accessUrl = await apiAdapter.getJsonFrom(httpsAccessUrl, accessUrlAuth);
                 } catch (error) {

--- a/martha/martha_v3.js
+++ b/martha/martha_v3.js
@@ -12,11 +12,11 @@ const {
     MARTHA_V3_DEFAULT_FIELDS,
     MARTHA_V3_ALL_FIELDS,
     overlapFields,
-} = require("martha_fields");
+} = require("./martha_fields");
 
 const {
     determineDrsProvider
-} = require("drs_providers");
+} = require("./drs_providers");
 
 const config = require('../common/config');
 const apiAdapter = require('../common/api_adapter');

--- a/martha/martha_v3.js
+++ b/martha/martha_v3.js
@@ -14,6 +14,7 @@ const {
 
 const {
     determineDrsProvider,
+    DrsProvider,
 } = require("./drs_providers");
 
 const config = require('../common/config');
@@ -299,9 +300,13 @@ function buildRequestInfo(params) {
 
     validateRequest(url, auth, requestedFields);
     const urlParts = getHttpsUrlParts(url);
-    const drsProvider = determineDrsProvider(url, urlParts);
-    // Force the retrieval of a (signed) access URL for this request if the `martha-force-access-url` header is set.
-    Object.assign(drsProvider, {forceAccessUrl: Boolean(forceAccessUrl)});
+
+    // Force the retrieval of a (signed) access URL for this request if the `martha-force-access-url` header is set
+    // copying the original object with `forceAccessUrl` set appropriately.
+    // Shallow clone a JavaScript ES6 class instance
+    // https://stackoverflow.com/questions/41474986/how-to-clone-a-javascript-es6-class-instance
+    const drsProvider = { ...determineDrsProvider(url, urlParts), forceAccessUrl: Boolean(forceAccessUrl) };
+    Object.setPrototypeOf(drsProvider, DrsProvider.prototype);
 
     Object.assign(params, {
         drsProvider,

--- a/martha/martha_v3.js
+++ b/martha/martha_v3.js
@@ -155,8 +155,9 @@ class DrsProvider {
     // eslint-disable-next-line id-length
     shouldFetchGoogleServiceAccount(accessMethod, requestedFields) {
         return this.couldHaveGoogleServiceAccount &&
-            accessMethod &&
-            accessMethod.type === Type.GCS &&
+            // "Not definitely not GCS". A falsy accessMethod is okay because there may not have been a preceding
+            // metadata request.
+            (!accessMethod || accessMethod.type === Type.GCS) &&
             overlapFields(requestedFields, MARTHA_V3_BOND_SA_FIELDS);
     }
 

--- a/martha/martha_v3.js
+++ b/martha/martha_v3.js
@@ -430,8 +430,8 @@ async function retrieveFromServers(params) {
             if (drsProvider.shouldFailOnAccessUrlFail(accessMethod)) {
                 throw error;
             }
-            // For non-S3 just log the error for now. There is still a native GCS path available that the caller
-            // can use to access the object. Eventually, we'll want to remove this outer try.
+            // Just log the error for now, there should be a cloud native way for the user to access the object.
+            // Eventually once signed URLs are on by default for all providers we'll want to remove this outer try.
             console.warn('Ignoring error from fetching signed URL:', error);
         }
     };

--- a/martha/martha_v3.js
+++ b/martha/martha_v3.js
@@ -302,10 +302,9 @@ function buildRequestInfo(params) {
     const urlParts = getHttpsUrlParts(url);
 
     // Force the retrieval of a (signed) access URL for this request if the `martha-force-access-url` header is set
-    // copying the original object with `forceAccessUrl` set appropriately.
-    // Shallow clone a JavaScript ES6 class instance
-    // https://stackoverflow.com/questions/41474986/how-to-clone-a-javascript-es6-class-instance
-    const drsProvider = { ...determineDrsProvider(url, urlParts), forceAccessUrl: Boolean(forceAccessUrl) };
+    // copying the original object with `forceAccessUrl` set appropriately. Note that for real life headers `Boolean()`
+    // is going to exercise JavaScript's quirks with thuthiness and return true for any String value.
+    const drsProvider = determineDrsProvider(url, urlParts, Boolean(forceAccessUrl));
     Object.setPrototypeOf(drsProvider, DrsProvider.prototype);
 
     Object.assign(params, {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "start": "functions-framework --target=index --port=8010",
     "test": "./minnie-kenny.sh && nyc --reporter=html --reporter=text ava -m !smoketest* -m !live_test* -m !integration*",
-    "me": "ava --match 'martha_v3 parses PDC response correctly'",
+    "me": "ava --match 'martha_v3 calls the correct endpoints when only the fileName is requested and the metadata contains only an access id'",
     "smoketest": "ava --timeout 10m --match smoketest*",
     "smoketest_v2": "ava -m smoketest_v2*",
     "smoketest_v3": "ava --timeout 10m --match smoketest_v3*",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,6 @@
   "scripts": {
     "start": "functions-framework --target=index --port=8010",
     "test": "./minnie-kenny.sh && nyc --reporter=html --reporter=text ava -m !smoketest* -m !live_test* -m !integration*",
-    "me": "ava --match 'martha_v3 calls the correct endpoints when access url fetch is forced for The AnVIL'",
     "smoketest": "ava --timeout 10m --match smoketest*",
     "smoketest_v2": "ava -m smoketest_v2*",
     "smoketest_v3": "ava --timeout 10m --match smoketest_v3*",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "start": "functions-framework --target=index --port=8010",
     "test": "./minnie-kenny.sh && nyc --reporter=html --reporter=text ava -m !smoketest* -m !live_test* -m !integration*",
-    "me": "ava --match 'martha_v3 calls the correct endpoints when access url fetch is forced for TDR'",
+    "me": "ava --match 'martha_v3 calls the correct endpoints when access url fetch is forced for CRDC'",
     "smoketest": "ava --timeout 10m --match smoketest*",
     "smoketest_v2": "ava -m smoketest_v2*",
     "smoketest_v3": "ava --timeout 10m --match smoketest_v3*",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "start": "functions-framework --target=index --port=8010",
     "test": "./minnie-kenny.sh && nyc --reporter=html --reporter=text ava -m !smoketest* -m !live_test* -m !integration*",
-    "me": "ava --match 'martha_v3 calls the correct endpoints when only the fileName is requested and the metadata contains only an access id'",
+    "me": "ava --match 'martha_v3 parses a PDC CIB URI response correctly'",
     "smoketest": "ava --timeout 10m --match smoketest*",
     "smoketest_v2": "ava -m smoketest_v2*",
     "smoketest_v3": "ava --timeout 10m --match smoketest_v3*",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "start": "functions-framework --target=index --port=8010",
     "test": "./minnie-kenny.sh && nyc --reporter=html --reporter=text ava -m !smoketest* -m !live_test* -m !integration*",
-    "me": "ava --match 'martha_v3 parses a PDC CIB URI response correctly'",
+    "me": "ava --match 'martha_v3 parses a Kids First CIB URI response correctly'",
     "smoketest": "ava --timeout 10m --match smoketest*",
     "smoketest_v2": "ava -m smoketest_v2*",
     "smoketest_v3": "ava --timeout 10m --match smoketest_v3*",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "start": "functions-framework --target=index --port=8010",
     "test": "./minnie-kenny.sh && nyc --reporter=html --reporter=text ava -m !smoketest* -m !live_test* -m !integration*",
-    "me": "ava --match 'martha_v3 calls the correct endpoints when only the accessUrl is requested for TDR'",
+    "me": "ava --match 'martha_v3 calls the correct endpoints when access url fetch is forced for TDR'",
     "smoketest": "ava --timeout 10m --match smoketest*",
     "smoketest_v2": "ava -m smoketest_v2*",
     "smoketest_v3": "ava --timeout 10m --match smoketest_v3*",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "start": "functions-framework --target=index --port=8010",
     "test": "./minnie-kenny.sh && nyc --reporter=html --reporter=text ava -m !smoketest* -m !live_test* -m !integration*",
-    "me": "ava --match 'martha_v3 parses a Kids First CIB URI response correctly'",
+    "me": "ava --match 'martha_v3 calls the correct endpoints when only the accessUrl is requested for TDR'",
     "smoketest": "ava --timeout 10m --match smoketest*",
     "smoketest_v2": "ava -m smoketest_v2*",
     "smoketest_v3": "ava --timeout 10m --match smoketest_v3*",

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "start": "functions-framework --target=index --port=8010",
     "test": "./minnie-kenny.sh && nyc --reporter=html --reporter=text ava -m !smoketest* -m !live_test* -m !integration*",
+    "me": "ava --match 'martha_v3 parses a Gen3 CRDC CIB URI response correctly'",
     "smoketest": "ava --timeout 10m --match smoketest*",
     "smoketest_v2": "ava -m smoketest_v2*",
     "smoketest_v3": "ava --timeout 10m --match smoketest_v3*",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "start": "functions-framework --target=index --port=8010",
     "test": "./minnie-kenny.sh && nyc --reporter=html --reporter=text ava -m !smoketest* -m !live_test* -m !integration*",
-    "me": "ava --match 'martha_v3 calls the correct endpoints when access url fetch is forced for CRDC'",
+    "me": "ava --match 'martha_v3 calls the correct endpoints when access url fetch is forced for The AnVIL'",
     "smoketest": "ava --timeout 10m --match smoketest*",
     "smoketest_v2": "ava -m smoketest_v2*",
     "smoketest_v3": "ava --timeout 10m --match smoketest_v3*",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "start": "functions-framework --target=index --port=8010",
     "test": "./minnie-kenny.sh && nyc --reporter=html --reporter=text ava -m !smoketest* -m !live_test* -m !integration*",
-    "me": "ava --match 'martha_v3 parses a Gen3 CRDC CIB URI response correctly'",
+    "me": "ava --match 'martha_v3 parses PDC response correctly'",
     "smoketest": "ava --timeout 10m --match smoketest*",
     "smoketest_v2": "ava -m smoketest_v2*",
     "smoketest_v3": "ava --timeout 10m --match smoketest_v3*",

--- a/test/martha/_martha_v3_resources.js
+++ b/test/martha/_martha_v3_resources.js
@@ -155,6 +155,59 @@ const jadeDrsMarthaResult = {
     }
 };
 
+const jadeAccessUrlMetadataResponse = {
+    "id": "v1_0c86170e-312d-4b39-a0a4-2a2bfaa24c7a_c0e40912-8b14-43f6-9a2f-b278144d0060",
+    "name": "hapmap_3.3.hg38.vcf.gz",
+    "self_uri": "drs://jade.datarepo-dev.broadinstitute.org/v1_0c86170e-312d-4b39-a0a4-2a2bfaa24c7a_c0e40912-8b14-43f6-9a2f-b278144d0060",
+    "size": 62043448,
+    "created_time": "2020-08-04T19:55:22.570Z",
+    "updated_time": "2020-08-04T19:55:22.570Z",
+    "version": "0",
+    "mime_type": "text/plain",
+    "checksums": [
+        {
+            "checksum": "fd528923",
+            "type": "crc32c"
+        },
+        {
+            "checksum": "d05ac6b9a247a21ce0030c7494194da9",
+            "type": "md5"
+        }
+    ],
+    "access_methods": [
+        {
+            "type": "gs",
+            "access_url": {
+                "url": "gs://broad-jade-dev-data-bucket/ca8edd48-e954-4c20-b911-b017fedffb67/c0e40912-8b14-43f6-9a2f-b278144d0060",
+                "headers": null
+            },
+            "access_id": "gcp-us-central1",
+            "region": "us-central1"
+        },
+        {
+            "type": "https",
+            "access_url": {
+                "url": "https://www.googleapis.com/storage/v1/b/broad-jade-dev-data-bucket/o/ca8edd48-e954-4c20-b911-b017fedffb67%2Fc0e40912-8b14-43f6-9a2f-b278144d0060?alt=media",
+                "headers": [
+                    "Authorization: Bearish"
+                ]
+            },
+            "access_id": null,
+            "region": "us-central1"
+        }
+    ],
+    "contents": null,
+    "description": "cromwell test file",
+    "aliases": [
+        "/CromwellSimpleWithFilerefs/gs:/broad-jade-dev-data-bucket/ca8edd48-e954-4c20-b911-b017fedffb67/hapmap_3.3.hg38.vcf.gz"
+    ]
+};
+
+const jadeAccessUrlAccessResponse = {
+    "url": "https://storage.googleapis.com/broad-jade-dev-data-bucket/ca8edd48-e954-4c20-b911-b017fedffb67/c0e40912-8b14-43f6-9a2f-b278144d0060?sig=ABC",
+    "headers": null
+};
+
 // Gen3/CRDC
 
 const gen3CrdcResponse = {
@@ -579,5 +632,7 @@ module.exports = {
     pdcDrsMarthaResult,
     kidsFirstDrsResponse,
     kidsFirstDrsResponseCustom,
-    kidsFirstDrsMarthaResult
+    kidsFirstDrsMarthaResult,
+    jadeAccessUrlMetadataResponse,
+    jadeAccessUrlAccessResponse,
 };

--- a/test/martha/_martha_v3_resources.js
+++ b/test/martha/_martha_v3_resources.js
@@ -160,6 +160,7 @@ const jadeDrsMarthaResult = {
 const jadeAccessUrlMetadataResponse = {
     "id": "v1_0c86170e-312d-4b39-a0a4-2a2bfaa24c7a_c0e40912-8b14-43f6-9a2f-b278144d0060",
     "name": "hapmap_3.3.hg38.vcf.gz",
+    // 2021-10-04 this is a minor forgery, dev TDR actually had a `null` value for the "self_uri" key
     "self_uri": "drs://jade.datarepo-dev.broadinstitute.org/v1_0c86170e-312d-4b39-a0a4-2a2bfaa24c7a_c0e40912-8b14-43f6-9a2f-b278144d0060",
     "size": 62043448,
     "created_time": "2020-08-04T19:55:22.570Z",
@@ -203,11 +204,6 @@ const jadeAccessUrlMetadataResponse = {
     "aliases": [
         "/CromwellSimpleWithFilerefs/gs:/broad-jade-dev-data-bucket/ca8edd48-e954-4c20-b911-b017fedffb67/hapmap_3.3.hg38.vcf.gz"
     ]
-};
-
-const jadeAccessUrlAccessResponse = {
-    "url": "https://storage.googleapis.com/broad-jade-dev-data-bucket/ca8edd48-e954-4c20-b911-b017fedffb67/c0e40912-8b14-43f6-9a2f-b278144d0060?sig=ABC",
-    "headers": null // 2021-10-04 Unlike any known Gen3 systems Jade dev returns access `headers` with a null value.
 };
 
 // Gen3/CRDC
@@ -635,5 +631,4 @@ module.exports = {
     kidsFirstDrsResponseCustom,
     kidsFirstDrsMarthaResult,
     jadeAccessUrlMetadataResponse,
-    jadeAccessUrlAccessResponse,
 };

--- a/test/martha/_martha_v3_resources.js
+++ b/test/martha/_martha_v3_resources.js
@@ -7,6 +7,8 @@
 
 const config = require('../../common/config');
 
+const fakeToken = 'Definitely not a real token';
+
 const dosObjectWithMissingFields = {
     data_object: {
         id: 'v1_abc-123',
@@ -189,7 +191,7 @@ const jadeAccessUrlMetadataResponse = {
             "access_url": {
                 "url": "https://www.googleapis.com/storage/v1/b/broad-jade-dev-data-bucket/o/ca8edd48-e954-4c20-b911-b017fedffb67%2Fc0e40912-8b14-43f6-9a2f-b278144d0060?alt=media",
                 "headers": [
-                    "Authorization: Bearish"
+                    `Authorization: Bearer ${fakeToken}`
                 ]
             },
             "access_id": null,
@@ -205,7 +207,7 @@ const jadeAccessUrlMetadataResponse = {
 
 const jadeAccessUrlAccessResponse = {
     "url": "https://storage.googleapis.com/broad-jade-dev-data-bucket/ca8edd48-e954-4c20-b911-b017fedffb67/c0e40912-8b14-43f6-9a2f-b278144d0060?sig=ABC",
-    "headers": null
+    "headers": null // 2021-10-04 Unlike any known Gen3 systems Jade dev returns access `headers` with a null value.
 };
 
 // Gen3/CRDC
@@ -548,7 +550,6 @@ const bdcDrsMarthaResult = (expectedGoogleServiceAccount, expectedAccessUrl) => 
 // HCA
 // returned via
 //   `curl https://jade.datarepo-dev.broadinstitute.org/ga4gh/drs/v1/objects/v1_4641bafb-5190-425b-aea9-9c7b125515c8_e37266ba-790d-4641-aa76-854d94be2fbe`
-const fakeToken = 'Definitely not a real token';
 const hcaDrsResponse = {
     id: 'v1_4641bafb-5190-425b-aea9-9c7b125515c8_e37266ba-790d-4641-aa76-854d94be2fbe',
     name: 'E18_20161004_Neurons_Sample_49_S048_L004_R2_005.fastq.gz',

--- a/test/martha/martha_v3.test.js
+++ b/test/martha/martha_v3.test.js
@@ -62,9 +62,9 @@ const {BondProviders} = require("../../common/bond");
 const terraAuth = 'bearer abc123';
 
 const mockRequest = (req, options = {}) => {
-    const forceAccessUrl = options.forceAccessUrl || false;
+    const forceAccessUrl = Boolean(options.forceAccessUrl || false);
     req.method = 'POST';
-    req.headers = { 'authorization': terraAuth, 'martha-force-access-url': forceAccessUrl };
+    req.headers = { 'authorization': terraAuth, 'martha-force-access-url': forceAccessUrl.toString() };
     if (req.body && typeof req.body.fields === "undefined") {
         req.body.fields = MARTHA_V3_ALL_FIELDS;
     }

--- a/test/martha/martha_v3.test.js
+++ b/test/martha/martha_v3.test.js
@@ -52,7 +52,7 @@ const {
 } = require("../../martha/drs_providers");
 
 const {
-    MARTHA_V3_ALL_FIELDS,
+    MARTHA_V3_ALL_FIELDS, MARTHA_V3_ACCESS_ID_FIELDS,
 } = require("../../martha/martha_fields");
 
 const apiAdapter = require('../../common/api_adapter');
@@ -261,7 +261,7 @@ test.serial('martha_v3 calls the correct endpoints when only the accessUrl is re
     sinon.assert.callCount(getJsonFromApiStub, 3);
 });
 
-test.serial('martha_v3 calls the correct endpoints when only the accessUrl is requested for TDR', async (t) => {
+test.serial('martha_v3 calls the correct endpoints when access url fetch is forced for TDR', async (t) => {
     const {
         id: objectId, self_uri: drsUri,
         access_methods: { 0: { access_id: accessId, access_url: { url: gsUrl } } }
@@ -274,8 +274,8 @@ test.serial('martha_v3 calls the correct endpoints when only the accessUrl is re
     getJsonFromApiStub.withArgs(drs.accessUrl, terraAuth).resolves(jadeAccessUrlAccessResponse);
     const response = mockResponse();
     const request = mockRequest(
-        { body: { url: drsUri, fields: ['accessUrl'] } },
-        MARTHA_V3_ALL_FIELDS,
+        { body: { url: drsUri } },
+        MARTHA_V3_ACCESS_ID_FIELDS,
         FORCE_ACCESS_URL
     );
 

--- a/test/martha/martha_v3.test.js
+++ b/test/martha/martha_v3.test.js
@@ -31,7 +31,6 @@ const {
     drsObjectWithInvalidFields,
     expectedObjWithMissingFields,
     jadeAccessUrlMetadataResponse,
-    jadeAccessUrlAccessResponse
 } = require('./_martha_v3_resources.js');
 
 const test = require('ava');
@@ -271,7 +270,7 @@ test.serial('martha_v3 calls the correct endpoints when access url fetch is forc
     // date omit the "headers" kv completely.
     const drsAccessUrlResponse = {...mockGcsAccessUrl(gsUrl), 'headers': null};
     getJsonFromApiStub.withArgs(drs.objectsUrl, terraAuth).resolves(jadeAccessUrlMetadataResponse);
-    getJsonFromApiStub.withArgs(drs.accessUrl, terraAuth).resolves(jadeAccessUrlAccessResponse);
+    getJsonFromApiStub.withArgs(drs.accessUrl, terraAuth).resolves(drsAccessUrlResponse);
     const response = mockResponse();
     const request = mockRequest(
         { body: { url: drsUri } },

--- a/test/martha/martha_v3.test.js
+++ b/test/martha/martha_v3.test.js
@@ -36,8 +36,8 @@ const test = require('ava');
 const sinon = require('sinon');
 const {
     marthaV3Handler: marthaV3,
-    DrsType,
-    determineDrsType,
+    DrsProvider,
+    determineDrsProvider,
     generateMetadataUrl,
     generateAccessUrl,
     getDrsAccessId,
@@ -996,14 +996,14 @@ test.serial('martha_v3 getDrsAccessId should not return an access_id for a null 
 
 test.serial('martha_v3 generateAccessUrl should generate an access url', (t) => {
     const urlParts = getHttpsUrlParts('drs://some.host.example.com/some_id');
-    const drsType = new DrsType(urlParts, '/some_prefix', false, null, null);
+    const drsType = new DrsProvider('Test Dummy Provider (TDP)', urlParts, '/some_prefix', false, null, null);
     const result = generateAccessUrl(drsType, 'some_access_id');
     t.is(result, 'https://some.host.example.com/some_prefix/some_id/access/some_access_id');
 });
 
 test.serial('martha_v3 generateAccessUrl should generate an access url with a different port', (t) => {
     const urlParts = getHttpsUrlParts('drs://some.host.example.com:8000/some_id');
-    const drsType = new DrsType(urlParts, '/some_prefix', false, null, null);
+    const drsType = new DrsProvider('Test Dummy Provider (TDP)', urlParts, '/some_prefix', false, null, null);
     const result = generateAccessUrl(drsType, 'some_access_id');
     t.is(result, 'https://some.host.example.com:8000/some_prefix/some_id/access/some_access_id');
 });
@@ -1016,7 +1016,7 @@ This is hypothetical scenario based on a combination of:
  */
 test.serial('martha_v3 generateAccessUrl should add the query string to the access url', (t) => {
     const urlParts = getHttpsUrlParts(`drs://${bdc}/some_id?query=value`);
-    const drsType = new DrsType(urlParts, '/some_prefix', false, null, null);
+    const drsType = new DrsProvider('Test Dummy Provider (TDP)', urlParts, '/some_prefix', false, null, null);
     const result = generateAccessUrl(drsType, 'some_access_id');
     t.is(result, `https://${bdc}/some_prefix/some_id/access/some_access_id?query=value`);
 });
@@ -1027,7 +1027,7 @@ test.serial('martha_v3 generateAccessUrl should add the query string to the acce
  * @return {string}
  */
 function determineDrsTypeTestWrapper(testUrl) {
-    const drsType = determineDrsType(testUrl);
+    const drsType = determineDrsProvider(testUrl);
     return generateMetadataUrl(drsType);
 }
 

--- a/test/martha/martha_v3.test.js
+++ b/test/martha/martha_v3.test.js
@@ -494,7 +494,7 @@ test.serial('martha_v3 should return 500 if key retrieval from Bond fails', asyn
     t.is(response.body.response.text, 'Received error contacting Bond. Bond key lookup forced to fail by testing stub');
 });
 
-test.serial('martha_v3 calls bond Bond with the "fence" provider when the Data Object URL host is "dg.4503"', async (t) => {
+test.serial('martha_v3 calls Bond with the "fence" provider when the Data Object URL host is "dg.4503"', async (t) => {
     const bond = bondUrls('fence');
     const drs = drsUrls(config.HOST_BIODATA_CATALYST_STAGING);
     getJsonFromApiStub.withArgs(bond.serviceAccountKeyUrl, terraAuth).resolves(googleSAKeyObject);

--- a/test/martha/martha_v3.test.js
+++ b/test/martha/martha_v3.test.js
@@ -1009,8 +1009,8 @@ test.serial('martha_v3 generateAccessUrl should add the query string to the acce
  * @return {string}
  */
 function determineDrsProviderWrapper(testUrl) {
-    const drsProvider = determineDrsProvider(testUrl);
     const urlParts = getHttpsUrlParts(testUrl);
+    const drsProvider = determineDrsProvider(testUrl, urlParts);
     return generateMetadataUrl(drsProvider, urlParts);
 }
 

--- a/test/martha/martha_v3.test.js
+++ b/test/martha/martha_v3.test.js
@@ -44,13 +44,13 @@ const {
 } = require('../../martha/martha_v3');
 
 const {
-    MARTHA_V3_ALL_FIELDS,
-} = require("../../martha/martha_fields");
-
-const {
     DrsProvider,
     determineDrsProvider,
 } = require("../../martha/drs_providers");
+
+const {
+    MARTHA_V3_ALL_FIELDS,
+} = require("../../martha/martha_fields");
 
 const apiAdapter = require('../../common/api_adapter');
 const config = require('../../common/config');

--- a/test/martha/martha_v3.test.js
+++ b/test/martha/martha_v3.test.js
@@ -120,7 +120,6 @@ function mockGcsAccessUrl(gsUrlString) {
     const gsUrl = new URL(gsUrlString);
     return {
         url: `https://storage.googleapis.com/${gsUrl.hostname}${gsUrl.pathname}?sig=ABC`,
-        headers: null
     };
 }
 
@@ -268,7 +267,9 @@ test.serial('martha_v3 calls the correct endpoints when only the accessUrl is re
         access_methods: { 0: { access_id: accessId, access_url: { url: gsUrl } } }
     } = jadeAccessUrlMetadataResponse;
     const drs = drsUrls('jade.datarepo-dev.broadinstitute.org', objectId, accessId);
-    const drsAccessUrlResponse = mockGcsAccessUrl(gsUrl);
+    // 2021-10-04 Jade returns `"headers": null` if there are no headers, while the Gen3 repos we have worked with to
+    // date omit the "headers" kv completely.
+    const drsAccessUrlResponse = {...mockGcsAccessUrl(gsUrl), 'headers': null};
     getJsonFromApiStub.withArgs(drs.objectsUrl, terraAuth).resolves(jadeAccessUrlMetadataResponse);
     getJsonFromApiStub.withArgs(drs.accessUrl, terraAuth).resolves(jadeAccessUrlAccessResponse);
     const response = mockResponse();

--- a/test/martha/martha_v3.test.js
+++ b/test/martha/martha_v3.test.js
@@ -40,12 +40,13 @@ const {
     generateAccessUrl,
     getHttpsUrlParts,
     overridePencilsDownSeconds,
-    PROTOCOL_PREFIX_DRS
+    PROTOCOL_PREFIX_DRS,
 } = require('../../martha/martha_v3');
 
 const {
     DrsProvider,
     determineDrsProvider,
+    DrsProviderInstances: DefaultDrsProviderInstances,
 } = require("../../martha/drs_providers");
 
 const {
@@ -1017,7 +1018,7 @@ test.serial('martha_v3 generateAccessUrl should add the query string to the acce
  */
 function determineDrsProviderWrapper(testUrl) {
     const urlParts = getHttpsUrlParts(testUrl);
-    const drsProvider = determineDrsProvider(testUrl, urlParts);
+    const drsProvider = determineDrsProvider(testUrl, urlParts, DefaultDrsProviderInstances);
     return generateMetadataUrl(drsProvider, urlParts);
 }
 

--- a/test/martha/martha_v3.test.js
+++ b/test/martha/martha_v3.test.js
@@ -47,7 +47,6 @@ const {
 const {
     DrsProvider,
     determineDrsProvider,
-    DrsProviderInstances: DefaultDrsProviderInstances,
 } = require("../../martha/drs_providers");
 
 const {
@@ -1118,7 +1117,7 @@ test.serial('martha_v3 generateAccessUrl should add the query string to the acce
  */
 function determineDrsProviderWrapper(testUrl) {
     const urlParts = getHttpsUrlParts(testUrl);
-    const drsProvider = determineDrsProvider(testUrl, urlParts, DefaultDrsProviderInstances);
+    const drsProvider = determineDrsProvider(testUrl, urlParts);
     return generateMetadataUrl(drsProvider, urlParts);
 }
 

--- a/test/martha/martha_v3.test.js
+++ b/test/martha/martha_v3.test.js
@@ -51,7 +51,7 @@ const {
 } = require("../../martha/drs_providers");
 
 const {
-    MARTHA_V3_ALL_FIELDS, MARTHA_V3_ACCESS_ID_FIELDS,
+    MARTHA_V3_ALL_FIELDS,
 } = require("../../martha/martha_fields");
 
 const apiAdapter = require('../../common/api_adapter');
@@ -62,11 +62,12 @@ const {BondProviders} = require("../../common/bond");
 
 const terraAuth = 'bearer abc123';
 
-const mockRequest = (req, requestFields = MARTHA_V3_ALL_FIELDS, forceAccessUrl = false) => {
+const mockRequest = (req, options = {}) => {
+    const forceAccessUrl = options.forceAccessUrl || false;
     req.method = 'POST';
     req.headers = { 'authorization': terraAuth, 'martha-force-access-url': forceAccessUrl };
     if (req.body && typeof req.body.fields === "undefined") {
-        req.body.fields = requestFields;
+        req.body.fields = MARTHA_V3_ALL_FIELDS;
     }
     return req;
 };
@@ -113,8 +114,6 @@ const drsUrls = (host, id, accessId) => {
         accessUrl: `${objectsUrl}/access/${accessId}`
     };
 };
-
-const FORCE_ACCESS_URL = true;
 
 function mockGcsAccessUrl(gsUrlString) {
     const gsUrl = new URL(gsUrlString);
@@ -229,7 +228,12 @@ test.serial('martha_v3 calls the correct endpoints if the googleServiceAccount i
     const response = mockResponse();
 
     await marthaV3(
-        mockRequest({ body: { url: `dos://${crdc}/123`, fields: ['googleServiceAccount'] } }),
+        mockRequest({
+            body: {
+                url: `dos://${crdc}/123`,
+                fields: ['googleServiceAccount']
+            }
+        }),
         response
     );
 
@@ -252,8 +256,9 @@ test.serial('martha_v3 calls the correct endpoints when only the accessUrl is re
     getJsonFromApiStub.withArgs(drs.accessUrl, `Bearer ${bondAccessTokenResponse.token}`)
         .resolves(drsAccessUrlResponse);
     const response = mockResponse();
+    const request = mockRequest({body: {url: drsUri, fields: ['accessUrl']}});
 
-    await marthaV3(mockRequest({ body: { url: drsUri, fields: ['accessUrl'] } }), response);
+    await marthaV3(request, response);
 
     t.is(response.statusCode, 200);
     t.deepEqual(response.body, { accessUrl: drsAccessUrlResponse });
@@ -273,11 +278,7 @@ test.serial('martha_v3 calls the correct endpoints when access url fetch is forc
     getJsonFromApiStub.withArgs(drs.objectsUrl, terraAuth).resolves(jadeAccessUrlMetadataResponse);
     getJsonFromApiStub.withArgs(drs.accessUrl, terraAuth).resolves(drsAccessUrlResponse);
     const response = mockResponse();
-    const request = mockRequest(
-        { body: { url: drsUri } },
-        MARTHA_V3_ACCESS_ID_FIELDS,
-        FORCE_ACCESS_URL
-    );
+    const request = mockRequest({body: {url: drsUri, fields: ['accessUrl']}}, {forceAccessUrl: true});
 
     await marthaV3(request, response);
 
@@ -300,11 +301,8 @@ test.serial('martha_v3 calls the correct endpoints when access url fetch is forc
     getJsonFromApiStub.withArgs(drs.accessUrl, `Bearer ${bondAccessTokenResponse.token}`)
         .resolves(drsAccessUrlResponse);
     const response = mockResponse();
-    const request = mockRequest(
-        {body: {url: drsUri, fields: ['accessUrl']}},
-        MARTHA_V3_ACCESS_ID_FIELDS,
-        FORCE_ACCESS_URL
-    );
+    const request = mockRequest({ body: { url: drsUri, fields: ['accessUrl']}},
+        {forceAccessUrl: true});
     await marthaV3(request, response);
 
     t.is(response.statusCode, 200);
@@ -326,11 +324,8 @@ test.serial('martha_v3 calls the correct endpoints when access url fetch is forc
     getJsonFromApiStub.withArgs(drs.accessUrl, `Bearer ${bondAccessTokenResponse.token}`)
         .resolves(drsAccessUrlResponse);
     const response = mockResponse();
-    const request = mockRequest(
-        {body: {url: drsUri, fields: ['accessUrl']}},
-        MARTHA_V3_ACCESS_ID_FIELDS,
-        FORCE_ACCESS_URL
-    );
+    const request = mockRequest({ body: { url: drsUri, fields: ['accessUrl']}},
+        {forceAccessUrl: true});
     await marthaV3(request, response);
 
     t.is(response.statusCode, 200);
@@ -352,11 +347,8 @@ test.serial('martha_v3 calls the correct endpoints when access url fetch is forc
     getJsonFromApiStub.withArgs(drs.accessUrl, `Bearer ${bondAccessTokenResponse.token}`)
         .resolves(drsAccessUrlResponse);
     const response = mockResponse();
-    const request = mockRequest(
-        {body: {url: drsUri, fields: ['accessUrl']}},
-        MARTHA_V3_ACCESS_ID_FIELDS,
-        FORCE_ACCESS_URL
-    );
+    const request = mockRequest({ body: { url: drsUri, fields: ['accessUrl']}},
+        {forceAccessUrl: true});
     await marthaV3(request, response);
 
     t.is(response.statusCode, 200);

--- a/test/martha/martha_v3.test.js
+++ b/test/martha/martha_v3.test.js
@@ -36,15 +36,22 @@ const test = require('ava');
 const sinon = require('sinon');
 const {
     marthaV3Handler: marthaV3,
-    DrsProvider,
-    determineDrsProvider,
     generateMetadataUrl,
     generateAccessUrl,
     getHttpsUrlParts,
-    MARTHA_V3_ALL_FIELDS,
     overridePencilsDownSeconds,
     PROTOCOL_PREFIX_DRS
 } = require('../../martha/martha_v3');
+
+const {
+    MARTHA_V3_ALL_FIELDS,
+} = require("../../martha/martha_fields");
+
+const {
+    DrsProvider,
+    determineDrsProvider,
+} = require("../../martha/drs_providers");
+
 const apiAdapter = require('../../common/api_adapter');
 const config = require('../../common/config');
 const { delay } = require('../../common/helpers');

--- a/test/martha/martha_v3.test.js
+++ b/test/martha/martha_v3.test.js
@@ -43,6 +43,7 @@ const {
     getHttpsUrlParts,
     MARTHA_V3_ALL_FIELDS,
     overridePencilsDownSeconds,
+    PROTOCOL_PREFIX_DRS
 } = require('../../martha/martha_v3');
 const apiAdapter = require('../../common/api_adapter');
 const config = require('../../common/config');
@@ -977,16 +978,16 @@ test.skip('martha_v3 should return 500 on exception trying to get signed URL fro
 
 test.serial('martha_v3 generateAccessUrl should generate an access url', (t) => {
     const urlParts = getHttpsUrlParts('drs://some.host.example.com/some_id');
-    const drsProvider = new DrsProvider('Test Dummy Provider (TDP)', '/some_prefix', false, null, null);
+    const drsProvider = new DrsProvider('Test Dummy Provider (TDP)', false, null, null);
     const result = generateAccessUrl(drsProvider, urlParts, 'some_access_id');
-    t.is(result, 'https://some.host.example.com/some_prefix/some_id/access/some_access_id');
+    t.is(result, `https://some.host.example.com${PROTOCOL_PREFIX_DRS}/some_id/access/some_access_id`);
 });
 
 test.serial('martha_v3 generateAccessUrl should generate an access url with a different port', (t) => {
     const urlParts = getHttpsUrlParts('drs://some.host.example.com:8000/some_id');
     const drsProvider = new DrsProvider('Test Dummy Provider (TDP)', '/some_prefix', false, null, null);
     const result = generateAccessUrl(drsProvider, urlParts, 'some_access_id');
-    t.is(result, 'https://some.host.example.com:8000/some_prefix/some_id/access/some_access_id');
+    t.is(result, `https://some.host.example.com:8000${PROTOCOL_PREFIX_DRS}/some_id/access/some_access_id`);
 });
 
 /*
@@ -999,7 +1000,7 @@ test.serial('martha_v3 generateAccessUrl should add the query string to the acce
     const urlParts = getHttpsUrlParts(`drs://${bdc}/some_id?query=value`);
     const drsProvider = new DrsProvider('Test Dummy Provider (TDP)', '/some_prefix', false, null, null);
     const result = generateAccessUrl(drsProvider, urlParts, 'some_access_id');
-    t.is(result, `https://${bdc}/some_prefix/some_id/access/some_access_id?query=value`);
+    t.is(result, `https://${bdc}${PROTOCOL_PREFIX_DRS}/some_id/access/some_access_id?query=value`);
 });
 
 /**


### PR DESCRIPTION
Allows for passing the `martha-force-access-url` header to force Martha to retrieve a signed URL even if the DRS provider is not configured to ordinarily return signed URLs. Also a fair bit of other, hopefully simplifying refactoring.