### PR TITLE
Update key rotation instructions

### DIFF
--- a/docs/deployment-key-rotation.md
+++ b/docs/deployment-key-rotation.md
@@ -3,7 +3,7 @@ Martha Deployment Key Rotation
 
 The service account key used to deploy Martha needs to be rotated every 90 days.
 
-1. Find the current BT ticket for rotating the deployment SA key. If these instructions were followed, it will be in the Slack notification that led you here. Add it to the current Jira board if it's not already there.
+1. Find the current WX ticket for rotating the deployment SA key. If these instructions were followed, it will be in the Slack notification that led you here. Add it to the current Jira board if it's not already there.
 2. [Run the full manual test on the prod environment](https://docs.google.com/document/d/1-SXw-tgt1tb3FEuNCGHWIZJ304POmfz5ragpphlq2Ng). Not strictly necessary, but this is expected to pass and sets a current baseline to avoid surprises if the post-rotation test deploy fails.
 3. Using your `@firecloud.org` account, [create a new key for the `cloud-functions-account@broad-dsde-prod.iam.gserviceaccount.com` service account](https://console.cloud.google.com/iam-admin/serviceaccounts/details/107440104000315564432/keys?project=broad-dsde-prod).
    1. Click `[ADD KEY]` > `Create new key`
@@ -11,7 +11,7 @@ The service account key used to deploy Martha needs to be rotated every 90 days.
    3. Click `[CREATE]` and make sure the key `.json` file downloads to your computer
 4. Write this new key to vault.
 ```
-vault write secret/dsde/martha/prod/deploy-account.json @[key .json file]
+vault write secret/dsde/martha/prod/deploy-account.json @/path/to/key.json
 ```
 5. Disable or delete the existing key (id found on above page). Using your `@firecloud.org` account:
 ```
@@ -23,5 +23,5 @@ gcloud iam service-accounts keys disable [key_id] --iam-account=cloud-functions-
 8. Clone the Jira ticket you've been working on, without cloning links or sprint fields. Update the due date to be 12 weeks (84 days) from today (which gives about a week to respond when the time comes).
 9. Add a slack reminder in `#dsp-batch-private` to trigger 84 days from today. Make sure to include links to these instructions and the Jira ticket you just created.
 ```
-/remind #dsp-batch-private :redalert: Reminder to rotate the service account key for Martha prod deploys. https://github.com/broadinstitute/martha/blob/dev/docs/deployment-key-rotation.md [Link to Jira ticket] :redalert: at 9am in 84 days
+/remind #dsp-workflows-private :redalert: Reminder to rotate the service account key for Martha prod deploys. https://github.com/broadinstitute/martha/blob/dev/docs/deployment-key-rotation.md [Link to Jira ticket] :redalert: at 9am in 84 days
 ```

--- a/docs/deployment-key-rotation.md
+++ b/docs/deployment-key-rotation.md
@@ -13,15 +13,15 @@ The service account key used to deploy Martha needs to be rotated every 90 days.
 ```
 vault write secret/dsde/martha/prod/deploy-account.json @/path/to/key.json
 ```
-6. Go to the [Jenkins prod manual deploy project](https://fcprod-jenkins.dsp-techops.broadinstitute.org/job/martha-manual-deploy/) and re-run the last Martha prod job. This will re-deploy the current version of Martha, verifying that the new service account key works.
-7. Again, [run the full manual test on the prod environment](https://docs.google.com/document/d/1-SXw-tgt1tb3FEuNCGHWIZJ304POmfz5ragpphlq2Ng) to make sure Martha still works.
-8. Disable or delete the old key(s) from [the list](https://console.cloud.google.com/iam-admin/serviceaccounts/details/107440104000315564432/keys?project=broad-dsde-prod). Only the one created today should remain. Using your `@firecloud.org` account:
+5. Go to the [Jenkins prod manual deploy project](https://fcprod-jenkins.dsp-techops.broadinstitute.org/job/martha-manual-deploy/) and re-run the last Martha prod job. This will re-deploy the current version of Martha, verifying that the new service account key works.
+6. Again, [run the full manual test on the prod environment](https://docs.google.com/document/d/1-SXw-tgt1tb3FEuNCGHWIZJ304POmfz5ragpphlq2Ng) to make sure Martha still works.
+7. Disable or delete the old key(s) from [the list](https://console.cloud.google.com/iam-admin/serviceaccounts/details/107440104000315564432/keys?project=broad-dsde-prod). Only the one created today should remain. Using your `@firecloud.org` account:
 ```
 gcloud config set project broad-dsde-prod
 gcloud iam service-accounts keys disable [key_id] --iam-account=cloud-functions-account@broad-dsde-prod.iam.gserviceaccount.com
 ```
-9. Clone the Jira ticket you've been working on, without cloning links or sprint fields. Update the due date to be 12 weeks (84 days) from today (which gives about a week to respond when the time comes).
-10. Add a slack reminder in `#dsp-batch-private` to trigger 84 days from today. Make sure to include links to these instructions and the Jira ticket you just created.
+8. Clone the Jira ticket you've been working on, without cloning links or sprint fields. Update the due date to be 12 weeks (84 days) from today (which gives about a week to respond when the time comes).
+9. Add a slack reminder in `#dsp-batch-private` to trigger 84 days from today. Make sure to include links to these instructions and the Jira ticket you just created.
 ```
 /remind #dsp-workflows-private :redalert: Reminder to rotate the service account key for Martha prod deploys. https://github.com/broadinstitute/martha/blob/dev/docs/deployment-key-rotation.md [Link to Jira ticket] :redalert: at 9am in 84 days
 ```

--- a/docs/deployment-key-rotation.md
+++ b/docs/deployment-key-rotation.md
@@ -13,13 +13,10 @@ The service account key used to deploy Martha needs to be rotated every 90 days.
 ```
 vault write secret/dsde/martha/prod/deploy-account.json @/path/to/key.json
 ```
-5. Go to the [Jenkins prod manual deploy project](https://fcprod-jenkins.dsp-techops.broadinstitute.org/job/martha-manual-deploy/) and re-run the last Martha prod job. This will re-deploy the current version of Martha, verifying that the new service account key works.
-6. Again, [run the full manual test on the prod environment](https://docs.google.com/document/d/1-SXw-tgt1tb3FEuNCGHWIZJ304POmfz5ragpphlq2Ng) to make sure Martha still works.
-7. Delete the old key(s) from [the list](https://console.cloud.google.com/iam-admin/serviceaccounts/details/107440104000315564432/keys?project=broad-dsde-prod). Only the one created today should remain. Using your `@firecloud.org` account:
-```
-gcloud config set project broad-dsde-prod
-gcloud iam service-accounts keys disable [key_id] --iam-account=cloud-functions-account@broad-dsde-prod.iam.gserviceaccount.com
-```
+5. Delete the old key(s) from [the list](https://console.cloud.google.com/iam-admin/serviceaccounts/details/107440104000315564432/keys?project=broad-dsde-prod) by selecting the trash can icon. Only the one created today should remain.
+
+6. Go to the [Jenkins prod manual deploy project](https://fcprod-jenkins.dsp-techops.broadinstitute.org/job/martha-manual-deploy/) and re-run the last Martha prod job. This will re-deploy the current version of Martha, verifying that the new service account key works.
+7. Again, [run the full manual test on the prod environment](https://docs.google.com/document/d/1-SXw-tgt1tb3FEuNCGHWIZJ304POmfz5ragpphlq2Ng) to make sure Martha still works.
 8. Clone the Jira ticket you've been working on, without cloning links or sprint fields. Update the due date to be 12 weeks (84 days) from today (which gives about a week to respond when the time comes).
 9. Add a slack reminder in `#dsp-batch-private` to trigger 84 days from today. Make sure to include links to these instructions and the Jira ticket you just created.
 ```

--- a/docs/deployment-key-rotation.md
+++ b/docs/deployment-key-rotation.md
@@ -13,15 +13,15 @@ The service account key used to deploy Martha needs to be rotated every 90 days.
 ```
 vault write secret/dsde/martha/prod/deploy-account.json @/path/to/key.json
 ```
-5. Disable or delete the existing key (id found on above page). Using your `@firecloud.org` account:
+6. Go to the [Jenkins prod manual deploy project](https://fcprod-jenkins.dsp-techops.broadinstitute.org/job/martha-manual-deploy/) and re-run the last Martha prod job. This will re-deploy the current version of Martha, verifying that the new service account key works.
+7. Again, [run the full manual test on the prod environment](https://docs.google.com/document/d/1-SXw-tgt1tb3FEuNCGHWIZJ304POmfz5ragpphlq2Ng) to make sure Martha still works.
+8. Disable or delete the old key(s) from [the list](https://console.cloud.google.com/iam-admin/serviceaccounts/details/107440104000315564432/keys?project=broad-dsde-prod). Only the one created today should remain. Using your `@firecloud.org` account:
 ```
 gcloud config set project broad-dsde-prod
 gcloud iam service-accounts keys disable [key_id] --iam-account=cloud-functions-account@broad-dsde-prod.iam.gserviceaccount.com
 ```
-6. Go to the [Jenkins prod manual deploy project](https://fcprod-jenkins.dsp-techops.broadinstitute.org/job/martha-manual-deploy/) and re-run the last Martha prod job. This will re-deploy the current version of Martha, verifying that the new service account key works.
-7. Again, [run the full manual test on the prod environment](https://docs.google.com/document/d/1-SXw-tgt1tb3FEuNCGHWIZJ304POmfz5ragpphlq2Ng) to make sure Martha still works.
-8. Clone the Jira ticket you've been working on, without cloning links or sprint fields. Update the due date to be 12 weeks (84 days) from today (which gives about a week to respond when the time comes).
-9. Add a slack reminder in `#dsp-batch-private` to trigger 84 days from today. Make sure to include links to these instructions and the Jira ticket you just created.
+9. Clone the Jira ticket you've been working on, without cloning links or sprint fields. Update the due date to be 12 weeks (84 days) from today (which gives about a week to respond when the time comes).
+10. Add a slack reminder in `#dsp-batch-private` to trigger 84 days from today. Make sure to include links to these instructions and the Jira ticket you just created.
 ```
 /remind #dsp-workflows-private :redalert: Reminder to rotate the service account key for Martha prod deploys. https://github.com/broadinstitute/martha/blob/dev/docs/deployment-key-rotation.md [Link to Jira ticket] :redalert: at 9am in 84 days
 ```

--- a/docs/deployment-key-rotation.md
+++ b/docs/deployment-key-rotation.md
@@ -4,7 +4,7 @@ Martha Deployment Key Rotation
 The service account key used to deploy Martha needs to be rotated every 90 days.
 
 1. Find the current WX ticket for rotating the deployment SA key. If these instructions were followed, it will be in the Slack notification that led you here. Add it to the current Jira board if it's not already there.
-2. [Run the full manual test on the prod environment](https://docs.google.com/document/d/1-SXw-tgt1tb3FEuNCGHWIZJ304POmfz5ragpphlq2Ng). Not strictly necessary, but this is expected to pass and sets a current baseline to avoid surprises if the post-rotation test deploy fails.
+2. [Run the full manual test on the prod environment](https://docs.google.com/document/d/1-SXw-tgt1tb3FEuNCGHWIZJ304POmfz5ragpphlq2Ng). This is expected to pass and sets a current baseline to avoid surprises if the post-rotation test deploy fails.
 3. Using your `@firecloud.org` account, [create a new key for the `cloud-functions-account@broad-dsde-prod.iam.gserviceaccount.com` service account](https://console.cloud.google.com/iam-admin/serviceaccounts/details/107440104000315564432/keys?project=broad-dsde-prod).
    1. Click `[ADD KEY]` > `Create new key`
    2. Select the JSON key type
@@ -15,7 +15,7 @@ vault write secret/dsde/martha/prod/deploy-account.json @/path/to/key.json
 ```
 5. Go to the [Jenkins prod manual deploy project](https://fcprod-jenkins.dsp-techops.broadinstitute.org/job/martha-manual-deploy/) and re-run the last Martha prod job. This will re-deploy the current version of Martha, verifying that the new service account key works.
 6. Again, [run the full manual test on the prod environment](https://docs.google.com/document/d/1-SXw-tgt1tb3FEuNCGHWIZJ304POmfz5ragpphlq2Ng) to make sure Martha still works.
-7. Disable or delete the old key(s) from [the list](https://console.cloud.google.com/iam-admin/serviceaccounts/details/107440104000315564432/keys?project=broad-dsde-prod). Only the one created today should remain. Using your `@firecloud.org` account:
+7. Delete the old key(s) from [the list](https://console.cloud.google.com/iam-admin/serviceaccounts/details/107440104000315564432/keys?project=broad-dsde-prod). Only the one created today should remain. Using your `@firecloud.org` account:
 ```
 gcloud config set project broad-dsde-prod
 gcloud iam service-accounts keys disable [key_id] --iam-account=cloud-functions-account@broad-dsde-prod.iam.gserviceaccount.com

--- a/docs/deployment-key-rotation.md
+++ b/docs/deployment-key-rotation.md
@@ -5,20 +5,24 @@ The service account key used to deploy Martha needs to be rotated every 90 days.
 
 1. Find the current WX ticket for rotating the deployment SA key. If these instructions were followed, it will be in the Slack notification that led you here. Add it to the current Jira board if it's not already there.
 2. [Run the full manual test on the prod environment](https://docs.google.com/document/d/1-SXw-tgt1tb3FEuNCGHWIZJ304POmfz5ragpphlq2Ng). This is expected to pass and sets a current baseline to avoid surprises if the post-rotation test deploy fails.
-3. Using your `@firecloud.org` account, [create a new key for the `cloud-functions-account@broad-dsde-prod.iam.gserviceaccount.com` service account](https://console.cloud.google.com/iam-admin/serviceaccounts/details/107440104000315564432/keys?project=broad-dsde-prod).
+3. Disable all existing key(s) on [this list](https://console.cloud.google.com/iam-admin/serviceaccounts/details/107440104000315564432/keys?project=broad-dsde-prod). Using your @firecloud.org account:
+```
+gcloud config set project broad-dsde-prod
+gcloud iam service-accounts keys disable [key_id] --iam-account=cloud-functions-account@broad-dsde-prod.iam.gserviceaccount.com
+```
+4. Using your `@firecloud.org` account, [create a new key for the `cloud-functions-account@broad-dsde-prod.iam.gserviceaccount.com` service account](https://console.cloud.google.com/iam-admin/serviceaccounts/details/107440104000315564432/keys?project=broad-dsde-prod).
    1. Click `[ADD KEY]` > `Create new key`
    2. Select the JSON key type
    3. Click `[CREATE]` and make sure the key `.json` file downloads to your computer
-4. Write this new key to vault.
+5. Write this new key to vault.
 ```
 vault write secret/dsde/martha/prod/deploy-account.json @/path/to/key.json
 ```
-5. Delete the old key(s) from [the list](https://console.cloud.google.com/iam-admin/serviceaccounts/details/107440104000315564432/keys?project=broad-dsde-prod) by selecting the trash can icon. Only the one created today should remain.
-
 6. Go to the [Jenkins prod manual deploy project](https://fcprod-jenkins.dsp-techops.broadinstitute.org/job/martha-manual-deploy/) and re-run the last Martha prod job. This will re-deploy the current version of Martha, verifying that the new service account key works.
 7. Again, [run the full manual test on the prod environment](https://docs.google.com/document/d/1-SXw-tgt1tb3FEuNCGHWIZJ304POmfz5ragpphlq2Ng) to make sure Martha still works.
-8. Clone the Jira ticket you've been working on, without cloning links or sprint fields. Update the due date to be 12 weeks (84 days) from today (which gives about a week to respond when the time comes).
-9. Add a slack reminder in `#dsp-batch-private` to trigger 84 days from today. Make sure to include links to these instructions and the Jira ticket you just created.
+8. Now that we know it works, delete the disabled key(s) from [the list](https://console.cloud.google.com/iam-admin/serviceaccounts/details/107440104000315564432/keys?project=broad-dsde-prod) by selecting the trash can icon. Only the one created today should remain.
+9. Clone the Jira ticket you've been working on, without cloning links or sprint fields. Update the due date to be 12 weeks (84 days) from today (which gives about a week to respond when the time comes).
+10. Add a slack reminder in `#dsp-batch-private` to trigger 84 days from today. Make sure to include links to these instructions and the Jira ticket you just created.
 ```
 /remind #dsp-workflows-private :redalert: Reminder to rotate the service account key for Martha prod deploys. https://github.com/broadinstitute/martha/blob/dev/docs/deployment-key-rotation.md [Link to Jira ticket] :redalert: at 9am in 84 days
 ```

--- a/docs/deployment-key-rotation.md
+++ b/docs/deployment-key-rotation.md
@@ -22,7 +22,7 @@ vault write secret/dsde/martha/prod/deploy-account.json @/path/to/key.json
 7. Again, [run the full manual test on the prod environment](https://docs.google.com/document/d/1-SXw-tgt1tb3FEuNCGHWIZJ304POmfz5ragpphlq2Ng) to make sure Martha still works.
 8. Now that we know it works, delete the disabled key(s) from [the list](https://console.cloud.google.com/iam-admin/serviceaccounts/details/107440104000315564432/keys?project=broad-dsde-prod) by selecting the trash can icon. Only the one created today should remain.
 9. Clone the Jira ticket you've been working on, without cloning links or sprint fields. Update the due date to be 12 weeks (84 days) from today (which gives about a week to respond when the time comes).
-10. Add a slack reminder in `#dsp-batch-private` to trigger 84 days from today. Make sure to include links to these instructions and the Jira ticket you just created.
+10. Add a slack reminder in `#dsp-workflows-private` to trigger 84 days from today. Make sure to include links to these instructions and the Jira ticket you just created.
 ```
 /remind #dsp-workflows-private :redalert: Reminder to rotate the service account key for Martha prod deploys. https://github.com/broadinstitute/martha/blob/dev/docs/deployment-key-rotation.md [Link to Jira ticket] :redalert: at 9am in 84 days
 ```


### PR DESCRIPTION
The finding stated that `ServiceAccount Keys for cloud-functions-account@broad-dsde-prod.iam.gserviceaccount.com older than 7776000 seconds is expected not to exist`.

It doesn't actually say it matters whether the key is enabled or not.

So, it's possible we are triggering the warning system by leaving disabled keys in place. Update instructions to be more specific about deleting them.