### PR TITLE
Add localizationPath [BT-417]

### DIFF
--- a/common/helpers.js
+++ b/common/helpers.js
@@ -176,6 +176,7 @@ class MarthaV3Response extends CommonFileInfoResponse {
         googleServiceAccount,
         bondProvider,
         fileName,
+        localizationPath,
         hashesMap,
         accessUrl,
     ) {
@@ -192,6 +193,7 @@ class MarthaV3Response extends CommonFileInfoResponse {
         this.hashes = hashesMap || null;
         this.timeUpdated = updated || null;
         this.fileName = fileName || null;
+        this.localizationPath = localizationPath || null;
         this.bondProvider = bondProvider || null;
         this.accessUrl = accessUrl || null;
         delete this.updated;
@@ -366,9 +368,10 @@ function getGsUrlFromDrsObject(drsResponse) {
  * @param {?Object} [accessUrl] An access URL
  * @param {string} accessUrl.url A URL used to fetch object bytes
  * @param {?Object} [accessUrl.headers] The optional headers to include in the HTTP request to url
+ * @param {?string} [localizationPath] The preferred localization path
  * @returns {MarthaV3Response} The drs object converted to a martha_v3 response
  */
-function convertToMarthaV3Response(drsResponse, fileName, bondProvider, googleSA, accessUrl) {
+function convertToMarthaV3Response(drsResponse, fileName, bondProvider, googleSA, accessUrl, localizationPath) {
     const {
         checksums,
         mime_type: mimeType = 'application/octet-stream',
@@ -417,6 +420,7 @@ function convertToMarthaV3Response(drsResponse, fileName, bondProvider, googleSA
         googleServiceAccount,
         bondProvider,
         fileName,
+        localizationPath,
         hashesMap,
         accessUrl,
     );

--- a/martha/drs_providers.js
+++ b/martha/drs_providers.js
@@ -48,14 +48,14 @@ class AccessMethod {
 }
 
 class DrsProvider {
-    constructor(providerName, sendMetadataAuth, bondProvider, accessMethods, forceAccessUrl,
-        options = { usesAliasesForLocalizationPath: false }) {
+    constructor(providerName, sendMetadataAuth, bondProvider, accessMethods, forceAccessUrl, options) {
+        const defaultOptions = { usesAliasesForLocalizationPath: false };
+        this.options = { ...defaultOptions, ...options };
         this.providerName = providerName;
         this.sendMetadataAuth = sendMetadataAuth;
         this.bondProvider = bondProvider;
         this.accessMethods = accessMethods;
         this.forceAccessUrl = forceAccessUrl;
-        this.options = options;
     }
 
     accessMethodHavingSameTypeAs(accessMethod) {

--- a/martha/drs_providers.js
+++ b/martha/drs_providers.js
@@ -48,12 +48,14 @@ class AccessMethod {
 }
 
 class DrsProvider {
-    constructor(providerName, sendMetadataAuth, bondProvider, accessMethods, forceAccessUrl) {
+    constructor(providerName, sendMetadataAuth, bondProvider, accessMethods, forceAccessUrl,
+        options = { usesAliasesForLocalizationPath: false}) {
         this.providerName = providerName;
         this.sendMetadataAuth = sendMetadataAuth;
         this.bondProvider = bondProvider;
         this.accessMethods = accessMethods;
         this.forceAccessUrl = forceAccessUrl;
+        this.options = options;
     }
 
     accessMethodHavingSameTypeAs(accessMethod) {
@@ -126,6 +128,10 @@ class DrsProvider {
 
     shouldRequestMetadata(requestedFields) {
         return this && overlapFields(requestedFields, MARTHA_V3_METADATA_FIELDS);
+    }
+
+    usesAliasesForLocalizationPath() {
+        return this.options.usesAliasesForLocalizationPath;
     }
 
     determineAccessUrlAuth(accessMethod, accessToken, requestAuth) {

--- a/martha/drs_providers.js
+++ b/martha/drs_providers.js
@@ -49,7 +49,7 @@ class AccessMethod {
 
 class DrsProvider {
     constructor(providerName, sendMetadataAuth, bondProvider, accessMethods, forceAccessUrl,
-        options = { usesAliasesForLocalizationPath: false}) {
+        options = { usesAliasesForLocalizationPath: false }) {
         this.providerName = providerName;
         this.sendMetadataAuth = sendMetadataAuth;
         this.bondProvider = bondProvider;
@@ -130,6 +130,11 @@ class DrsProvider {
         return this && overlapFields(requestedFields, MARTHA_V3_METADATA_FIELDS);
     }
 
+    /**
+     * This is hopefully a temporary measure until we can take the time to either get a new field
+     * added to the DRS spec or implement a temporary spec extension with the Terra Data Repo team.
+     * See BT-417 for more details.
+     */
     usesAliasesForLocalizationPath() {
         return this.options.usesAliasesForLocalizationPath;
     }
@@ -169,7 +174,8 @@ class TerraDataRepoDrsProvider extends DrsProvider {
             [
                 new AccessMethod(AccessMethodType.GCS, AccessUrlAuth.CURRENT_REQUEST, FetchAccessUrl.NO)
             ],
-            forceAccessUrl
+            forceAccessUrl,
+            { usesAliasesForLocalizationPath: true }
         );
     }
 }

--- a/martha/martha_fields.js
+++ b/martha/martha_fields.js
@@ -3,6 +3,7 @@ const MARTHA_V3_CORE_FIELDS = [
     'bucket',
     'name',
     'fileName',
+    'localizationPath',
     'contentType',
     'size',
     'hashes',

--- a/martha/martha_v3.js
+++ b/martha/martha_v3.js
@@ -89,7 +89,7 @@ function getDrsFileName(drsResponse) {
 }
 
 function getLocalizationPath(drsProvider, drsResponse) {
-    if (drsProvider.usesAliasesForLocalizationPath && drsResponse && Array.isArray(drsResponse.aliases)) {
+    if (drsProvider.usesAliasesForLocalizationPath() && drsResponse && Array.isArray(drsResponse.aliases)) {
         return drsResponse.aliases[0];
     }
 }

--- a/martha/martha_v3.js
+++ b/martha/martha_v3.js
@@ -88,6 +88,12 @@ function getDrsFileName(drsResponse) {
     }
 }
 
+function getLocalizationPath(drsProvider, drsResponse) {
+    if (drsProvider.usesAliasesForLocalizationPath && drsResponse && Array.isArray(drsResponse.aliases)) {
+        return drsResponse.aliases[0];
+    }
+}
+
 /** *************************************************************************************************
  * URI parsers
  */
@@ -339,6 +345,7 @@ async function retrieveFromServers(params) {
     let bondSA;
     let drsResponse;
     let fileName;
+    let localizationPath;
     let accessUrl;
 
     // `fetch` below might time out in a way that we want to report as an error. Since the timeout
@@ -396,6 +403,8 @@ async function retrieveFromServers(params) {
         // We've gotten far enough that we don't want to raise an error, even if we run out of time
         // while fetching a signed URL.
         hypotheticalErrorMessage = null;
+
+        localizationPath = getLocalizationPath(drsProvider, drsResponse);
 
         try {
             let accessToken;
@@ -459,6 +468,7 @@ async function retrieveFromServers(params) {
         bondProvider,
         drsResponse,
         fileName,
+        localizationPath,
         accessUrl,
         bondSA,
     });
@@ -470,13 +480,14 @@ function buildResponseInfo(params) {
         bondProvider,
         drsResponse,
         fileName,
+        localizationPath,
         accessUrl,
         bondSA,
     } = params;
 
     const fullResponse =
         requestedFields.length
-            ? convertToMarthaV3Response(drsResponse, fileName, bondProvider, bondSA, accessUrl)
+            ? convertToMarthaV3Response(drsResponse, fileName, bondProvider, bondSA, accessUrl, localizationPath)
             : {};
     const partialResponse = mask(fullResponse, requestedFields.join(","));
 

--- a/test/common/helpers.test.js
+++ b/test/common/helpers.test.js
@@ -257,6 +257,7 @@ test('convertToMarthaV3Response should return null for all fields in an unlikely
         null,
         null,
         null,
+        null,
         null
     );
     t.deepEqual(convertToMarthaV3Response({}, null, null, {}), expectedResponse);
@@ -283,6 +284,7 @@ test('convertToMarthaV3Response should return null for fields that are missing i
         null,
         null,
         '123.mapped.abc.bam',
+        null,
         null
     );
 
@@ -313,6 +315,7 @@ test('convertToMarthaV3Response should return null for fields that are empty in 
         null,
         null,
         '123.mapped.abc.bam',
+        null,
         null
     );
 
@@ -356,6 +359,7 @@ test('convertToMarthaV3Response should return null for googleServiceAccount if b
         null,
         null,
         '123.mapped.abc.bam',
+        null,
         { md5: '123abc' },
     );
 

--- a/test/martha/_martha_v3_resources.js
+++ b/test/martha/_martha_v3_resources.js
@@ -43,6 +43,7 @@ const expectedObjWithMissingFields = {
     googleServiceAccount: null,
     bondProvider: 'dcf-fence',
     fileName: '123.mapped.abc.bam',
+    localizationPath: null,
     hashes: null
 };
 
@@ -91,6 +92,7 @@ const sampleDosMarthaResult = (expectedGoogleServiceAccount) => {
         googleServiceAccount: expectedGoogleServiceAccount,
         bondProvider: 'dcf-fence',
         fileName: 'my_data',
+        localizationPath: null,
         accessUrl: null,
         hashes: {
             md5: '336ea55913bc261b72875bd259753046',
@@ -150,6 +152,7 @@ const jadeDrsMarthaResult = {
     googleServiceAccount: null,
     bondProvider: null,
     fileName: 'HG00096.mapped.ILLUMINA.bwa.GBR.low_coverage.20120522.bam',
+    localizationPath: null,
     hashes: {
         md5: '336ea55913bc261b72875bd259753046',
         sha256: 'f76877f8e86ec3932fd2ae04239fbabb8c90199dab0019ae55fa42b31c314c44',
@@ -266,6 +269,7 @@ const gen3CrdcDrsMarthaResult = (expectedGoogleServiceAccount, expectedAccessUrl
     googleServiceAccount: expectedGoogleServiceAccount,
     bondProvider: 'dcf-fence',
     fileName: 'UNCID_2210188.c71ca9f7-248f-460c-b5d3-afb2c648fef2.110412_UNC13-SN749_0051_AB0168ABXX_4.tar.gz',
+    localizationPath: null,
     hashes: {
         md5: '2edd5fdb4f1deac4ef2bdf969de9f8ad'
     }
@@ -322,6 +326,7 @@ const pdcDrsMarthaResult = (expectedAccessUrl) => {
         googleServiceAccount: null,
         bondProvider: 'dcf-fence',
         fileName: '01BR001_variant_proteome.fasta',
+        localizationPath: null,
         hashes: {
             md5: '87a588424a5920617c843f22ee662fda'
         }
@@ -380,6 +385,7 @@ const anvilDrsMarthaResult = (expectedGoogleServiceAccount, expectedAccessUrl) =
         googleServiceAccount: expectedGoogleServiceAccount,
         bondProvider: 'anvil',
         fileName: 'GTEX-1GZHY-0011-R6a-SM-9OSWL.Aligned.sortedByCoord.out.patched.md.bigWig',
+        localizationPath: null,
         hashes: {
             md5: '18156430a5eea715b9b58fb53d0cef99'
         }
@@ -432,6 +438,7 @@ const kidsFirstDrsMarthaResult = (expectedAccessUrl) => {
         googleServiceAccount: null,
         bondProvider: 'kids-first',
         fileName: 'IMG_2325.jpg',
+        localizationPath: null,
         hashes: {
             etag: '74c88671bb0cd4cdde5ae45e49db6f47'
         }
@@ -536,6 +543,7 @@ const bdcDrsMarthaResult = (expectedGoogleServiceAccount, expectedAccessUrl) => 
         googleServiceAccount: expectedGoogleServiceAccount,
         bondProvider: 'fence',
         fileName: 'HG01131.final.cram.crai',
+        localizationPath: null,
         hashes: {
             md5: '8bec761c8a626356eb34dbdfe20649b4'
         },
@@ -597,6 +605,7 @@ const hcaDrsMarthaResult = {
     name: 'ecb5601e-9026-428c-b49d-3c5f1807ecb7/e37266ba-790d-4641-aa76-854d94be2fbe/E18_20161004_Neurons_Sample_49_S048_L004_R2_005.fastq.gz',
     accessUrl: null,
     fileName: 'E18_20161004_Neurons_Sample_49_S048_L004_R2_005.fastq.gz',
+    localizationPath: '/hca_dev_20201217_test4/5acd55ef/E18_20161004_Neurons_Sample_49_S048_L004_R2_005.fastq.gz',
     contentType: null,
     size: 438932948,
     hashes: {

--- a/test/martha/integration_v3.test.js
+++ b/test/martha/integration_v3.test.js
@@ -235,6 +235,7 @@ test.cb('integration_v3 responds with Data Object for authorized user for jade d
                         '8b07563a-542f-4b5c-9e00-e8fe6b1861de',
                     googleServiceAccount: null,
                     fileName: 'HG00096.mapped.ILLUMINA.bwa.GBR.low_coverage.20120522.bam',
+                    localizationPath: '/1000GenomesDataset/bam_files/HG00096.mapped.ILLUMINA.bwa.GBR.low_coverage.20120522.bam',
                     hashes: {
                         md5: '336ea55913bc261b72875bd259753046',
                         crc32c: 'ecb19226'

--- a/test/martha/martha_v3.test.js
+++ b/test/martha/martha_v3.test.js
@@ -486,7 +486,7 @@ test.serial('martha_v3 returns an error when an invalid field is requested', asy
                 status: 400,
                 text:
                     "Request is invalid. Fields 'meaningOfLife' are not supported. Supported fields are " +
-                    "'gsUri', 'bucket', 'name', 'fileName', 'contentType', 'size', 'hashes', " +
+                    "'gsUri', 'bucket', 'name', 'fileName', 'localizationPath', 'contentType', 'size', 'hashes', " +
                     "'timeCreated', 'timeUpdated', 'googleServiceAccount', 'bondProvider', 'accessUrl'.",
             },
             status: 400,


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/BT-417

Add interpretation of `aliases` from TDR as a preferred localization path. Martha will return this in a new `localizationPath` field. `localizationPath` is included in the fields returned by default, which means that Martha responses from non-TDR DRS providers will always return `null` values for this.