### PR TITLE
WX-839: Add Strict-Transport-Security and CacheControl headers to Martha responses

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,7 +12,7 @@ const getSignedUrlV1 = require('./handlers/getSignedUrlV1');
 const addSecurityHeaders = (res) => {
     res.set({
         'Strict-Transport-Security': 'max-age=63072000',
-        'CacheControl': 'no-store',
+        'Cache-Control': 'no-store',
     });
 };
 

--- a/index.js
+++ b/index.js
@@ -9,19 +9,30 @@ const { marthaV3Handler } = require('./martha/martha_v3');
 const { fileSummaryV1Handler } = require('./fileSummaryV1/fileSummaryV1');
 const getSignedUrlV1 = require('./handlers/getSignedUrlV1');
 
+const addSecurityHeaders = (res) => {
+    res.set({
+      'Strict-Transport-Security': 'max-age=63072000',
+      CacheControl: 'no-store',
+    });
+}
+
 exports.martha_v2 = (req, res) => {
+    addSecurityHeaders(res);
     corsMiddleware(req, res, () => marthaV2Handler(req, res));
 };
 
 exports.martha_v3 = (req, res) => {
+    addSecurityHeaders(res);
     corsMiddleware(req, res, () => marthaV3Handler(req, res));
 };
 
 exports.fileSummaryV1 = (req, res) => {
+    addSecurityHeaders(res);
     corsMiddleware(req, res, () => fileSummaryV1Handler(req, res));
 };
 
 exports.getSignedUrlV1 = (req, res) => {
+    addSecurityHeaders(res);
     corsMiddleware(req, res, () => getSignedUrlV1(req, res));
 };
 
@@ -47,6 +58,7 @@ exports.index = (req, res) => {
         case '/dockerized-martha/us-central1/getSignedUrlV1':
             return exports.getSignedUrlV1(req, res);
         default:
+            addSecurityHeaders(res);
             res.send('function not defined');
     }
 };

--- a/index.js
+++ b/index.js
@@ -11,10 +11,10 @@ const getSignedUrlV1 = require('./handlers/getSignedUrlV1');
 
 const addSecurityHeaders = (res) => {
     res.set({
-      'Strict-Transport-Security': 'max-age=63072000',
-      CacheControl: 'no-store',
+        'Strict-Transport-Security': 'max-age=63072000',
+        'CacheControl': 'no-store',
     });
-}
+};
 
 exports.martha_v2 = (req, res) => {
     addSecurityHeaders(res);


### PR DESCRIPTION
Addresses [WX-839](https://broadworkbench.atlassian.net/browse/WX-839)

PR adds the state two security headers to Martha responses. Responses were adjusted per route since functions-framework doesn't allow for custom middleware out of the box.