### PR TITLE
[ID-351] enable signed urls for TDR

### DIFF
--- a/martha/drs_providers.js
+++ b/martha/drs_providers.js
@@ -172,7 +172,7 @@ class TerraDataRepoDrsProvider extends DrsProvider {
             MetadataAuth.YES,
             BondProvider.NONE,
             [
-                new AccessMethod(AccessMethodType.GCS, AccessUrlAuth.CURRENT_REQUEST, FetchAccessUrl.NO),
+                new AccessMethod(AccessMethodType.GCS, AccessUrlAuth.CURRENT_REQUEST, FetchAccessUrl.YES),
                 new AccessMethod(AccessMethodType.HTTPS, AccessUrlAuth.CURRENT_REQUEST, FetchAccessUrl.YES) // Used for Azure
             ],
             forceAccessUrl,

--- a/test/martha/martha_v3.test.js
+++ b/test/martha/martha_v3.test.js
@@ -729,7 +729,7 @@ test.serial('martha_v3 does not call Bond or return SA key when the host url is 
     t.deepEqual(response.body, jadeDrsMarthaResult);
     t.falsy(result.googleServiceAccount);
 
-    sinon.assert.callCount(getJsonFromApiStub, 1);
+    sinon.assert.callCount(getJsonFromApiStub, 2);
 });
 
 test.serial('martha_v3 parses response and generates signed URL correctly for an Azure-hosted TDR file', async (t) => {
@@ -994,7 +994,7 @@ test.serial('martha_v3 parses HCA response correctly', async (t) => {
     t.is(response.statusCode, 200);
     t.deepEqual(response.body, hcaDrsMarthaResult);
 
-    sinon.assert.callCount(getJsonFromApiStub, 1);
+    sinon.assert.callCount(getJsonFromApiStub, 2);
 });
 
 const testWithTimeout = (ms, asyncTestFn) => (t) => {


### PR DESCRIPTION
Signed URLs are already turned on for Azure workspaces, but now that TDR is capable of serving signed URLs for data in Google requester pays buckets, we can enable it for Google as well. This one line change just flips the switch.