### PR TITLE
Passports

### DIFF
--- a/common/api_adapter.js
+++ b/common/api_adapter.js
@@ -31,7 +31,9 @@ async function getHeaders(url, authorization) {
 
 async function httpCallWithRetry(url, httpCall, retryAttempt = 1, delay = INITIAL_BACKOFF_DELAY) {
     try {
-        return await httpCall();
+        const response = await httpCall();
+        console.log(`Successfully received response from url '${url}'.`);
+        return response;
     } catch (error) {
         console.log(`Received error for url '${url}'. Attempt ${retryAttempt}.`);
         console.error(error);
@@ -59,20 +61,16 @@ async function httpCallWithRetry(url, httpCall, retryAttempt = 1, delay = INITIA
 
 function getJsonFrom(url, authorization) {
     return httpCallWithRetry(url, async () => {
-        const {body} = await get('get', url, authorization)
+        const {body} = await get('get', url, authorization);
         /*
          handle the case when Martha receives empty JSON body. The reason behind forming a response with status 500
          and throwing it in `try` is so that it can be caught locally and be retried.
          */
         if (Object.keys(body).length === 0) {
-            console.log(`Received an empty JSON body while trying to resolve url '${url}'. Attempt ${retryAttempt}. ` +
-                'Creating a response with status 500.');
-
-            const errorMsg = `Something went wrong while trying to resolve url '${url}'. It came back with empty JSON body!`;
+            const errorMsg = `Received an empty JSON body while trying to resolve url '${url}'`;
             throw new FailureResponse(500, errorMsg);
         }
         else {
-            console.log(`Successfully received response from url '${url}'.`);
             return body;
         }
     });

--- a/common/api_adapter.js
+++ b/common/api_adapter.js
@@ -29,22 +29,6 @@ async function getHeaders(url, authorization) {
     }
 }
 
-async function getJsonFrom(url, authorization) {
-    return httpCallWithRetry(url, async () => get('get', url, authorization))
-}
-
-async function postJsonTo(url, authorization, payload) {
-    return httpCallWithRetry(url, async () => {
-        const postReq = request.post(url, payload);
-        postReq.set('Content-Type', 'application/json');
-        if (authorization) {
-            postReq.set('authorization', authorization);
-        }
-
-        return postReq.then((response) => response.body);
-    })
-}
-
 async function httpCallWithRetry(url, httpCall, retryAttempt = 1, delay = INITIAL_BACKOFF_DELAY) {
     try {
         const {body} = await httpCall();
@@ -87,6 +71,22 @@ async function httpCallWithRetry(url, httpCall, retryAttempt = 1, delay = INITIA
         }
         else { throw error; }
     }
+}
+
+function getJsonFrom(url, authorization) {
+    return httpCallWithRetry(url, () => get('get', url, authorization));
+}
+
+function postJsonTo(url, authorization, payload) {
+    return httpCallWithRetry(url, () => {
+        const postReq = request.post(url, payload);
+        postReq.set('Content-Type', 'application/json');
+        if (authorization) {
+            postReq.set('authorization', authorization);
+        }
+
+        return postReq.then((response) => response.body);
+    });
 }
 
 exports.get = get;

--- a/common/config.js
+++ b/common/config.js
@@ -20,6 +20,7 @@ const HOST_CRDC_STAGING = 'nci-crdc-staging.datacommons.io';
 const HOST_KIDS_FIRST_PROD = 'data.kidsfirstdrc.org';
 const HOST_KIDS_FIRST_STAGING = 'gen3staging.kidsfirstdrc.org';
 const HOST_TDR_DEV = 'jade.datarepo-dev.broadinstitute.org';
+const HOST_PASSPORT_TEST = 'ctds-test-env.planx-pla.net';
 
 /**
  * Return the DSDE environment for the specified Martha environment.
@@ -57,6 +58,8 @@ function configDefaultsForEnv({marthaEnv, dsdeEnv = dsdeEnvFrom(marthaEnv)}) {
                         return `https://broad-bond-${dsdeEnv}.appspot.com`;
                 }
             })(),
+        externalcredsBaseUrl:
+            `https://externalcreds.dsde-${dsdeEnv}.broadinstitute.org`,
         bioDataCatalystHost:
             (() => {
                 switch (marthaEnv) {
@@ -99,6 +102,15 @@ function configDefaultsForEnv({marthaEnv, dsdeEnv = dsdeEnvFrom(marthaEnv)}) {
                         return HOST_KIDS_FIRST_PROD;
                     default:
                         return HOST_KIDS_FIRST_STAGING;
+                }
+            })(),
+        passportTestHost:
+            (() => {
+                switch (marthaEnv) {
+                    case ENV_MOCK:
+                        return HOST_MOCK_DRS;
+                    default:
+                        return HOST_PASSPORT_TEST;
                 }
             })(),
         itMarthaBaseUrl:
@@ -168,6 +180,8 @@ function removeUndefined(orig) {
  *      Default: Sam in dsde-dev.
  * @property {string} bondBaseUrl - Base URL for calling Bond.
  *      Default: Bond in dsde-dev.
+ * @property {string} externalcredsBaseUrl - Base URL for calling External Credentials Manager.
+ *      Default: Externalcreds in dsde-dev.
  * @property {string} bioDataCatalystHost Host (hostname + port) for calling DRS resolvers (production or staging)
  *      or mock DRS for BioData Catalyst.
  * @property {string} theAnvilHost (hostname + port) for calling DRS resolvers (production or staging)
@@ -176,6 +190,8 @@ function removeUndefined(orig) {
  *      or mock DRS for CRDC.
  * @property {string} kidsFirstHost (hostname + port) for calling DRS resolvers (production or staging)
  *      or mock DRS for Kids First.
+ * @property {string} passportTestHost (hostname + port) for calling DRS resolvers (production or staging)
+ *      or mock DRS for Passport testing.
  * @property {string} itMarthaBaseUrl - Base URL for calling Martha from integration-test code.
  *      Default: Martha in FiaB.
  * @property {string} itBondBaseUrl - Base URL for calling Bond from integration-test code.
@@ -192,6 +208,7 @@ const configExport = Object.freeze({
     HOST_KIDS_FIRST_PROD,
     HOST_KIDS_FIRST_STAGING,
     HOST_TDR_DEV,
+    HOST_PASSPORT_TEST,
     ENV_PROD,
     ENV_DEV,
     ENV_MOCK,

--- a/martha/drs_providers.js
+++ b/martha/drs_providers.js
@@ -82,7 +82,7 @@ class DrsProvider {
             overlapFields(requestedFields, MARTHA_V3_ACCESS_ID_FIELDS) &&
             (this.forceAccessUrl || (accessMethod &&
                 this.accessMethods.find((m) => m.accessMethodType === accessMethod.type &&
-                    m.accessUrlAuth === AccessUrlAuth.FENCE_TOKEN &&
+                    (m.accessUrlAuth === AccessUrlAuth.FENCE_TOKEN || m.fallbackAccessUrlAuth === AccessUrlAuth.FENCE_TOKEN) &&
                     m.fetchAccessUrl === FetchAccessUrl.YES)));
     }
 
@@ -223,7 +223,7 @@ class PassportTestDrsProvider extends DrsProvider {
         super(
             'Passport Test Provider',
             MetadataAuth.NO,
-            BondProvider.NONE,
+            BondProvider.DCF_FENCE,
             [
                 new AccessMethod(AccessMethodType.GCS, AccessUrlAuth.PASSPORT, FetchAccessUrl.YES, AccessUrlAuth.FENCE_TOKEN),
                 new AccessMethod(AccessMethodType.S3, AccessUrlAuth.PASSPORT, FetchAccessUrl.YES, AccessUrlAuth.FENCE_TOKEN)

--- a/martha/drs_providers.js
+++ b/martha/drs_providers.js
@@ -42,10 +42,11 @@ const MetadataAuth = {
 };
 
 class AccessMethod {
-    constructor(accessMethodType, accessUrlAuth, fetchAccessUrl) {
+    constructor(accessMethodType, accessUrlAuth, fetchAccessUrl, fallbackAccessUrlAuth) {
         this.accessMethodType = accessMethodType;
         this.accessUrlAuth = accessUrlAuth;
         this.fetchAccessUrl = fetchAccessUrl;
+        this.fallbackAccessUrlAuth = fallbackAccessUrlAuth;
     }
 }
 
@@ -224,8 +225,8 @@ class PassportTestDrsProvider extends DrsProvider {
             MetadataAuth.NO,
             BondProvider.NONE,
             [
-                new AccessMethod(AccessMethodType.GCS, AccessUrlAuth.PASSPORT, FetchAccessUrl.YES),
-                new AccessMethod(AccessMethodType.S3, AccessUrlAuth.PASSPORT, FetchAccessUrl.YES)
+                new AccessMethod(AccessMethodType.GCS, AccessUrlAuth.PASSPORT, FetchAccessUrl.YES, AccessUrlAuth.FENCE_TOKEN),
+                new AccessMethod(AccessMethodType.S3, AccessUrlAuth.PASSPORT, FetchAccessUrl.YES, AccessUrlAuth.FENCE_TOKEN)
             ],
             forceAccessUrl
         );

--- a/martha/drs_providers.js
+++ b/martha/drs_providers.js
@@ -82,7 +82,7 @@ class DrsProvider {
             overlapFields(requestedFields, MARTHA_V3_ACCESS_ID_FIELDS) &&
             (this.forceAccessUrl || (accessMethod &&
                 this.accessMethods.find((m) => m.accessMethodType === accessMethod.type &&
-                    (m.accessUrlAuth === AccessUrlAuth.FENCE_TOKEN || m.fallbackAccessUrlAuth === AccessUrlAuth.FENCE_TOKEN) &&
+                    [m.accessUrlAuth, m.fallbackAccessUrlAuth].includes(AccessUrlAuth.FENCE_TOKEN) &&
                     m.fetchAccessUrl === FetchAccessUrl.YES)));
     }
 

--- a/martha/drs_providers.js
+++ b/martha/drs_providers.js
@@ -75,14 +75,16 @@ class DrsProvider {
      * URL flows (TDR uses the same auth supplied to the current Martha request for calling `access`).
      * @param accessMethod
      * @param requestedFields
+     * @param useFallbackAuth if false (default) check accessUrlAuth in accessMethods, otherwise check fallbackAccessUrlAuth
      * @return {boolean}
      */
-    shouldFetchFenceAccessToken(accessMethod, requestedFields) {
+    shouldFetchFenceAccessToken(accessMethod, requestedFields, useFallbackAuth) {
         return this.bondProvider &&
             overlapFields(requestedFields, MARTHA_V3_ACCESS_ID_FIELDS) &&
             (this.forceAccessUrl || (accessMethod &&
                 this.accessMethods.find((m) => m.accessMethodType === accessMethod.type &&
-                    [m.accessUrlAuth, m.fallbackAccessUrlAuth].includes(AccessUrlAuth.FENCE_TOKEN) &&
+                    (!useFallbackAuth || m.fallbackAccessUrlAuth === AccessUrlAuth.FENCE_TOKEN) &&
+                    (useFallbackAuth || m.accessUrlAuth === AccessUrlAuth.FENCE_TOKEN) &&
                     m.fetchAccessUrl === FetchAccessUrl.YES)));
     }
 

--- a/martha/drs_providers.js
+++ b/martha/drs_providers.js
@@ -224,7 +224,8 @@ class PassportTestDrsProvider extends DrsProvider {
             MetadataAuth.NO,
             BondProvider.NONE,
             [
-                new AccessMethod(AccessMethodType.GCS, AccessUrlAuth.PASSPORT, FetchAccessUrl.YES)
+                new AccessMethod(AccessMethodType.GCS, AccessUrlAuth.PASSPORT, FetchAccessUrl.YES),
+                new AccessMethod(AccessMethodType.S3, AccessUrlAuth.PASSPORT, FetchAccessUrl.YES)
             ],
             forceAccessUrl
         );

--- a/martha/martha_v3.js
+++ b/martha/martha_v3.js
@@ -481,7 +481,7 @@ async function retrieveFromServers(params) {
                         const providerAccessMethod = drsProvider.accessMethodHavingSameTypeAs(accessMethod);
                         console.log(`Requesting DRS access URL for '${url}' from '${httpsAccessUrl}'`);
 
-                        let accessUrlFirstTry = await getAccessUrl(providerAccessMethod.accessUrlAuth, httpsAccessUrl, accessToken, auth);
+                        const accessUrlFirstTry = await getAccessUrl(providerAccessMethod.accessUrlAuth, httpsAccessUrl, accessToken, auth);
                         if (!accessUrlFirstTry && providerAccessMethod.fallbackAccessUrlAuth) {
                             console.log(`Requesting DRS access URL for '${url}' from '${httpsAccessUrl}' with fallback auth`);
                             const fallbackAccessToken = await maybeFetchFenceAccessToken(accessMethod, true);
@@ -492,7 +492,7 @@ async function retrieveFromServers(params) {
                     } catch (error) {
                         throw new RemoteServerError(error, 'Received error contacting DRS provider.');
                     }
-                }
+                };
                 accessUrl = await fetchAccessUrl();
             }
         } catch (error) {

--- a/martha/martha_v3.js
+++ b/martha/martha_v3.js
@@ -358,26 +358,31 @@ async function retrieveFromServers(params) {
     let hypotheticalErrorMessage;
 
     const getAccessUrl = async (accessUrlAuth, httpsAccessUrl, accessToken, auth) => {
-        if (accessUrlAuth === AccessUrlAuth.PASSPORT) {
-            if (passports) {
-                try {
-                    return await apiAdapter.postJsonTo(httpsAccessUrl, null, {passports});
-                } catch (error) {
-                    console.log(`Passport authorized request failed for ${httpsAccessUrl} with error ${error}`);
+        switch (accessUrlAuth) {
+            case AccessUrlAuth.PASSPORT:
+                if (passports) {
+                    try {
+                        return await apiAdapter.postJsonTo(httpsAccessUrl, null, {passports});
+                    } catch (error) {
+                        console.log(`Passport authorized request failed for ${httpsAccessUrl} with error ${error}`);
+                    }
                 }
-            }
-        } else if (accessUrlAuth === AccessUrlAuth.CURRENT_REQUEST) {
-            return apiAdapter.getJsonFrom(httpsAccessUrl, auth);
-        } else if (accessUrlAuth === AccessUrlAuth.FENCE_TOKEN) {
-            if (accessToken) {
-                return apiAdapter.getJsonFrom(httpsAccessUrl, `Bearer ${accessToken}`);
-            } else {
-                throw new BadRequestError(`Fence access token required for ${httpsAccessUrl} but is missing. Does use have an account linked in Bond?`);
-            }
+                // if we made it this far, there are no passports or there was an error using them so return nothing.
+                return;
 
-        } else {
-            throw new BadRequestError(
-                `Programmer error: 'determineAccessUrlAuth' called with AccessUrlAuth.${accessUrlAuth} for provider ${this.providerName}`);
+            case AccessUrlAuth.CURRENT_REQUEST:
+                return apiAdapter.getJsonFrom(httpsAccessUrl, auth);
+
+            case AccessUrlAuth.FENCE_TOKEN:
+                if (accessToken) {
+                    return apiAdapter.getJsonFrom(httpsAccessUrl, `Bearer ${accessToken}`);
+                } else {
+                    throw new BadRequestError(`Fence access token required for ${httpsAccessUrl} but is missing. Does use have an account linked in Bond?`);
+                }
+
+            default:
+                throw new BadRequestError(
+                    `Programmer error: 'determineAccessUrlAuth' called with AccessUrlAuth.${accessUrlAuth} for provider ${this.providerName}`);
         }
     };
 

--- a/martha/martha_v3.js
+++ b/martha/martha_v3.js
@@ -364,7 +364,7 @@ async function retrieveFromServers(params) {
             let accessUrl;
             try {
                 if (passports) {
-                    accessUrl = await apiAdapter.postJsonTo(httpsAccessUrl, null, {"passports": passports});
+                    accessUrl = await apiAdapter.postJsonTo(httpsAccessUrl, null, {passports});
                 }
             } catch (error) {
                 console.log(`Passport authorized request failed for ${httpsAccessUrl} with error ${error}, falling back to ${fallbackAccessUrlAuth} authorization`);

--- a/martha/martha_v3.js
+++ b/martha/martha_v3.js
@@ -446,11 +446,14 @@ async function retrieveFromServers(params) {
                     switch (providerAccessMethod.accessUrlAuth) {
                         case AccessUrlAuth.FENCE_TOKEN:
                             accessUrl = await apiAdapter.getJsonFrom(httpsAccessUrl, `Bearer ${accessToken}`);
+                            break;
                         case AccessUrlAuth.CURRENT_REQUEST:
                             accessUrl = await apiAdapter.getJsonFrom(httpsAccessUrl, auth);
+                            break;
                         case AccessUrlAuth.PASSPORT:
                             accessUrl = await apiAdapter.postJsonTo(httpsAccessUrl, null,
                                 {"passports": passports});
+                            break;
                         default:
                             throw new BadRequestError(
                                 `Programmer error: 'determineAccessUrlAuth' called with AccessUrlAuth.${providerAccessMethod.accessUrlAuth} for provider ${this.providerName}`);

--- a/martha/martha_v3.js
+++ b/martha/martha_v3.js
@@ -357,6 +357,8 @@ async function retrieveFromServers(params) {
     // try doing just before we do it so that we can provide that detail in the error report.
     let hypotheticalErrorMessage;
 
+    // TODO: test that ecm is called when it should be
+    //  test that if (accessUrlAuth === AccessUrlAuth.PASSPORT), then it should use postJsonToApiStub with a "passport" payload, and if it errors use the fallbackAccessUrlAuth
     const getAccessUrl = async (args) => {
         const { providerAccessMethod: {accessUrlAuth, fallbackAccessUrlAuth}, httpsAccessUrl, accessToken, auth } = args;
 
@@ -417,6 +419,7 @@ async function retrieveFromServers(params) {
             }
         }
 
+        // TODO: test this to make sure that when it hits this it fetches a passport correctly, and fails correctly
         if (drsProvider.shouldFetchPassports(accessMethod, requestedFields)) {
             try {
                 // For now, we are only getting a RAS passport. In the future it may also fetch from other providers.
@@ -470,6 +473,7 @@ async function retrieveFromServers(params) {
                 }
             }
 
+            // TODO: maybe check here too
             // Retrieve the accessUrl using the returned accessToken, even if the token was empty.
             if (drsProvider.shouldFetchAccessUrl(accessMethod, requestedFields)) {
                 try {

--- a/martha/martha_v3.js
+++ b/martha/martha_v3.js
@@ -364,7 +364,7 @@ async function retrieveFromServers(params) {
             try {
                 return await apiAdapter.postJsonTo(httpsAccessUrl, null, {"passports": passports});
             } catch (error) {
-                console.log(`Passport authorized request failed for ${httpsAccessUrl} with error ${error}, falling back to ${fallbackAccessUrlAuth} authorization`)
+                console.log(`Passport authorized request failed for ${httpsAccessUrl} with error ${error}, falling back to ${fallbackAccessUrlAuth} authorization`);
                 // retry with fallbackAccessUrlAuth
                 return getAccessUrl({ ...args, providerAccessMethod: { accessUrlAuth: fallbackAccessUrlAuth }});
             }
@@ -374,7 +374,7 @@ async function retrieveFromServers(params) {
             if (accessToken) {
                 return apiAdapter.getJsonFrom(httpsAccessUrl, `Bearer ${accessToken}`);
             } else {
-                throw new BadRequestError(`Fence access token required for ${httpsAccessUrl} but is missing. Does use have an account linked in Bond?`)
+                throw new BadRequestError(`Fence access token required for ${httpsAccessUrl} but is missing. Does use have an account linked in Bond?`);
             }
 
         } else {

--- a/martha/martha_v3.js
+++ b/martha/martha_v3.js
@@ -373,7 +373,7 @@ async function retrieveFromServers(params) {
                 // didn't get an access url using passport, try with fallback
                 accessUrl = getAccessUrl({ ...args, providerAccessMethod: { accessUrlAuth: fallbackAccessUrlAuth }});
             }
-            return accessUrl
+            return accessUrl;
         } else if (accessUrlAuth === AccessUrlAuth.CURRENT_REQUEST) {
             return apiAdapter.getJsonFrom(httpsAccessUrl, auth);
         } else if (accessUrlAuth === AccessUrlAuth.FENCE_TOKEN) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,6 @@
   "requires": true,
   "packages": {
     "": {
-      "name": "martha",
       "version": "0.0.0",
       "dependencies": {
         "@google-cloud/functions-framework": "^1.7.1",

--- a/test/common/config_test.js
+++ b/test/common/config_test.js
@@ -6,11 +6,13 @@ const tmp = require('tmp');
 test('configDefaultsFrom should get the right answer for the mock environment', (t) => {
     const expectedForMock = {
         samBaseUrl: `https://sam.dsde-dev.broadinstitute.org`,
+        externalcredsBaseUrl: 'https://externalcreds.dsde-dev.broadinstitute.org',
         bondBaseUrl: 'http://127.0.0.1:8080',
         bioDataCatalystHost: config.HOST_MOCK_DRS,
         theAnvilHost: config.HOST_MOCK_DRS,
         crdcHost: config.HOST_MOCK_DRS,
         kidsFirstHost: config.HOST_MOCK_DRS,
+        passportTestHost: config.HOST_MOCK_DRS,
         itMarthaBaseUrl: 'http://localhost:8010',
         itBondBaseUrl: 'http://127.0.0.1:8080'
     };
@@ -20,11 +22,13 @@ test('configDefaultsFrom should get the right answer for the mock environment', 
 test('configDefaultsFrom should get the right answer for the dev environment', (t) => {
     const expectedForDev = {
         samBaseUrl: `https://sam.dsde-dev.broadinstitute.org`,
+        externalcredsBaseUrl: 'https://externalcreds.dsde-dev.broadinstitute.org',
         bondBaseUrl: 'https://broad-bond-dev.appspot.com',
         bioDataCatalystHost: config.HOST_BIODATA_CATALYST_STAGING,
         theAnvilHost: config.HOST_THE_ANVIL_STAGING,
         crdcHost: config.HOST_CRDC_STAGING,
         kidsFirstHost: config.HOST_KIDS_FIRST_STAGING,
+        passportTestHost: config.HOST_PASSPORT_TEST,
         itMarthaBaseUrl: 'https://martha-fiab.dsde-dev.broadinstitute.org:32443',
         itBondBaseUrl: 'https://bond-fiab.dsde-dev.broadinstitute.org:31443'
     };
@@ -34,11 +38,13 @@ test('configDefaultsFrom should get the right answer for the dev environment', (
 test('configDefaultsFrom should get the right answer for the Cromwell dev environment', (t) => {
     const expectedForCromwellDev = {
         samBaseUrl: `https://sam.dsde-dev.broadinstitute.org`,
+        externalcredsBaseUrl: 'https://externalcreds.dsde-dev.broadinstitute.org',
         bondBaseUrl: 'https://broad-bond-dev.appspot.com',
         bioDataCatalystHost: config.HOST_BIODATA_CATALYST_STAGING,
         theAnvilHost: config.HOST_THE_ANVIL_STAGING,
         crdcHost: config.HOST_CRDC_STAGING,
         kidsFirstHost: config.HOST_KIDS_FIRST_STAGING,
+        passportTestHost: config.HOST_PASSPORT_TEST,
         itMarthaBaseUrl: 'https://martha-fiab.dsde-dev.broadinstitute.org:32443',
         itBondBaseUrl: 'https://bond-fiab.dsde-dev.broadinstitute.org:31443'
     };
@@ -48,11 +54,13 @@ test('configDefaultsFrom should get the right answer for the Cromwell dev enviro
 test('configDefaultsFrom should get the right answer for the production environment', (t) => {
     const expectedForProduction = {
         samBaseUrl: `https://sam.dsde-prod.broadinstitute.org`,
+        externalcredsBaseUrl: 'https://externalcreds.dsde-prod.broadinstitute.org',
         bondBaseUrl: 'https://broad-bond-prod.appspot.com',
         bioDataCatalystHost: config.HOST_BIODATA_CATALYST_PROD,
         theAnvilHost: config.HOST_THE_ANVIL_PROD,
         crdcHost: config.HOST_CRDC_PROD,
         kidsFirstHost: config.HOST_KIDS_FIRST_PROD,
+        passportTestHost: config.HOST_PASSPORT_TEST,
         itMarthaBaseUrl: 'https://martha-fiab.dsde-prod.broadinstitute.org:32443',
         itBondBaseUrl: 'https://bond-fiab.dsde-prod.broadinstitute.org:31443'
     };

--- a/test/martha/_martha_v3_resources.js
+++ b/test/martha/_martha_v3_resources.js
@@ -496,6 +496,38 @@ const kidsFirstDrsMarthaResult = (expectedAccessUrl) => {
     };
 };
 
+// passport test response
+
+const passportTestResponse = {
+    "access_methods": [{
+        "access_id": "gs",
+        "access_url": {"url": "gs://ctds-test-controlled-a/testdata.txt"},
+        "region": "",
+        "type": "gs",
+    }, {
+        "access_id": "s3",
+        "access_url": {"url": "s3://cdis-presigned-url-test/testdata"},
+        "region": "",
+        "type": "s3",
+    }],
+    "aliases": [],
+    "checksums": [{
+        "checksum": "f8a0ddfc5202e67c8c98583c0acfbbdc",
+        "type": "md5",
+    }],
+    "contents": [],
+    "created_time": "2021-11-22T18:01:37.150334",
+    "description": null,
+    "form": "object",
+    "id": "000311ea-64e4-4462-9582-00562eb757aa",
+    "mime_type": "application/json",
+    "name": "",
+    "self_uri": "drs://dg.TEST0/000311ea-64e4-4462-9582-00562eb757aa",
+    "size": 42,
+    "updated_time": "2021-11-23T16:30:44.463962",
+    "version": "64bbb8c7",
+};
+
 // BDC
 
 const bdcDrsResponse = {
@@ -692,5 +724,6 @@ module.exports = {
     kidsFirstDrsResponse,
     kidsFirstDrsResponseCustom,
     kidsFirstDrsMarthaResult,
+    passportTestResponse,
     jadeAccessUrlMetadataResponse,
 };

--- a/test/martha/integration_v3.test.js
+++ b/test/martha/integration_v3.test.js
@@ -29,7 +29,8 @@ const authorizedEmail = `hermione.owner@${emailDomain}`;
 const publicFenceUrl = 'dos://dg.4503/preview_dos.json';
 const protectedFenceUrl = 'dos://dg.4503/65e4cd14-f549-4a7f-ad0c-d29212ff6e46';
 const fenceAuthLink =
-    `${myBondBaseUrl}/api/link/v1/fence/oauthcode` +
+    `${myBondBaseUrl}/api/link/v1/fence/
+    oauthcode` +
     '?oauthcode=IgnoredByMockProvider' +
     '&redirect_uri=http%3A%2F%2Flocal.broadinstitute.org%2F%23fence-callback';
 

--- a/test/martha/integration_v3.test.js
+++ b/test/martha/integration_v3.test.js
@@ -29,8 +29,7 @@ const authorizedEmail = `hermione.owner@${emailDomain}`;
 const publicFenceUrl = 'dos://dg.4503/preview_dos.json';
 const protectedFenceUrl = 'dos://dg.4503/65e4cd14-f549-4a7f-ad0c-d29212ff6e46';
 const fenceAuthLink =
-    `${myBondBaseUrl}/api/link/v1/fence/
-    oauthcode` +
+    `${myBondBaseUrl}/api/link/v1/fence/oauthcode` +
     '?oauthcode=IgnoredByMockProvider' +
     '&redirect_uri=http%3A%2F%2Flocal.broadinstitute.org%2F%23fence-callback';
 

--- a/test/martha/martha_v3.test.js
+++ b/test/martha/martha_v3.test.js
@@ -132,6 +132,8 @@ const bdc = config.HOST_BIODATA_CATALYST_STAGING;
 const crdc = config.HOST_CRDC_STAGING;
 const kidsFirst = config.HOST_KIDS_FIRST_STAGING;
 
+// TODO: add postJsonToApiStub (used to get access url with passport)
+
 let getJsonFromApiStub;
 const getJsonFromApiMethodName = 'getJsonFrom';
 
@@ -152,6 +154,10 @@ test.serial('martha_v3 uses the default error handler for unexpected errors', as
     t.is(actualError, expectedError);
     sinon.assert.callCount(response.send, 0);
 });
+
+// TODO: add ecm related tests here
+// TODO: test that if (accessUrlAuth === AccessUrlAuth.PASSPORT), then it should use postJsonToApiStub with a "passport" payload, and if it errors use the fallbackAccessUrlAuth
+// TODO: test that if (drsProvider.shouldFetchPassports(accessMethod, requestedFields)), it fetches a passport correctly from ecm, and fails correctly if a passport is not present
 
 // According to the DRS specification authors [0] it's OK for a client to call Martha with a `drs://` URI and get
 // back a DOS object. Martha should just "do the right thing" and return whichever format the server supports,

--- a/test/martha/martha_v3.test.js
+++ b/test/martha/martha_v3.test.js
@@ -178,8 +178,8 @@ test.serial('martha_v3 calls the correct endpoints when only the accessUrl is re
     const drs = drsUrls(config.HOST_PASSPORT_TEST, objectId, accessId);
     const drsAccessUrlResponse = mockGcsAccessUrl(gcsUrl);
     getJsonFromApiStub.withArgs(drs.objectsUrl, null).resolves(passportTestResponse);
-    getJsonFromApiStub.withArgs(bondUrls(BondProviders.DCF_FENCE), terraAuth).resolves(bondAccessTokenResponse);
-    getJsonFromApiStub.withArgs(ecmUrls('ras'), terraAuth).resolves(passport);
+    getJsonFromApiStub.withArgs(bondUrls(BondProviders.DCF_FENCE).accessTokenUrl, terraAuth).resolves(bondAccessTokenResponse);
+    getJsonFromApiStub.withArgs(ecmUrls('ras').passportUrl, terraAuth).resolves(passport);
     postJsonToApiStub.withArgs(drs.accessUrl, null, {"passports": [passport]}).resolves(drsAccessUrlResponse);
     const response = mockResponse();
     const request = mockRequest({body: {url: drsUri, fields: ['accessUrl']}});
@@ -190,6 +190,7 @@ test.serial('martha_v3 calls the correct endpoints when only the accessUrl is re
     t.deepEqual(response.body, { accessUrl: drsAccessUrlResponse });
 
     sinon.assert.callCount(getJsonFromApiStub, 3);
+    sinon.assert.callCount(postJsonToApiStub, 1);
 });
 
 // According to the DRS specification authors [0] it's OK for a client to call Martha with a `drs://` URI and get

--- a/test/martha/martha_v3.test.js
+++ b/test/martha/martha_v3.test.js
@@ -168,7 +168,7 @@ test.serial('martha_v3 uses the default error handler for unexpected errors', as
 test.serial('martha_v3 calls the correct endpoints when only the accessUrl is requested with passports', async (t) => {
     const {
         id: objectId, self_uri: drsUri,
-        access_methods: { 0: { access_id: accessId, access_url: { url: gcsUrl } } }
+        access_methods: [{ access_id: accessId, access_url: { url: gcsUrl } }]
     } = passportTestResponse;
     const passport = '"I am a passport"';
     const drs = drsUrls(config.HOST_PASSPORT_TEST, objectId, accessId);
@@ -192,7 +192,7 @@ test.serial('martha_v3 calls the correct endpoints when only the accessUrl is re
 test.serial('martha_v3 calls the correct endpoints when only the accessUrl is requested with passports but using fallback', async (t) => {
     const {
         id: objectId, self_uri: drsUri,
-        access_methods: { 0: { access_id: accessId, access_url: { url: gcsUrl } } }
+        access_methods: [{ access_id: accessId, access_url: { url: gcsUrl } }]
     } = passportTestResponse;
     const drs = drsUrls(config.HOST_PASSPORT_TEST, objectId, accessId);
     const drsAccessUrlResponse = mockGcsAccessUrl(gcsUrl);

--- a/test/martha/martha_v3.test.js
+++ b/test/martha/martha_v3.test.js
@@ -165,10 +165,6 @@ test.serial('martha_v3 uses the default error handler for unexpected errors', as
     sinon.assert.callCount(response.send, 0);
 });
 
-// TODO: add ecm related tests here
-// TODO: test that if (accessUrlAuth === AccessUrlAuth.PASSPORT), then it should use postJsonToApiStub with a "passport" payload, and if it errors use the fallbackAccessUrlAuth
-// TODO: test that if (drsProvider.shouldFetchPassports(accessMethod, requestedFields)), it fetches a passport correctly from ecm, and fails correctly if a passport is not present
-
 test.serial('martha_v3 calls the correct endpoints when only the accessUrl is requested with passports', async (t) => {
     const {
         id: objectId, self_uri: drsUri,

--- a/test/martha/martha_v3.test.js
+++ b/test/martha/martha_v3.test.js
@@ -1379,7 +1379,7 @@ test.serial('martha_v3 should return 4xx with an unrecognized CIB hostname', asy
         {
             response: {
                 status: 400,
-                text: `Request is invalid. Unrecognized Compact Identifier Based host 'dg.CAFE.'`,
+                text: `Request is invalid. Unrecognized Compact Identifier Based host 'dg.CAFE'.`,
             },
             status: 400,
         },

--- a/test/martha/martha_v3.test.js
+++ b/test/martha/martha_v3.test.js
@@ -174,7 +174,6 @@ test.serial('martha_v3 calls the correct endpoints when only the accessUrl is re
     const drs = drsUrls(config.HOST_PASSPORT_TEST, objectId, accessId);
     const drsAccessUrlResponse = mockGcsAccessUrl(gcsUrl);
     getJsonFromApiStub.withArgs(drs.objectsUrl, null).resolves(passportTestResponse);
-    getJsonFromApiStub.withArgs(bondUrls(BondProviders.DCF_FENCE).accessTokenUrl, terraAuth).resolves(bondAccessTokenResponse);
     getJsonFromApiStub.withArgs(ecmUrls('ras').passportUrl, terraAuth).resolves(passport);
     postJsonToApiStub.withArgs(drs.accessUrl, null, {"passports": [passport]}).resolves(drsAccessUrlResponse);
     const response = mockResponse();
@@ -185,7 +184,7 @@ test.serial('martha_v3 calls the correct endpoints when only the accessUrl is re
     t.is(response.statusCode, 200);
     t.deepEqual(response.body, { accessUrl: drsAccessUrlResponse });
 
-    sinon.assert.callCount(getJsonFromApiStub, 3);
+    sinon.assert.callCount(getJsonFromApiStub, 2);
     sinon.assert.callCount(postJsonToApiStub, 1);
 });
 


### PR DESCRIPTION
Added support for `AccessUrlAuth.PASSPORT`. If the provider has this set, when an `accessUrl` is requested, martha will query externalcreds for a user's passport and make a `POST` request to get the `accessUrl`. If this fails, martha will use a fallback authentication mechanism which for Gen3 will be `AccessUrlAuth.FENCE_TOKEN`. In the process retries were added to `api_adapter.postJsonTo`.

For now a new drs provider was added called `PassportTestDrsProvider` which handles compact id `dg.test0`.