### PR TITLE
ID-694 Fix Integration Tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "smoketest_v2": "ava -m smoketest_v2*",
     "smoketest_v3": "ava --timeout 10m --match smoketest_v3*",
     "smoketest_fileSummaryV1": "ava -m smoketest_fileSummaryV1*",
-    "integration": "ava --timeout 10m --match integration*",
+    "integration": "ava --timeout 10m --match integration_v2* && ava --timeout 10m --match integration_v3*",
     "integration_v2": "ava -m integration_v2*",
     "integration_v3": "ava --timeout 10m --match integration_v3*",
     "integration_fileSummaryV1": "ava -m integration_fileSummaryV1*",


### PR DESCRIPTION
Because Bond now requires a `state` parameter to avoid CSRF attacks, the Bond API endpoints called by the integration tests changed. Additionally, the `state` now means that integration test suites need to be run separately, since getting state for one integration suite will invalidate the state for the other. 